### PR TITLE
fix: correct SigV4a P-256 key derivation to match aws-crt (#103)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Protocol/S3SigV4aSigner.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3SigV4aSigner.cs
@@ -41,26 +41,34 @@ public static class S3SigV4aSigner
         var label = Encoding.UTF8.GetBytes(Algorithm);
         var context = Encoding.UTF8.GetBytes(accessKeyId);
 
-        // NIST SP 800-108 fixed input: counter(4) || label || 0x00 || context || L(4)
-        // L = 256 bits = key length
-        var fixedInput = new byte[4 + label.Length + 1 + context.Length + 4];
+        // aws-c-auth fixed input (SP 800-108 counter-mode, per iteration):
+        //   0x00000001 || label || 0x00 || accessKeyId || counter(1 byte) || 0x00000100
+        // where 0x00000001 is the fixed "i" prefix and 0x00000100 encodes L = 256 bits.
+        // The counter is a single byte that varies each iteration (1..254).
+        var counterIndex = 4 + label.Length + 1 + context.Length;
+        var fixedInput = new byte[counterIndex + 1 + 4];
+        // i = 1 (big-endian 4 bytes)
+        fixedInput[0] = 0x00;
+        fixedInput[1] = 0x00;
+        fixedInput[2] = 0x00;
+        fixedInput[3] = 0x01;
         Buffer.BlockCopy(label, 0, fixedInput, 4, label.Length);
         fixedInput[4 + label.Length] = 0x00;
         Buffer.BlockCopy(context, 0, fixedInput, 4 + label.Length + 1, context.Length);
-        // L = 256 in big-endian
-        fixedInput[fixedInput.Length - 4] = 0;
-        fixedInput[fixedInput.Length - 3] = 0;
-        fixedInput[fixedInput.Length - 2] = 1;
-        fixedInput[fixedInput.Length - 1] = 0;
+        // L = 256 bits in big-endian (0x00000100)
+        fixedInput[fixedInput.Length - 4] = 0x00;
+        fixedInput[fixedInput.Length - 3] = 0x00;
+        fixedInput[fixedInput.Length - 2] = 0x01;
+        fixedInput[fixedInput.Length - 1] = 0x00;
 
         var curveOrder = new BigInteger(CurveOrderBytes, isUnsigned: true, isBigEndian: true);
+        // Accept the candidate when c <= N-2 (reject when c > N-2), matching aws-c-auth.
+        var maxCandidate = curveOrder - 2;
 
-        for (var counter = 1; counter <= 255; counter++)
+        // Counter runs 1..254; 255 is treated as exhaustion, mirroring aws-c-auth.
+        for (var counter = 1; counter <= 254; counter++)
         {
-            fixedInput[0] = (byte)(counter >> 24);
-            fixedInput[1] = (byte)(counter >> 16);
-            fixedInput[2] = (byte)(counter >> 8);
-            fixedInput[3] = (byte)counter;
+            fixedInput[counterIndex] = (byte)counter;
 
             byte[] candidateBytes;
             using (var hmac = new HMACSHA256(fixedInputKey))
@@ -69,12 +77,22 @@ public static class S3SigV4aSigner
             }
 
             var candidate = new BigInteger(candidateBytes, isUnsigned: true, isBigEndian: true);
-            if (candidate >= 1 && candidate < curveOrder)
+            if (candidate <= maxCandidate)
             {
+                // Private scalar d = c + 1 so that d is in [1, N-1] (FIPS 186-4 B.4.1).
+                var privateScalar = candidate + BigInteger.One;
+                var d = privateScalar.ToByteArray(isUnsigned: true, isBigEndian: true);
+                if (d.Length < 32)
+                {
+                    var padded = new byte[32];
+                    Buffer.BlockCopy(d, 0, padded, 32 - d.Length, d.Length);
+                    d = padded;
+                }
+
                 var ecParams = new ECParameters
                 {
                     Curve = ECCurve.NamedCurves.nistP256,
-                    D = candidateBytes
+                    D = d
                 };
                 return ECDsa.Create(ecParams);
             }

--- a/src/IntegratedS3/IntegratedS3.Tests/S3SigV4aSignerTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3SigV4aSignerTests.cs
@@ -15,6 +15,28 @@ public sealed class S3SigV4aSignerTests
         Assert.Equal(32, ecParams.Q.Y!.Length);
     }
 
