### PR TITLE
ci: drop unused packages: write GITHUB_TOKEN scope from nuget-publish

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -20,7 +20,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 # Serialize publish runs: never cancel an in-flight publish (a half-pushed package set is
 # worse than a queued run), but make sure two dispatches cannot race each other.
@@ -66,7 +65,6 @@ jobs:
     # contents: write is required to push the release tag and create the GitHub Release.
     permissions:
       contents: write
-      packages: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

The `Publish NuGet Packages` workflow requested `packages: write` on the `GITHUB_TOKEN` — both at the top level (line 23) and on the `pack-and-publish` job (line 69) — but nothing in the workflow writes to the GitHub Packages registry.

Verified against the whole workflow:
- The only package push targets `https://api.nuget.org/v3/index.json`, authenticated by the `NUGET_API_KEY` secret (not `GITHUB_TOKEN`).
- `GITHUB_TOKEN` (`github.token`) is consumed only by the tag push + `gh release create` steps, which need `contents: write`.
- No `nuget.pkg.github.com` / ghcr feed is referenced anywhere.

`packages: write` therefore grants no capability the workflow uses; it only widens the token's blast radius. Removed from both permission blocks to restore least privilege.

## Verification
- YAML validated with `yaml.safe_load` — OK.
- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — 0 errors.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)