### PR TITLE
fix: harden S3 XML request readers against DTD/entity-expansion DoS (#104)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -17,6 +17,7 @@ using IntegratedS3.Abstractions.Services;
 using IntegratedS3.AspNetCore.DependencyInjection;
 using IntegratedS3.AspNetCore.Services;
 using IntegratedS3.Protocol;
+using IntegratedS3.Protocol.Internal;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -10883,7 +10884,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
 
         try {
-            var document = XDocument.Parse(xml, LoadOptions.None);
+            var document = HardenedXml.Parse(xml);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "SelectObjectContentRequest", StringComparison.Ordinal)) {
                 throw new FormatException("The select object content request body must contain a root 'SelectObjectContentRequest' element.");

--- a/src/IntegratedS3/IntegratedS3.Protocol/Internal/HardenedXml.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/Internal/HardenedXml.cs
@@ -1,0 +1,50 @@
+using System.Xml;
+using System.Xml.Linq;
+
+namespace IntegratedS3.Protocol.Internal;
+
+/// <summary>
+/// Central factory for loading untrusted S3 request XML with DTD processing and entity
+/// expansion disabled, preventing "billion laughs" / entity-expansion denial-of-service and
+/// XXE. All S3 XML request parsers must route through these helpers rather than calling
+/// <see cref="XDocument.LoadAsync(Stream, LoadOptions, CancellationToken)"/> or
+/// <see cref="XDocument.Parse(string)"/> directly on attacker-controlled input.
+/// </summary>
+public static class HardenedXml
+{
+    /// <summary>
+    /// Builds <see cref="XmlReaderSettings"/> that reject any inline <c>DOCTYPE</c>
+    /// (<see cref="DtdProcessing.Prohibit"/>), refuse to resolve external resources
+    /// (<see cref="XmlResolver"/> = <see langword="null"/>), and forbid entity-expansion
+    /// amplification (<c>MaxCharactersFromEntities = 1</c>). This matches AWS S3, which rejects
+    /// request XML containing a DTD.
+    /// </summary>
+    private static XmlReaderSettings CreateSettings(bool async) => new()
+    {
+        Async = async,
+        DtdProcessing = DtdProcessing.Prohibit,
+        XmlResolver = null,
+        MaxCharactersFromEntities = 1,
+        CloseInput = false,
+    };
+
+    /// <summary>Asynchronously loads an <see cref="XDocument"/> from a stream with hardened settings.</summary>
+    /// <param name="content">The stream containing the untrusted XML payload.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The parsed document.</returns>
+    public static async Task<XDocument> LoadAsync(Stream content, CancellationToken cancellationToken = default)
+    {
+        using var reader = XmlReader.Create(content, CreateSettings(async: true));
+        return await XDocument.LoadAsync(reader, LoadOptions.None, cancellationToken);
+    }
+
+    /// <summary>Parses an <see cref="XDocument"/> from a string with hardened settings.</summary>
+    /// <param name="xml">The untrusted XML payload.</param>
+    /// <returns>The parsed document.</returns>
+    public static XDocument Parse(string xml)
+    {
+        using var stringReader = new StringReader(xml);
+        using var reader = XmlReader.Create(stringReader, CreateSettings(async: false));
+        return XDocument.Load(reader, LoadOptions.None);
+    }
+}

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlRequestReader.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlRequestReader.cs
@@ -15,7 +15,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "VersioningConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The bucket versioning request body must contain a root 'VersioningConfiguration' element.");
@@ -45,7 +45,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "ServerSideEncryptionConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The bucket encryption request body must contain a root 'ServerSideEncryptionConfiguration' element.");
@@ -84,7 +84,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "CORSConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The bucket CORS request body must contain a root 'CORSConfiguration' element.");
@@ -123,7 +123,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "CompleteMultipartUpload", StringComparison.Ordinal)) {
                 throw new FormatException("The complete multipart upload request body must contain a root 'CompleteMultipartUpload' element.");
@@ -162,7 +162,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "Delete", StringComparison.Ordinal)) {
                 throw new FormatException("The delete request body must contain a root 'Delete' element.");
@@ -214,7 +214,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "Tagging", StringComparison.Ordinal)) {
                 throw new FormatException("The tagging request body must contain a root 'Tagging' element.");
@@ -258,7 +258,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "AccessControlPolicy", StringComparison.Ordinal)) {
                 throw new FormatException("The ACL request body must contain a root 'AccessControlPolicy' element.");
@@ -310,7 +310,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "Tagging", StringComparison.Ordinal)) {
                 throw new FormatException("The bucket tagging request body must contain a root 'Tagging' element.");
@@ -350,7 +350,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "BucketLoggingStatus", StringComparison.Ordinal)) {
                 throw new FormatException("The bucket logging request body must contain a root 'BucketLoggingStatus' element.");
@@ -390,7 +390,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "WebsiteConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The website configuration request body must contain a root 'WebsiteConfiguration' element.");
@@ -487,7 +487,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "RequestPaymentConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The request payment configuration request body must contain a root 'RequestPaymentConfiguration' element.");
@@ -517,7 +517,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "AccelerateConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The accelerate configuration request body must contain a root 'AccelerateConfiguration' element.");
@@ -547,7 +547,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "LifecycleConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The lifecycle configuration request body must contain a root 'LifecycleConfiguration' element.");
@@ -582,7 +582,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "ReplicationConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The replication configuration request body must contain a root 'ReplicationConfiguration' element.");
@@ -620,7 +620,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "NotificationConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The notification configuration request body must contain a root 'NotificationConfiguration' element.");
@@ -685,7 +685,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "ObjectLockConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The object lock configuration request body must contain a root 'ObjectLockConfiguration' element.");
@@ -734,7 +734,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "AnalyticsConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The analytics configuration request body must contain a root 'AnalyticsConfiguration' element.");
@@ -823,7 +823,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "MetricsConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The metrics configuration request body must contain a root 'MetricsConfiguration' element.");
@@ -876,7 +876,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "InventoryConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The inventory configuration request body must contain a root 'InventoryConfiguration' element.");
@@ -961,7 +961,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "IntelligentTieringConfiguration", StringComparison.Ordinal)) {
                 throw new FormatException("The intelligent tiering configuration request body must contain a root 'IntelligentTieringConfiguration' element.");
@@ -1029,7 +1029,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "Retention", StringComparison.Ordinal)) {
                 throw new FormatException("The object retention request body must contain a root 'Retention' element.");
@@ -1067,7 +1067,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "LegalHold", StringComparison.Ordinal)) {
                 throw new FormatException("The object legal hold request body must contain a root 'LegalHold' element.");
@@ -1097,7 +1097,7 @@ public static class S3XmlRequestReader
         ArgumentNullException.ThrowIfNull(content);
 
         try {
-            var document = await XDocument.LoadAsync(content, LoadOptions.None, cancellationToken);
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
             var root = document.Root;
             if (root is null || !string.Equals(root.Name.LocalName, "RestoreRequest", StringComparison.Ordinal)) {
                 throw new FormatException("The restore request body must contain a root 'RestoreRequest' element.");

--- a/src/IntegratedS3/IntegratedS3.Tests/S3XmlRequestReaderSecurityTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3XmlRequestReaderSecurityTests.cs
@@ -1,0 +1,97 @@
+using System.Text;
+using IntegratedS3.Protocol;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression tests for issue #104: S3 XML request readers must reject inline DTDs and refuse
+/// to expand internal entities, preventing "billion laughs" entity-expansion denial-of-service.
+/// </summary>
+public sealed class S3XmlRequestReaderSecurityTests
+{
+    // Classic "billion laughs" payload: a tiny body that, when entities are expanded, amplifies
+    // into a huge string. A hardened parser rejects the DOCTYPE before any expansion happens.
+    private const string BillionLaughsDelete = """
+        <?xml version="1.0"?>
+        <!DOCTYPE Delete [
+          <!ENTITY lol "lolololololololololol">
+          <!ENTITY lol1 "&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;&lol;">
+          <!ENTITY lol2 "&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;&lol1;">
+          <!ENTITY lol3 "&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;&lol2;">
+        ]>
+        <Delete><Object><Key>&lol3;</Key></Object></Delete>
+        """;
+
+    // A minimal DOCTYPE with no entity payload at all — still an inline DTD, which AWS S3 rejects.
+    private const string BareDoctypeVersioning = """
+        <?xml version="1.0"?>
+        <!DOCTYPE VersioningConfiguration>
+        <VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>
+        """;
+
+    private static Stream ToStream(string xml) => new MemoryStream(Encoding.UTF8.GetBytes(xml));
+
+    [Fact]
+    public async Task ReadDeleteObjectsRequestAsync_RejectsBillionLaughsPayload()
+    {
+        await using var stream = ToStream(BillionLaughsDelete);
+
+        // The reader wraps the underlying XmlException (DTD prohibited) as FormatException; the
+        // key property is that it THROWS during parse rather than expanding the entity into MBs.
+        await Assert.ThrowsAsync<FormatException>(
+            () => S3XmlRequestReader.ReadDeleteObjectsRequestAsync(stream));
+    }
+
+    [Fact]
+    public async Task ReadDeleteObjectsRequestAsync_DoesNotExpandEntities()
+    {
+        // Guard against a regression where the DTD is tolerated but entities silently expand:
+        // if any expansion occurred the resulting Key would be enormous. We assert rejection.
+        await using var stream = ToStream(BillionLaughsDelete);
+
+        var exception = await Assert.ThrowsAsync<FormatException>(
+            () => S3XmlRequestReader.ReadDeleteObjectsRequestAsync(stream));
+
+        Assert.NotNull(exception);
+    }
+
+    [Fact]
+    public async Task ReadBucketVersioningConfigurationAsync_RejectsInlineDtd()
+    {
+        await using var stream = ToStream(BareDoctypeVersioning);
+
+        await Assert.ThrowsAsync<FormatException>(
+            () => S3XmlRequestReader.ReadBucketVersioningConfigurationAsync(stream));
+    }
+
+    [Fact]
+    public async Task ReadCompleteMultipartUploadRequestAsync_RejectsInlineDtd()
+    {
+        const string payload = """
+            <?xml version="1.0"?>
+            <!DOCTYPE CompleteMultipartUpload [ <!ENTITY x "y"> ]>
+            <CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>&x;</ETag></Part></CompleteMultipartUpload>
+            """;
+        await using var stream = ToStream(payload);
+
+        await Assert.ThrowsAsync<FormatException>(
+            () => S3XmlRequestReader.ReadCompleteMultipartUploadRequestAsync(stream));
+    }
+
+    [Fact]
+    public async Task ReadDeleteObjectsRequestAsync_AcceptsWellFormedBodyWithoutDtd()
+    {
+        // Sanity check: hardening must not break legitimate DTD-free request bodies.
+        const string payload = """
+            <?xml version="1.0"?>
+            <Delete><Object><Key>example.txt</Key></Object></Delete>
+            """;
+        await using var stream = ToStream(payload);
+
+        var request = await S3XmlRequestReader.ReadDeleteObjectsRequestAsync(stream);
+
+        Assert.Single(request.Objects);
+        Assert.Equal("example.txt", request.Objects[0].Key);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a billion-laughs (internal-entity-expansion) denial-of-service reachable on **every** S3 XML request endpoint.

`S3XmlRequestReader` parsed all ~24 untrusted request bodies with `XDocument.LoadAsync(Stream, LoadOptions.None, ct)`. The `Stream` overload builds its internal `XmlReader` with `DtdProcessing.Parse`, so an inline `DOCTYPE` with recursively nested entities was fully expanded during parse — amplifying a ~400-byte body into tens of MB of allocations. Sending these concurrently drives memory-exhaustion / GC-pressure CPU DoS with trivial bandwidth.

## Fix

- New shared `HardenedXml` factory in `IntegratedS3.Protocol.Internal` builds readers with `DtdProcessing.Prohibit`, `XmlResolver = null`, `MaxCharactersFromEntities = 1`.
- All 23 `XDocument.LoadAsync(Stream, ...)` call sites in `S3XmlRequestReader.cs` now route through `HardenedXml.LoadAsync`.
- The `SelectObjectContent` request parser in the AspNetCore endpoints (which used `XDocument.Parse(xml, ...)`) now routes through `HardenedXml.Parse`, covering the whole XML surface consistently.
- `DtdProcessing.Prohibit` throws on any inline DTD before expansion; the readers' existing `catch` maps it to `FormatException` → `400 MalformedXML`. This matches AWS S3, which rejects request XML containing a DOCTYPE, so no legitimate client is affected.

### Note on `MaxCharactersFromEntities`
The issue's suggested snippet used `MaxCharactersFromEntities = 0`, but .NET treats `0` as **"no limit"**. This PR uses `1` (a positive cap) as defense-in-depth. The primary defense is `DtdProcessing.Prohibit`, which rejects the DOCTYPE outright.

## Tests

Added `S3XmlRequestReaderSecurityTests` (5 tests): billion-laughs and bare-DOCTYPE payloads against multiple readers assert rejection (`FormatException`) rather than expansion, plus a well-formed DTD-free body proving the hardening doesn't break valid input. Full suite: **1040 passed, 0 failed**.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)