+    // Known-answer vector from awslabs/aws-c-auth tests/key_derivation_tests.c
+    // (s_sigv4a_key_derivation_test). Locks cross-implementation interop: the derived
+    // scalar/public key must byte-for-byte equal what a genuine aws-crt SigV4a client
+    // derives for the same secret + access-key. Fails if the mandatory +1 offset,
+    // the c<=N-2 acceptance bound, or the fixed-input layout regresses.
+    [Fact]
+    public void DeriveEcdsaKey_MatchesAwsCrtKnownAnswerVector()
+    {
+        const string secretAccessKey = "q+jcrXGc+0zWN6uzclKVhvMmUsIfRPa4rlRandom";
+        const string accessKeyId = "AKISORANDOMAASORANDOM";
+        const string expectedD = "7fd3bd010c0d9c292141c2b77bfbde1042c92e6836fff749d1269ec890fca1bd";
+        const string expectedX = "15d242ceebf8d8169fd6a8b5a746c41140414c3b07579038da06af89190fffcb";
+        const string expectedY = "0515242cedd82e94799482e4c0514b505afccf2c0c98d6a553bf539f424c5ec0";
+
+        using var key = S3SigV4aSigner.DeriveEcdsaKey(secretAccessKey, accessKeyId);
+        var ecParams = key.ExportParameters(includePrivateParameters: true);
+
+        Assert.Equal(expectedD, Convert.ToHexStringLower(ecParams.D!));
+        Assert.Equal(expectedX, Convert.ToHexStringLower(ecParams.Q.X!));
+        Assert.Equal(expectedY, Convert.ToHexStringLower(ecParams.Q.Y!));
+    }
+
     [Fact]
     public void DeriveEcdsaKey_IsDeterministic()
     {


### PR DESCRIPTION
## Summary

`S3SigV4aSigner.DeriveEcdsaKey` derived the ECDSA P-256 private scalar incorrectly, so keys did **not** match those any genuine AWS/aws-crt SigV4a client derives for the same secret + access-key. This broke cross-implementation SigV4a interop (self-signed round-trips still passed, hiding the defect).

Auditing against `awslabs/aws-c-auth` (`source/key_derivation.c`) surfaced **two** deviations, both fixed here:

1. **Wrong fixed-input layout.** The SP 800-108 counter-mode input is `0x00000001 || label || 0x00 || accessKeyId || counter(1 byte) || 0x00000100`. The old code placed the loop counter as a 4-byte big-endian **prefix** at the front (and had no fixed `i=1` prefix / single-byte counter after the access key id).
2. **Missing `+1` offset & wrong acceptance bound.** Per FIPS 186-4 B.4.1 / aws-c-auth: accept the candidate `c` when `c <= N-2` (reject when `c > N-2`), then set the private scalar to `d = c + 1` (in `[1, N-1]`). The old code accepted `c ∈ [1, N-1)` and used the raw candidate as `D` with no offset.

The scalar is now encoded as a left-padded 32-byte big-endian value for `ECParameters.D`, and the counter loop runs `1..254` (255 = exhaustion), mirroring aws-c-auth.

## Regression test

Added `DeriveEcdsaKey_MatchesAwsCrtKnownAnswerVector`, an **independent** known-answer vector lifted from `aws-c-auth/tests/key_derivation_tests.c`:

- secret `q+jcrXGc+0zWN6uzclKVhvMmUsIfRPa4rlRandom`, access-key `AKISORANDOMAASORANDOM`
- asserts derived `D`, `Q.X`, `Q.Y` byte-for-byte against the aws-crt reference.

This fails on the old derivation (which produced a different `D`) and passes after the fix, locking interop against future regressions.

## Verification

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — 0 errors.
- `dotnet test IntegratedS3.Tests` — **1029 passed, 0 failed, 0 skipped**.

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)