### PR TITLE
fix: reject invalid ListObjects V1/V2/Versions query args with 400 InvalidArgument (#150)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -1691,8 +1691,6 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     ParseDelimiter(httpContext.Request),
                     ParseKeyMarker(httpContext.Request),
                     ParseVersionIdMarker(httpContext.Request),
-                    ParseMaxKeys(httpContext.Request),
-                    ParseEncodingType(httpContext.Request),
                     httpContext,
                     requestContextAccessor,
                     storageService,
@@ -1735,9 +1733,6 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         ParseDelimiter(httpContext.Request),
                         ParseStartAfter(httpContext.Request),
                         ParseContinuationToken(httpContext.Request),
-                        ParseMaxKeys(httpContext.Request),
-                        ParseEncodingType(httpContext.Request),
-                        ParseFetchOwner(httpContext.Request),
                         httpContext,
                         requestContextAccessor,
                         storageService,
@@ -1747,8 +1742,6 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         ParsePrefix(httpContext.Request),
                         ParseDelimiter(httpContext.Request),
                         ParseMarker(httpContext.Request),
-                        ParseMaxKeys(httpContext.Request),
-                        ParseEncodingType(httpContext.Request),
                         httpContext,
                         requestContextAccessor,
                         storageService,
@@ -3422,14 +3415,15 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? prefix,
         string? delimiter,
         string? marker,
-        int? maxKeys,
-        string? encodingType,
         HttpContext httpContext,
         IIntegratedS3RequestContextAccessor requestContextAccessor,
         IStorageService storageService,
         CancellationToken cancellationToken)
     {
         try {
+            var maxKeys = ParseMaxKeys(httpContext.Request);
+            var encodingType = ParseEncodingType(httpContext.Request);
+
             return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
                 var bucketResult = await storageService.HeadBucketAsync(bucketName, innerCancellationToken);
                 if (!bucketResult.IsSuccess) {
@@ -3484,15 +3478,16 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? delimiter,
         string? startAfter,
         string? continuationToken,
-        int? maxKeys,
-        string? encodingType,
-        bool fetchOwner,
         HttpContext httpContext,
         IIntegratedS3RequestContextAccessor requestContextAccessor,
         IStorageService storageService,
         CancellationToken cancellationToken)
     {
         try {
+            var maxKeys = ParseMaxKeys(httpContext.Request);
+            var encodingType = ParseEncodingType(httpContext.Request);
+            var fetchOwner = ParseFetchOwner(httpContext.Request);
+
             return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
                 var bucketResult = await storageService.HeadBucketAsync(bucketName, innerCancellationToken);
                 if (!bucketResult.IsSuccess) {
@@ -3547,14 +3542,15 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? delimiter,
         string? keyMarker,
         string? versionIdMarker,
-        int? maxKeys,
-        string? encodingType,
         HttpContext httpContext,
         IIntegratedS3RequestContextAccessor requestContextAccessor,
         IStorageService storageService,
         CancellationToken cancellationToken)
     {
         try {
+            var maxKeys = ParseMaxKeys(httpContext.Request);
+            var encodingType = ParseEncodingType(httpContext.Request);
+
             return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
                 var bucketResult = await storageService.HeadBucketAsync(bucketName, innerCancellationToken);
                 if (!bucketResult.IsSuccess) {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -3220,6 +3220,166 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectsV1_WithNonIntegerMaxKeys_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-maxkeys-v1-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-maxkeys-v1-bucket?max-keys=abc");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("max-keys", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithNonIntegerMaxKeys_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-maxkeys-v2-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-maxkeys-v2-bucket?list-type=2&max-keys=abc");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("max-keys", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectVersions_WithNonIntegerMaxKeys_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-maxkeys-versions-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-maxkeys-versions-bucket?versions&max-keys=abc");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("max-keys", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectsV1_WithNegativeMaxKeys_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/negative-maxkeys-v1-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/negative-maxkeys-v1-bucket?max-keys=-1");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("max-keys", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithNegativeMaxKeys_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/negative-maxkeys-v2-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/negative-maxkeys-v2-bucket?list-type=2&max-keys=-1");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("max-keys", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectVersions_WithNegativeMaxKeys_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/negative-maxkeys-versions-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/negative-maxkeys-versions-bucket?versions&max-keys=-1");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("max-keys", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectsV1_WithUnsupportedEncodingType_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-encoding-v1-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-encoding-v1-bucket?encoding-type=bogus");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("encoding-type", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithUnsupportedEncodingType_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-encoding-v2-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-encoding-v2-bucket?list-type=2&encoding-type=bogus");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("encoding-type", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListObjectVersions_WithUnsupportedEncodingType_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-encoding-versions-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-encoding-versions-bucket?versions&encoding-type=bogus");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("encoding-type", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithNonBooleanFetchOwner_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/invalid-fetch-owner-v2-bucket", content: null);
+
+        var response = await client.GetAsync("/integrated-s3/invalid-fetch-owner-v2-bucket?list-type=2&fetch-owner=maybe");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("fetch-owner", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public async Task S3CompatibleBucketRoute_ListType2_WithFetchOwnerAndEncodingType_ReturnsOwnerMetadata()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary
Fixes #150. Non-numeric `max-keys`, a non-`url` `encoding-type`, or a non-boolean `fetch-owner` on the object-listing operations (ListObjects V1/V2, ListObjectVersions) previously escaped as an uncaught `ArgumentException` → ASP.NET default **HTTP 500**, instead of the AWS `400 InvalidArgument`.

## Root cause
The `ParseMaxKeys` / `ParseEncodingType` / `ParseFetchOwner` calls were evaluated as method **arguments** at the bucket dispatch call-site, *outside* the catching scope of the list handlers. Those handlers already own a correct `catch (ArgumentException) → 400 InvalidArgument`, but it was unreachable because the parsers threw before the handler body ran; the only enclosing dispatch `catch` rethrows.

## Fix
Move the three parse calls **inside** `ListObjectsV1Async` / `ListObjectsV2Async` / `ListObjectVersionsAsync`, at the top of their existing `try` — the same pattern already used by `ListMultipartUploadsAsync`. The parser arguments are dropped from the three method signatures and their call-sites.

Scope note: the valid-value **clamping** behavior from #149 (`max-keys` > 1000 clamped to 1000, `max-keys=0` → empty `200`) is intentionally left unchanged; this change only rejects genuinely *invalid / malformed* values.

## Tests
Added 10 endpoint regression tests in `IntegratedS3HttpEndpointsTests.cs` across V1/V2/Versions:
- non-integer `max-keys=abc`
- negative `max-keys=-1`
- bogus `encoding-type=bogus`
- non-boolean `fetch-owner=maybe` (V2)

all asserting `400` + `InvalidArgument`. Verified **fails-before** (7 previously returned `500 InternalServerError`) / **passes-after**. Full suite green: 1059 passed, 0 failed.

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)
