### PR TITLE
docs: correct README benchmark harness description

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ See [docs/observability.md](docs/observability.md) for the full list of instrume
 | [Observability](docs/observability.md) | Traces, metrics, structured logging, and OpenTelemetry integration |
 | [Provider Contract Testing](docs/provider-contract-testing.md) | xUnit harness for validating custom `IStorageBackend` implementations |
 | [Host Maintenance Jobs](docs/host-maintenance-jobs.md) | Opt-in recurring maintenance hosted service |
-| [Performance Benchmarks](docs/performance-benchmarks.md) | BenchmarkDotNet harness and hot-path scenario catalog |
+| [Performance Benchmarks](docs/performance-benchmarks.md) | Custom Stopwatch-based hot-path benchmark harness and scenario catalog |
 | [AOT/Trimming Guidance](docs/aot-trimming-guidance.md) | Guidelines for AOT and trimming compatibility |
 
 ---


### PR DESCRIPTION
Closes #146

## Summary

The Performance Benchmarks row in the README docs table described the benchmark project as a "BenchmarkDotNet harness". The `IntegratedS3.Benchmarks` project has **no BenchmarkDotNet dependency** — its csproj references only `AWSSDK.S3` (plus project/framework references), and `Directory.Packages.props` defines no `BenchmarkDotNet` version. It is a hand-rolled, `Stopwatch`-based scenario runner.

## Change

`README.md:182`:

```diff
-| [Performance Benchmarks](docs/performance-benchmarks.md) | BenchmarkDotNet harness and hot-path scenario catalog |
+| [Performance Benchmarks](docs/performance-benchmarks.md) | Custom Stopwatch-based hot-path benchmark harness and scenario catalog |
```

Documentation-only; no runtime effect. Sanity build of `IntegratedS3.slnx` passes with 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)