### PR TITLE
fix: dispose checksum validation when resume seeding throws (#141)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Client/IntegratedS3ClientTransferExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.Client/IntegratedS3ClientTransferExtensions.cs
@@ -824,10 +824,20 @@ public static class IntegratedS3ClientTransferExtensions
     {
         var validation = IntegratedS3ClientTransferChecksumHelper.CreateDownloadValidation(response);
         if (validation is not null) {
-            await IntegratedS3ClientTransferChecksumHelper.SeedExistingBytesAsync(
-                validation,
-                filePath,
-                cancellationToken);
+            try {
+                await IntegratedS3ClientTransferChecksumHelper.SeedExistingBytesAsync(
+                    validation,
+                    filePath,
+                    cancellationToken);
+            }
+            catch {
+                // CopyToAsync takes ownership of disposing the validation object, but it is
+                // never reached if seeding throws (e.g. the partial file is locked or removed
+                // after the length probe). Dispose here to avoid leaking the IncrementalHash
+                // native handles the SHA1/SHA256 validators hold.
+                validation.Dispose();
+                throw;
+            }
         }
 
         await using var fileStream = new FileStream(

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ClientTransferTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ClientTransferTests.cs
@@ -1156,6 +1156,66 @@ public sealed class IntegratedS3ClientTransferTests(WebUiApplicationFactory fact
         }
     }
 
+    // Regression for #141: when the SHA checksum validation is created but seeding the
+    // existing on-disk bytes throws (here the partial file is exclusively locked so the
+    // seed's read-open fails), the seed failure must surface without the copy/validation
+    // path ever running, and the pre-existing partial file must be left untouched. The fix
+    // disposes the ResponseChecksumValidation (which owns IncrementalHash native handles) on
+    // this throw path. The dispose itself is not observable through the public API — the
+    // validation type is internal — so this test locks in the throw-during-seed path the fix
+    // guards and confirms no side effects leak past it.
+    [Fact]
+    public async Task DownloadToFileWithResumeAsync_PartialContentSeedFails_SurfacesSeedFailureAndPreservesPartialFile()
+    {
+        var tempDir = CreateTransferTempDirectory();
+        Directory.CreateDirectory(tempDir);
+        try {
+            var destPath = Path.Combine(tempDir, "resume-seed-failure.txt");
+            const string existingPayload = "hello ";
+            const string appendedPayload = "world";
+            await File.WriteAllTextAsync(destPath, existingPayload);
+
+            var capturingClient = new CapturingIntegratedS3Client();
+            var existingLength = new FileInfo(destPath).Length;
+            var responseProduced = false;
+            using var transferClient = new HttpClient(new DelegateHttpMessageHandler((request, cancellationToken) => {
+                var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+                {
+                    Content = new ByteArrayContent(Encoding.UTF8.GetBytes(appendedPayload))
+                };
+                response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                    existingLength,
+                    existingLength + appendedPayload.Length - 1,
+                    existingLength + appendedPayload.Length);
+                // SHA256 header makes CreateDownloadValidation return a non-null validation that
+                // owns IncrementalHash native handles, so the seed step below actually runs.
+                response.Headers.TryAddWithoutValidation(
+                    "x-amz-checksum-sha256",
+                    ComputeSha256Base64(existingPayload + appendedPayload));
+                responseProduced = true;
+                return Task.FromResult(response);
+            }));
+
+            // Hold an exclusive lock so SeedExistingBytesAsync's FileShare.Read open throws.
+            using (new FileStream(destPath, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) {
+                await Assert.ThrowsAsync<IOException>(() =>
+                    capturingClient.DownloadToFileWithResumeAsync(
+                        transferClient,
+                        "bucket",
+                        "key",
+                        destPath,
+                        expiresInSeconds: 60));
+            }
+
+            Assert.True(responseProduced, "The resume request should have produced a checksummed partial response.");
+            Assert.True(File.Exists(destPath), "The pre-existing partial file must be preserved when seeding fails.");
+            Assert.Equal(existingPayload, await File.ReadAllTextAsync(destPath));
+        }
+        finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
     [Fact]
     public async Task DownloadToFileWithResumeAsync_RangeIgnored_RewritesFromStartAndForwardsAccessMode()
     {


### PR DESCRIPTION
## Summary

Fixes a native-handle leak on the download-resume path. `AppendPartialDownloadAsync` created a `ResponseChecksumValidation` — which owns SHA1/SHA256 `IncrementalHash` native handles — and seeded it from the existing on-disk bytes **before** the code path that disposes it (`using (validation)` inside `CopyToAsync`). If `SeedExistingBytesAsync` threw (e.g. the partial file was locked by another process or removed between the length probe and the seed read), the exception unwound past every disposal path and the `IncrementalHash` handles leaked until the finalizer ran.

## Fix

Wrap the seed step in a `try/catch` that disposes `validation` before rethrowing:

- Smallest correct change: only `AppendPartialDownloadAsync` has a pre-seed step that can leak, so the guard lives there.
- `CopyToAsync` retains ownership of disposal on the success path, so the other three `CopyToAsync` callers are unchanged.
- The CRC32 path never leaked (its `Dispose` is a no-op); this only affected the SHA1/SHA256 validators.

## Test

Added `DownloadToFileWithResumeAsync_PartialContentSeedFails_SurfacesSeedFailureAndPreservesPartialFile`: holds an exclusive lock on the destination so `SeedExistingBytesAsync`'s `FileShare.Read` open throws `IOException`, with a `x-amz-checksum-sha256` header present so the validation is actually created. Asserts the seed failure surfaces and the pre-existing partial file is untouched. The dispose itself is not observable through the public API (the validation type is `internal`, no `InternalsVisibleTo`), so the test locks in the throw-during-seed path the fix guards; this limitation is documented in the test.

Build: green. Tests: 1036 passed, 0 failed.

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)