### PR TITLE
fix: clamp list max-keys to 1000 and treat max-keys=0 as empty page (#149)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -103,6 +103,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string MarkerQueryParameterName = "marker";
     private const string StartAfterQueryParameterName = "start-after";
     private const string MaxKeysQueryParameterName = "max-keys";
+    private const int MaxKeysLimit = 1000;
     private const string MaxUploadsQueryParameterName = "max-uploads";
     private const string MaxPartsQueryParameterName = "max-parts";
     private const string ContinuationTokenQueryParameterName = "continuation-token";
@@ -3434,11 +3435,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return ToErrorResult(httpContext, bucketResult.Error, resourceOverride: BuildObjectResource(bucketName, null));
                 }
 
-                if (maxKeys is <= 0) {
-                    return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-keys must be greater than zero.", BuildObjectResource(bucketName, null), bucketName);
+                if (maxKeys is < 0) {
+                    return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-keys must not be negative.", BuildObjectResource(bucketName, null), bucketName);
                 }
 
-                var requestedPageSize = maxKeys ?? 1000;
+                var requestedPageSize = Math.Min(maxKeys ?? MaxKeysLimit, MaxKeysLimit);
 
                 try {
                     var objects = await storageService.ListObjectsAsync(new ListObjectsRequest
@@ -3497,11 +3498,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return ToErrorResult(httpContext, bucketResult.Error, resourceOverride: BuildObjectResource(bucketName, null));
                 }
 
-                if (maxKeys is <= 0) {
-                    return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-keys must be greater than zero.", BuildObjectResource(bucketName, null), bucketName);
+                if (maxKeys is < 0) {
+                    return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-keys must not be negative.", BuildObjectResource(bucketName, null), bucketName);
                 }
 
-                var requestedPageSize = maxKeys ?? 1000;
+                var requestedPageSize = Math.Min(maxKeys ?? MaxKeysLimit, MaxKeysLimit);
 
                 try {
                     var objects = await storageService.ListObjectsAsync(new ListObjectsRequest
@@ -3559,11 +3560,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return ToErrorResult(httpContext, bucketResult.Error, resourceOverride: BuildObjectResource(bucketName, null));
                 }
 
-                if (maxKeys is <= 0) {
-                    return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-keys must be greater than zero.", BuildObjectResource(bucketName, null), bucketName);
+                if (maxKeys is < 0) {
+                    return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-keys must not be negative.", BuildObjectResource(bucketName, null), bucketName);
                 }
 
-                var requestedPageSize = maxKeys ?? 1000;
+                var requestedPageSize = Math.Min(maxKeys ?? MaxKeysLimit, MaxKeysLimit);
 
                 try {
                     var versions = await storageService.ListObjectVersionsAsync(new ListObjectVersionsRequest
@@ -4505,8 +4506,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             Marker = isV2 ? null : marker,
             StartAfter = isV2 ? startAfter : null,
             ContinuationToken = isV2 ? continuationToken : null,
-            NextMarker = !isV2 && isTruncated && normalizedDelimiter is not null ? page[^1].ContinuationToken : null,
-            NextContinuationToken = isV2 && isTruncated ? page[^1].ContinuationToken : null,
+            NextMarker = !isV2 && isTruncated && normalizedDelimiter is not null && page.Length > 0 ? page[^1].ContinuationToken : null,
+            NextContinuationToken = isV2 && isTruncated && page.Length > 0 ? page[^1].ContinuationToken : null,
             EncodingType = encodingType,
             KeyCount = isV2 ? page.Length : 0,
             MaxKeys = maxKeys,
@@ -4593,8 +4594,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             Delimiter = normalizedDelimiter,
             KeyMarker = keyMarker,
             VersionIdMarker = versionIdMarker,
-            NextKeyMarker = isTruncated ? page[^1].NextKeyMarker : null,
-            NextVersionIdMarker = isTruncated ? page[^1].NextVersionIdMarker : null,
+            NextKeyMarker = isTruncated && page.Length > 0 ? page[^1].NextKeyMarker : null,
+            NextVersionIdMarker = isTruncated && page.Length > 0 ? page[^1].NextVersionIdMarker : null,
             EncodingType = encodingType,
             MaxKeys = maxKeys,
             IsTruncated = isTruncated,

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -3107,6 +3107,98 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithMaxKeysAbove1000_ClampsMaxKeysToLimit()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-clamp-v2-bucket", content: null);
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-clamp-v2-bucket/objects/a.txt", new StringContent("A", Encoding.UTF8, "text/plain"));
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-clamp-v2-bucket/objects/b.txt", new StringContent("B", Encoding.UTF8, "text/plain"));
+
+        var response = await client.GetAsync("/integrated-s3/maxkeys-clamp-v2-bucket?list-type=2&max-keys=5000");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(document, "ListBucketResult");
+        Assert.Equal("1000", GetRequiredElementValue(document, "MaxKeys"));
+        Assert.Equal("false", GetRequiredElementValue(document, "IsTruncated"));
+        Assert.Equal("2", GetRequiredElementValue(document, "KeyCount"));
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectsV1_WithMaxKeysAbove1000_ClampsMaxKeysToLimit()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-clamp-v1-bucket", content: null);
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-clamp-v1-bucket/objects/a.txt", new StringContent("A", Encoding.UTF8, "text/plain"));
+
+        var response = await client.GetAsync("/integrated-s3/maxkeys-clamp-v1-bucket?max-keys=5000");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(document, "ListBucketResult");
+        Assert.Equal("1000", GetRequiredElementValue(document, "MaxKeys"));
+        Assert.Equal("false", GetRequiredElementValue(document, "IsTruncated"));
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithMaxKeysZero_ReturnsEmptyPageWithOk()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-v2-bucket", content: null);
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-v2-bucket/objects/a.txt", new StringContent("A", Encoding.UTF8, "text/plain"));
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-v2-bucket/objects/b.txt", new StringContent("B", Encoding.UTF8, "text/plain"));
+
+        var response = await client.GetAsync("/integrated-s3/maxkeys-zero-v2-bucket?list-type=2&max-keys=0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(document, "ListBucketResult");
+        Assert.Equal("0", GetRequiredElementValue(document, "MaxKeys"));
+        Assert.Equal("0", GetRequiredElementValue(document, "KeyCount"));
+        Assert.Equal("true", GetRequiredElementValue(document, "IsTruncated"));
+        Assert.Empty(document.Root!.S3Elements("Contents"));
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectsV1_WithMaxKeysZero_ReturnsEmptyPageWithOk()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-v1-bucket", content: null);
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-v1-bucket/objects/a.txt", new StringContent("A", Encoding.UTF8, "text/plain"));
+
+        var response = await client.GetAsync("/integrated-s3/maxkeys-zero-v1-bucket?max-keys=0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(document, "ListBucketResult");
+        Assert.Equal("0", GetRequiredElementValue(document, "MaxKeys"));
+        Assert.Equal("true", GetRequiredElementValue(document, "IsTruncated"));
+        Assert.Empty(document.Root!.S3Elements("Contents"));
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectVersions_WithMaxKeysZero_ReturnsEmptyPageWithOk()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-versions-bucket", content: null);
+        await client.PutAsync("/integrated-s3/buckets/maxkeys-zero-versions-bucket/objects/a.txt", new StringContent("A", Encoding.UTF8, "text/plain"));
+
+        var response = await client.GetAsync("/integrated-s3/maxkeys-zero-versions-bucket?versions&max-keys=0");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(document, "ListVersionsResult");
+        Assert.Equal("0", GetRequiredElementValue(document, "MaxKeys"));
+        Assert.Equal("true", GetRequiredElementValue(document, "IsTruncated"));
+        Assert.Empty(document.Root!.S3Elements("Version"));
+    }
+
+    [Fact]
     public async Task S3CompatibleBucketRoute_ListType2_WithFetchOwnerAndEncodingType_ReturnsOwnerMetadata()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary
Fixes the `max-keys` paging contract for `ListObjects` (V1), `ListObjectsV2`, and `ListObjectVersions` so it matches AWS S3.

Before:
- `max-keys=5000` returned up to 5000 keys in one page and echoed `<MaxKeys>5000</MaxKeys>` (no upper bound).
- `max-keys=0` returned `400 InvalidArgument`.

After:
- The effective page size is clamped to `min(max-keys, 1000)`. Since that value drives both truncation and the echoed `<MaxKeys>`, the page is capped at 1000 and `<MaxKeys>` reflects the clamped value (AWS behavior).
- `max-keys=0` is a valid empty page: HTTP 200, `KeyCount=0`, `IsTruncated` reflecting whether more keys exist, empty `Contents`.
- Negative `max-keys` still returns 400.

## Changes
- `IntegratedS3EndpointRouteBuilderExtensions.cs`: add `MaxKeysLimit = 1000`; clamp `requestedPageSize` in all three handlers; change the guard from `<= 0` to `< 0`.
- Guard `page[^1]` access in `BuildListBucketResult` / `BuildListObjectVersionsResult` so an empty-but-truncated page (from `max-keys=0`) does not throw `IndexOutOfRangeException`.
- Regression tests: `max-keys=5000` clamps echoed `MaxKeys` to 1000 (V1/V2); `max-keys=0` returns an empty 200 page (V1/V2/Versions).

## Scope
Invalid `max-keys` / `encoding-type` / `fetch-owner` -> 400 `InvalidArgument` is intentionally **out of scope** here; that is tracked by #150.

## Verification
- `dotnet build` (Debug): succeeded.
- `dotnet test` (full project): 1033 passed, 0 failed.

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)