### PR TITLE
fix: dispose opened GetObjectResponse when CORS wrapper throws before delegating to inner result (#128)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -8967,10 +8967,34 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
     private sealed class BucketCorsResult(string bucketName, IResult innerResult) : IResult
     {
-        public async Task ExecuteAsync(HttpContext httpContext)
+        public Task ExecuteAsync(HttpContext httpContext)
         {
             ArgumentNullException.ThrowIfNull(httpContext);
 
+            // The inner result may own an already-opened, disposable resource (e.g. a
+            // StreamObjectResult holding a live GetObjectResponse / upstream connection).
+            // The CORS pre-delegation work below performs backend I/O that can throw or be
+            // aborted; if it does so before we delegate, the inner result never executes and
+            // never disposes what it owns. Route both phases through a helper that guarantees
+            // the inner result is disposed if the pre-delegation work fails. See issue #128.
+            return ExecuteWithBucketCorsAsync(bucketName, innerResult, httpContext);
+        }
+    }
+
+    /// <summary>
+    /// Applies the actual (non-preflight) CORS headers for <paramref name="bucketName"/> and then
+    /// delegates to <paramref name="innerResult"/>. If the CORS pre-delegation work throws (or the
+    /// request is aborted) before <paramref name="innerResult"/> is executed, the inner result is
+    /// disposed first (when it implements <see cref="IAsyncDisposable"/>/<see cref="IDisposable"/>)
+    /// so that any resource it owns — such as an opened <c>GetObjectResponse</c> — is released
+    /// instead of leaked. See issue #128.
+    /// </summary>
+    internal static async Task ExecuteWithBucketCorsAsync(string bucketName, IResult innerResult, HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(innerResult);
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        try {
             var origin = httpContext.Request.Headers[OriginHeaderName].ToString();
             if (!string.IsNullOrWhiteSpace(origin)) {
                 AppendVaryHeader(httpContext.Response, OriginHeaderName);
@@ -8986,18 +9010,45 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             if (response is not null) {
                 ApplyBucketCorsActualHeaders(httpContext.Response, response);
             }
+        }
+        catch {
+            // The inner result never ran, so it never disposed what it owns. Release it here
+            // before propagating so the opened response/connection is not leaked.
+            await DisposeResultAsync(innerResult);
+            throw;
+        }
 
-            await innerResult.ExecuteAsync(httpContext);
+        await innerResult.ExecuteAsync(httpContext);
+    }
+
+    private static async ValueTask DisposeResultAsync(IResult result)
+    {
+        switch (result) {
+            case IAsyncDisposable asyncDisposable:
+                await asyncDisposable.DisposeAsync();
+                break;
+            case IDisposable disposable:
+                disposable.Dispose();
+                break;
         }
     }
 
-    private sealed class StreamObjectResult(GetObjectResponse objectResponse) : IResult
+    private sealed class StreamObjectResult(GetObjectResponse objectResponse) : IResult, IAsyncDisposable
     {
+        private GetObjectResponse? _objectResponse = objectResponse;
+
         public async Task ExecuteAsync(HttpContext httpContext)
         {
             ArgumentNullException.ThrowIfNull(httpContext);
 
-            await using var response = objectResponse;
+            // Take ownership so a later DisposeAsync (e.g. from an outer wrapper) does not
+            // double-dispose the response we consume here.
+            var response = Interlocked.Exchange(ref _objectResponse, null);
+            if (response is null) {
+                return;
+            }
+
+            await using var owned = response;
 
             ApplyObjectHeaders(httpContext.Response, response.Object);
             ApplyObjectTaggingCountHeader(httpContext.Response, response.Object);
@@ -9021,6 +9072,16 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
             await response.Content.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted);
             IntegratedS3AspNetCoreTelemetry.RecordHttpBytesSent("GetObject", response.Object.ContentLength);
+        }
+
+        // Releases the opened response if this result is discarded without ever executing —
+        // e.g. an outer wrapper throws before delegating to it. Idempotent with ExecuteAsync.
+        public async ValueTask DisposeAsync()
+        {
+            var response = Interlocked.Exchange(ref _objectResponse, null);
+            if (response is not null) {
+                await response.DisposeAsync();
+            }
         }
     }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/BucketCorsResultDisposalTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/BucketCorsResultDisposalTests.cs
@@ -1,0 +1,167 @@
+using System.Runtime.CompilerServices;
+using IntegratedS3.Abstractions.Capabilities;
+using IntegratedS3.Abstractions.Errors;
+using IntegratedS3.Abstractions.Models;
+using IntegratedS3.Abstractions.Requests;
+using IntegratedS3.Abstractions.Responses;
+using IntegratedS3.Abstractions.Results;
+using IntegratedS3.Abstractions.Services;
+using IntegratedS3.AspNetCore.Endpoints;
+using IntegratedS3.AspNetCore.Services;
+using IntegratedS3.Core.Options;
+using IntegratedS3.Core.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression tests for issue #128: when the bucket CORS wrapper performs throwing async I/O
+/// (the actual-CORS lookup) BEFORE delegating to the inner result, the inner result — which on
+/// the GET-object hot path already owns an opened <c>GetObjectResponse</c> / upstream connection —
+/// must still be disposed. Otherwise every affected request leaks one upstream connection and one
+/// <c>Activity</c>.
+/// </summary>
+public sealed class BucketCorsResultDisposalTests
+{
+    private const string OriginHeaderName = "Origin";
+
+    [Fact]
+    public async Task ExecuteWithBucketCorsAsync_DisposesInnerResult_WhenCorsLookupThrowsBeforeDelegation()
+    {
+        // The Origin header + GET method force GetActualResponseAsync to reach the throwing backend.
+        var httpContext = CreateHttpContext(origin: "https://example.test", corsBackendThrows: true);
+        var innerResult = new SpyDisposableResult();
+
+        // The CORS pre-delegation work throws; the wrapper must surface the exception AND dispose the inner result.
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            IntegratedS3EndpointRouteBuilderExtensions.ExecuteWithBucketCorsAsync("bucket", innerResult, httpContext));
+
+        Assert.False(innerResult.WasExecuted);
+        Assert.Equal(1, innerResult.DisposeCount);
+    }
+
+    [Fact]
+    public async Task ExecuteWithBucketCorsAsync_DoesNotDisposeInnerResult_WhenNoOriginPresent()
+    {
+        // Without an Origin header the CORS lookup short-circuits and never throws, so the inner
+        // result is executed normally and owns its own disposal (control case: no double dispose).
+        var httpContext = CreateHttpContext(origin: null, corsBackendThrows: true);
+        var innerResult = new SpyDisposableResult();
+
+        await IntegratedS3EndpointRouteBuilderExtensions.ExecuteWithBucketCorsAsync("bucket", innerResult, httpContext);
+
+        Assert.True(innerResult.WasExecuted);
+        Assert.Equal(0, innerResult.DisposeCount);
+    }
+
+    private static DefaultHttpContext CreateHttpContext(string? origin, bool corsBackendThrows)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(Options.Create(new IntegratedS3CoreOptions()));
+        services.AddSingleton<IStorageBackendHealthEvaluator, AlwaysHealthyEvaluator>();
+        services.AddSingleton<IStorageBackend>(new ThrowingCorsStorageBackend("primary", isPrimary: true, throwOnCors: corsBackendThrows));
+        services.AddSingleton<BucketCorsRuntimeService>();
+
+        var httpContext = new DefaultHttpContext
+        {
+            RequestServices = services.BuildServiceProvider()
+        };
+        httpContext.Request.Method = "GET";
+        if (origin is not null) {
+            httpContext.Request.Headers[OriginHeaderName] = origin;
+        }
+
+        return httpContext;
+    }
+
+    private sealed class SpyDisposableResult : IResult, IAsyncDisposable
+    {
+        public bool WasExecuted { get; private set; }
+
+        public int DisposeCount { get; private set; }
+
+        public Task ExecuteAsync(HttpContext httpContext)
+        {
+            WasExecuted = true;
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            DisposeCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    private sealed class AlwaysHealthyEvaluator : IStorageBackendHealthEvaluator
+    {
+        public ValueTask<StorageBackendHealthStatus> GetStatusAsync(IStorageBackend backend, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(StorageBackendHealthStatus.Healthy);
+    }
+
+    // Minimal backend whose only interesting behaviour is throwing from the CORS-config getter,
+    // reproducing a transient backend failure during the actual-CORS lookup on the GET hot path.
+    private sealed class ThrowingCorsStorageBackend(string name, bool isPrimary, bool throwOnCors) : IStorageBackend
+    {
+        public string Name => name;
+        public string Kind => "test";
+        public bool IsPrimary => isPrimary;
+        public string? Description => null;
+
+        public ValueTask<StorageResult<BucketCorsConfiguration>> GetBucketCorsAsync(string bucketName, CancellationToken cancellationToken = default)
+        {
+            if (throwOnCors) {
+                throw new InvalidOperationException("Simulated transient CORS-config lookup failure (#128).");
+            }
+
+            return ValueTask.FromResult(StorageResult<BucketCorsConfiguration>.Failure(
+                StorageError.Unsupported("CORS not configured.", bucketName)));
+        }
+
+        public ValueTask<StorageCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(new StorageCapabilities());
+        public ValueTask<StorageSupportStateDescriptor> GetSupportStateDescriptorAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(new StorageSupportStateDescriptor());
+        public ValueTask<StorageProviderMode> GetProviderModeAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(StorageProviderMode.Managed);
+        public ValueTask<StorageObjectLocationDescriptor> GetObjectLocationDescriptorAsync(CancellationToken cancellationToken = default) => ValueTask.FromResult(new StorageObjectLocationDescriptor());
+
+        public async IAsyncEnumerable<BucketInfo> ListBucketsAsync([EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public async IAsyncEnumerable<ObjectInfo> ListObjectsAsync(ListObjectsRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        public async IAsyncEnumerable<ObjectInfo> ListObjectVersionsAsync(ListObjectVersionsRequest request, [EnumeratorCancellation] CancellationToken cancellationToken = default)
+        {
+            await Task.CompletedTask;
+            yield break;
+        }
+
+        private static NotSupportedException Boom() => new("Not used by the #128 disposal regression test.");
+
+        public ValueTask<StorageResult<BucketInfo>> CreateBucketAsync(CreateBucketRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<BucketVersioningInfo>> GetBucketVersioningAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<BucketVersioningInfo>> PutBucketVersioningAsync(PutBucketVersioningRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult> DeleteBucketAsync(DeleteBucketRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<GetObjectResponse>> GetObjectAsync(GetObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectTagSet>> GetObjectTagsAsync(GetObjectTagsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectInfo>> CopyObjectAsync(CopyObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectInfo>> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectTagSet>> PutObjectTagsAsync(PutObjectTagsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectTagSet>> DeleteObjectTagsAsync(DeleteObjectTagsRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<MultipartUploadInfo>> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<MultipartUploadPart>> UploadMultipartPartAsync(UploadMultipartPartRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectInfo>> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult> AbortMultipartUploadAsync(AbortMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<ObjectInfo>> HeadObjectAsync(HeadObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<DeleteObjectResult>> DeleteObjectAsync(DeleteObjectRequest request, CancellationToken cancellationToken = default) => throw Boom();
+    }
+}


### PR DESCRIPTION
Closes #128.

## Problem

On the object-GET hot path the endpoint composes `BucketCorsResult(StreamObjectResult(openedResponse))`. `StreamObjectResult` owns an already-opened `GetObjectResponse` — a live upstream S3 connection plus a started `Activity` — and is the only thing that disposes it.

`BucketCorsResult.ExecuteAsync` performed throwing async I/O (the actual-CORS-config lookup, reached whenever the request carries a non-empty `Origin` header) **before** delegating to the inner result, with no `try/finally`. If that lookup threw (transient backend error/timeout) or the client aborted during it, `innerResult.ExecuteAsync` never ran, so the `await using` that disposes the opened response never ran either. Result: one leaked upstream connection and one leaked `Activity` per affected request, accumulating under churn until the SDK connection pool drains.

## Fix

- Route the wrapper through a new `ExecuteWithBucketCorsAsync` helper that runs the CORS pre-delegation work inside a `try`; on any throw it disposes the inner `IResult` (`IAsyncDisposable`/`IDisposable`) before rethrowing, so the opened response is released instead of leaked.
- Make `StreamObjectResult` implement `IAsyncDisposable` so it releases its opened `GetObjectResponse` even when it is discarded without ever executing. Disposal is idempotent with `ExecuteAsync` via `Interlocked.Exchange`, so there is no double-dispose on the normal success path.

The change is confined to the composition layer; the existing `GetObjectResponse` disposal chain was already correct.

## Test

Adds `BucketCorsResultDisposalTests`:
- Throwing case: an `Origin` header forces the CORS lookup to reach a backend that throws before delegation; asserts the inner result is disposed exactly once and never executed. **Fails before the fix, passes after** (verified by temporarily neutralizing the catch block).
- Control case: no `Origin` header ⇒ the inner result executes normally and is not disposed by the wrapper (no double-dispose).

## Verification

`dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — succeeds.
`dotnet test IntegratedS3.Tests` — 1051 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)