### PR TITLE
fix: translate unhandled exceptions into S3 <Error> XML responses (#157)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
@@ -30,7 +30,7 @@ internal sealed class IntegratedS3RequestAuthenticationEndpointFilter(
                         activity?.SetTag(IntegratedS3Observability.Tags.Result, "failure");
                         activity?.SetTag(IntegratedS3Observability.Tags.ErrorCode, authenticationResult.ErrorCode);
 
-                        return new XmlAuthenticationFailureResult(
+                        return new XmlErrorResult(
                             authenticationResult.StatusCode,
                             S3XmlResponseWriter.WriteError(new S3ErrorResponse
                             {
@@ -54,20 +54,76 @@ internal sealed class IntegratedS3RequestAuthenticationEndpointFilter(
             throw;
         }
         catch (Exception exception) {
+            var (statusCode, errorCode, message) = MapException(exception);
             activity?.SetStatus(ActivityStatusCode.Error, exception.Message);
             activity?.SetTag(IntegratedS3Observability.Tags.Result, "failure");
+            activity?.SetTag(IntegratedS3Observability.Tags.ErrorCode, errorCode);
             logger.LogError(exception, "IntegratedS3 request handling failed unexpectedly.");
-            throw;
+
+            // If the response has already begun streaming we can no longer emit a clean error
+            // body; rethrow and let the host abort the connection.
+            if (httpContext.Response.HasStarted) {
+                throw;
+            }
+
+            // Translate any otherwise-unhandled exception into a well-formed S3 <Error> XML
+            // response so SDK XML error parsers can read it (and retry on 5xx), instead of
+            // ASP.NET's default non-S3 error (empty/text body, no x-amz-request-id).
+            return new XmlErrorResult(
+                statusCode,
+                S3XmlResponseWriter.WriteError(new S3ErrorResponse
+                {
+                    Code = errorCode,
+                    Message = message,
+                    Resource = httpContext.Request.PathBase.Add(httpContext.Request.Path).Value,
+                    RequestId = httpContext.TraceIdentifier
+                }));
         }
     }
 
-    private sealed class XmlAuthenticationFailureResult(int statusCode, string content) : IResult
+    /// <summary>
+    /// Maps an otherwise-unhandled exception to the S3 status code, error code and message.
+    /// Framework request errors (e.g. Kestrel body-size limit exceeded) carry their own
+    /// intended HTTP status via <see cref="BadHttpRequestException"/>; everything else is a
+    /// server-side <c>InternalError</c> 500.
+    /// </summary>
+    private static (int StatusCode, string Code, string Message) MapException(Exception exception)
+    {
+        if (exception is BadHttpRequestException badRequest) {
+            return badRequest.StatusCode switch
+            {
+                StatusCodes.Status413PayloadTooLarge => (
+                    StatusCodes.Status413PayloadTooLarge,
+                    "EntityTooLarge",
+                    "Your proposed upload exceeds the maximum allowed object size."),
+                StatusCodes.Status400BadRequest => (
+                    StatusCodes.Status400BadRequest,
+                    "InvalidRequest",
+                    "The request could not be understood by the server."),
+                _ => (
+                    badRequest.StatusCode,
+                    "InvalidRequest",
+                    "The request could not be understood by the server."),
+            };
+        }
+
+        return (
+            StatusCodes.Status500InternalServerError,
+            InternalErrorCode,
+            "We encountered an internal error. Please try again.");
+    }
+
+    private const string InternalErrorCode = "InternalError";
+
+    private sealed class XmlErrorResult(int statusCode, string content) : IResult
     {
         public async Task ExecuteAsync(HttpContext httpContext)
         {
             ArgumentNullException.ThrowIfNull(httpContext);
             httpContext.Response.StatusCode = statusCode;
             httpContext.Response.ContentType = "application/xml";
+            httpContext.Response.Headers["x-amz-request-id"] = httpContext.TraceIdentifier;
+            httpContext.Response.Headers["x-amz-id-2"] = httpContext.TraceIdentifier;
             await httpContext.Response.WriteAsync(content, httpContext.RequestAborted);
         }
     }

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -9422,6 +9422,173 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         });
     }
 
+    private sealed class ThrowingStorageService : IStorageService
+    {
+        private static InvalidOperationException Boom() =>
+            new("Simulated unexpected storage failure for the global exception handler regression test.");
+
+#pragma warning disable CS1998 // async method without await; the throw runs on first enumeration
+        private static async IAsyncEnumerable<T> ThrowingEnumerable<T>()
+        {
+            throw Boom();
+#pragma warning disable CS0162
+            yield break;
+#pragma warning restore CS0162
+        }
+#pragma warning restore CS1998
+
+        public IAsyncEnumerable<BucketInfo> ListBucketsAsync(CancellationToken cancellationToken = default) => ThrowingEnumerable<BucketInfo>();
+
+        public ValueTask<StorageResult<BucketInfo>> CreateBucketAsync(CreateBucketRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketLocationInfo>> GetBucketLocationAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketVersioningInfo>> GetBucketVersioningAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketVersioningInfo>> PutBucketVersioningAsync(PutBucketVersioningRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketCorsConfiguration>> GetBucketCorsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketCorsConfiguration>> PutBucketCorsAsync(PutBucketCorsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketCorsAsync(DeleteBucketCorsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketDefaultEncryptionConfiguration>> GetBucketDefaultEncryptionAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketDefaultEncryptionConfiguration>> PutBucketDefaultEncryptionAsync(PutBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketDefaultEncryptionAsync(DeleteBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketAsync(DeleteBucketRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public IAsyncEnumerable<ObjectInfo> ListObjectsAsync(ListObjectsRequest request, CancellationToken cancellationToken = default) => ThrowingEnumerable<ObjectInfo>();
+
+        public IAsyncEnumerable<ObjectInfo> ListObjectVersionsAsync(ListObjectVersionsRequest request, CancellationToken cancellationToken = default) => ThrowingEnumerable<ObjectInfo>();
+
+        public IAsyncEnumerable<MultipartUploadInfo> ListMultipartUploadsAsync(ListMultipartUploadsRequest request, CancellationToken cancellationToken = default) => ThrowingEnumerable<MultipartUploadInfo>();
+
+        public IAsyncEnumerable<MultipartUploadPart> ListMultipartUploadPartsAsync(ListMultipartUploadPartsRequest request, CancellationToken cancellationToken = default) => ThrowingEnumerable<MultipartUploadPart>();
+
+        public ValueTask<StorageResult<GetObjectResponse>> GetObjectAsync(GetObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectRetentionInfo>> GetObjectRetentionAsync(GetObjectRetentionRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectLegalHoldInfo>> GetObjectLegalHoldAsync(GetObjectLegalHoldRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<GetObjectAttributesResponse>> GetObjectAttributesAsync(GetObjectAttributesRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectTagSet>> GetObjectTagsAsync(GetObjectTagsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectInfo>> CopyObjectAsync(CopyObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectInfo>> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectTagSet>> PutObjectTagsAsync(PutObjectTagsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectTagSet>> DeleteObjectTagsAsync(DeleteObjectTagsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<MultipartUploadInfo>> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<MultipartUploadPart>> UploadMultipartPartAsync(UploadMultipartPartRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<MultipartUploadPart>> UploadPartCopyAsync(UploadPartCopyRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectInfo>> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> AbortMultipartUploadAsync(AbortMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectInfo>> HeadObjectAsync(HeadObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<DeleteObjectResult>> DeleteObjectAsync(DeleteObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketTaggingConfiguration>> GetBucketTaggingAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketTaggingConfiguration>> PutBucketTaggingAsync(PutBucketTaggingRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketTaggingAsync(DeleteBucketTaggingRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketLoggingConfiguration>> GetBucketLoggingAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketLoggingConfiguration>> PutBucketLoggingAsync(PutBucketLoggingRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketWebsiteConfiguration>> GetBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketWebsiteConfiguration>> PutBucketWebsiteAsync(PutBucketWebsiteRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketWebsiteAsync(DeleteBucketWebsiteRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketRequestPaymentConfiguration>> GetBucketRequestPaymentAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketRequestPaymentConfiguration>> PutBucketRequestPaymentAsync(PutBucketRequestPaymentRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketAccelerateConfiguration>> GetBucketAccelerateAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketAccelerateConfiguration>> PutBucketAccelerateAsync(PutBucketAccelerateRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketLifecycleConfiguration>> GetBucketLifecycleAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketLifecycleConfiguration>> PutBucketLifecycleAsync(PutBucketLifecycleRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketLifecycleAsync(DeleteBucketLifecycleRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketReplicationConfiguration>> GetBucketReplicationAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketReplicationConfiguration>> PutBucketReplicationAsync(PutBucketReplicationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketReplicationAsync(DeleteBucketReplicationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketNotificationConfiguration>> GetBucketNotificationConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketNotificationConfiguration>> PutBucketNotificationConfigurationAsync(PutBucketNotificationConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectLockConfiguration>> GetObjectLockConfigurationAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectLockConfiguration>> PutObjectLockConfigurationAsync(PutObjectLockConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketAnalyticsConfiguration>> GetBucketAnalyticsConfigurationAsync(string bucketName, string id, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketAnalyticsConfiguration>> PutBucketAnalyticsConfigurationAsync(PutBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketAnalyticsConfigurationAsync(DeleteBucketAnalyticsConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<IReadOnlyList<BucketAnalyticsConfiguration>>> ListBucketAnalyticsConfigurationsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketMetricsConfiguration>> GetBucketMetricsConfigurationAsync(string bucketName, string id, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketMetricsConfiguration>> PutBucketMetricsConfigurationAsync(PutBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketMetricsConfigurationAsync(DeleteBucketMetricsConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<IReadOnlyList<BucketMetricsConfiguration>>> ListBucketMetricsConfigurationsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketInventoryConfiguration>> GetBucketInventoryConfigurationAsync(string bucketName, string id, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketInventoryConfiguration>> PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<IReadOnlyList<BucketInventoryConfiguration>>> ListBucketInventoryConfigurationsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketIntelligentTieringConfiguration>> GetBucketIntelligentTieringConfigurationAsync(string bucketName, string id, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketIntelligentTieringConfiguration>> PutBucketIntelligentTieringConfigurationAsync(PutBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketIntelligentTieringConfigurationAsync(DeleteBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<IReadOnlyList<BucketIntelligentTieringConfiguration>>> ListBucketIntelligentTieringConfigurationsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectRetentionInfo>> PutObjectRetentionAsync(PutObjectRetentionRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<ObjectLegalHoldInfo>> PutObjectLegalHoldAsync(PutObjectLegalHoldRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<SelectObjectContentResponse>> SelectObjectContentAsync(SelectObjectContentRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<RestoreObjectResponse>> RestoreObjectAsync(RestoreObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+    }
+
     private sealed class RecordingStorageService : IStorageService
     {
         private static readonly DateTimeOffset DefaultTimestampUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z", CultureInfo.InvariantCulture);
@@ -10132,6 +10299,28 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         var errorDoc = XDocument.Parse(await errorResponse.Content.ReadAsStringAsync());
         Assert.Equal(S3Ns + "Error", errorDoc.Root!.Name);
         Assert.NotNull(errorDoc.Root.Element(S3Ns + "Code"));
+    }
+
+    [Fact]
+    public async Task UnhandledException_ReturnsInternalErrorS3XmlResponse()
+    {
+        await using var isolatedClient = await CreateStorageServiceIsolatedClientAsync(new ThrowingStorageService());
+        using var client = isolatedClient.Client;
+
+        var response = await client.GetAsync("/integrated-s3/some-bucket/some-key.txt");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+
+        Assert.True(response.Headers.Contains("x-amz-request-id"), "Missing x-amz-request-id header");
+        Assert.True(response.Headers.Contains("x-amz-id-2"), "Missing x-amz-id-2 header");
+        Assert.False(string.IsNullOrWhiteSpace(response.Headers.GetValues("x-amz-request-id").Single()));
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(S3Ns + "Error", document.Root!.Name);
+        Assert.Equal("InternalError", GetRequiredElementValue(document, "Code"));
+        Assert.False(string.IsNullOrWhiteSpace(document.Root.S3Element("Message")?.Value));
+        Assert.False(string.IsNullOrWhiteSpace(document.Root.S3Element("RequestId")?.Value));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Any exception escaping the S3 endpoint pipeline previously produced ASP.NET's default `500` (`text/plain`, no body, no `x-amz-request-id`), which SDK XML error parsers cannot read and which lacks the request-id headers AWS returns. The bucket/object dispatch `catch` blocks only logged and rethrew, and no global handler mapped the escape to an S3 `<Error>`.

## Fix
The group-wide `IntegratedS3RequestAuthenticationEndpointFilter` (already wrapping every S3 endpoint) now converts any otherwise-unhandled exception into a well-formed S3 `<Error>` XML response — `application/xml`, with `x-amz-request-id` / `x-amz-id-2` headers — reusing the existing `S3XmlResponseWriter.WriteError` / `S3ErrorResponse` serialization:

- **Unknown/unexpected** exceptions → `500 InternalError` (retryable by SDKs).
- **Framework request errors** carrying an intended status via `BadHttpRequestException` (e.g. Kestrel body-size limit exceeded) keep that status with a matching S3 code: `413 → EntityTooLarge`, `400 → InvalidRequest`. This preserves the existing `413 RequestEntityTooLarge` behaviour for oversized uploads *and* now returns a proper S3 error body for it.
- **Client aborts** (`OperationCanceledException`) still rethrow, and if the response has already started streaming the exception is rethrown so the host aborts the connection.

## Test
Adds `UnhandledException_ReturnsInternalErrorS3XmlResponse`: an endpoint whose storage service throws now returns `500` with a well-formed S3 `<Error>` `InternalError` body and request-id headers. Verified failing before the fix (`Content-Type` was `text/plain`) and passing after. Full suite green (1035 tests).

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)