### PR TITLE
ci: enforce automated CVE gating (NuGet audit gate + security-scan workflow)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,114 @@
+name: Security Scan
+
+# Automated CVE gating that runs independently of the normal build:
+#   * vulnerable-packages — `dotnet list package --vulnerable` over the full transitive graph,
+#     failing on any advisory that is NOT one of the documented, build-suppressed exceptions.
+#   * codeql — static analysis of the C# sources (SigV4 / auth surface warrants it).
+# The MSBuild NuGetAudit gate in Directory.Build.props already breaks `dotnet build` on new CVEs;
+# this workflow is the defence-in-depth layer and also runs on a schedule so a CVE disclosed
+# between commits is caught without waiting for a push.
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Every Monday 06:00 UTC — catches advisories published against pinned deps between commits.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  DOTNET_NOLOGO: true
+  DOTNET_CLI_TELEMETRY_OPTOUT: true
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  vulnerable-packages:
+    name: Vulnerable NuGet packages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          cache: true
+          cache-dependency-path: src/IntegratedS3/Directory.Packages.props
+
+      - name: Restore
+        run: dotnet restore src/IntegratedS3/IntegratedS3.slnx
+
+      # `dotnet list package --vulnerable` exits 0 even when it finds vulnerabilities and does NOT
+      # honour NuGetAuditSuppress, so we parse its output ourselves. The two advisory URLs below are
+      # the exact set suppressed (with justification) in src/IntegratedS3/Directory.Build.props:
+      #   GHSA-2m69-gcr7-jv3q  SQLitePCLRaw.lib.e_sqlite3  (no patched 2.1.x release exists)
+      #   GHSA-v5pm-xwqc-g5wc  Microsoft.OpenApi 2.0.0     (cannot bump without breaking AspNetCore.OpenApi 10.0.3)
+      # Any advisory NOT in that allowlist fails the job. Keep this list in sync with Directory.Build.props.
+      - name: Scan for vulnerable packages
+        run: |
+          set -euo pipefail
+          ALLOWED='GHSA-2m69-gcr7-jv3q|GHSA-v5pm-xwqc-g5wc'
+          report="$(dotnet list src/IntegratedS3/IntegratedS3.slnx package --vulnerable --include-transitive)"
+          echo "$report"
+          # Extract every advisory GHSA/CVE id that appears in the report.
+          found="$(printf '%s\n' "$report" | grep -oE 'GHSA-[0-9a-z-]+|CVE-[0-9-]+' | sort -u || true)"
+          if [ -z "$found" ]; then
+            echo "No vulnerable packages reported."
+            exit 0
+          fi
+          # Anything found that is not in the documented allowlist is a gate failure.
+          unexpected="$(printf '%s\n' "$found" | grep -vE "^($ALLOWED)$" || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::New vulnerable package advisories detected (not in the documented allowlist):"
+            printf '%s\n' "$unexpected"
+            echo "Fix by bumping the offending package, or — only if unavoidable and non-shipping —"
+            echo "add a documented NuGetAuditSuppress in Directory.Build.props and this allowlist."
+            exit 1
+          fi
+          echo "Only the documented, build-suppressed advisories were found; gate passes."
+
+  codeql:
+    name: CodeQL (C#)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+          cache: true
+          cache-dependency-path: src/IntegratedS3/Directory.Packages.props
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: csharp
+          build-mode: manual
+
+      # Manual build mode: exclude sample WebUi hosts / test project from analysis is unnecessary;
+      # a plain restore+build of the solution is what CodeQL needs to see the compiled sources.
+      - name: Build for analysis
+        run: |
+          dotnet build src/IntegratedS3/IntegratedS3.slnx --configuration Release
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: '/language:csharp'

--- a/src/IntegratedS3/Directory.Build.props
+++ b/src/IntegratedS3/Directory.Build.props
@@ -19,14 +19,18 @@
     <PackageReadmeFile Condition="'$(IsPackable)' != 'false'">README.md</PackageReadmeFile>
 
     <!-- Build quality -->
-    <!-- All compiler, analyzer, and MSBuild warnings fail the build. NuGet audit findings
-         (NU1901-NU1904) are exempted because the flagged packages are transitive
-         (Microsoft.OpenApi via Microsoft.AspNetCore.OpenApi, SQLitePCLRaw via EF Core Sqlite,
-         OpenTelemetry.Api/Exporter via the pinned OpenTelemetry 1.11.x line); they stay visible
-         as warnings and are upgraded through Dependabot instead of failing every build. -->
+    <!-- All compiler, analyzer, and MSBuild warnings fail the build. NuGet security audit is a
+         first-class CVE gate: it runs on every restore, covers the full transitive graph, and a
+         genuine advisory (NU1901-NU1904) now FAILS the build instead of being demoted to a warning. -->
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <WarningsAsErrors>$(WarningsAsErrors);nullable</WarningsAsErrors>
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);NU1901;NU1902;NU1903;NU1904</WarningsNotAsErrors>
+
+    <!-- NuGet security audit: scan direct AND transitive packages, report from 'low' up, and let
+         the audit codes flow through TreatWarningsAsErrors so any real CVE breaks the build. -->
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
+
     <AnalysisLevel>latest</AnalysisLevel>
     <AnalysisMode>Default</AnalysisMode>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
@@ -42,6 +46,28 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
+
+  <!-- CVE-gate exceptions, suppressed per-advisory (NOT a blanket NU190x waiver) so every OTHER
+       high/critical CVE still fails the build. Both entries below are transitive-only, land solely
+       in IsPackable=false projects (sample hosts / test project) that are never packed or published,
+       and have no low-risk fixed version reachable today. Each must be removed the moment its
+       upstream ships a patched release.
+
+       1. GHSA-2m69-gcr7-jv3q (CVE-2025-6965, SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11, NU1903 high).
+          No patched 2.1.x release exists (the fix lives upstream in SQLite 3.50.2, not yet in a
+          2.1.x bundle). Pulled only by Microsoft.EntityFrameworkCore.Sqlite into IntegratedS3.Tests.
+
+       2. GHSA-v5pm-xwqc-g5wc (Microsoft.OpenApi 2.0.0, NU1903 high). Pulled transitively by
+          Microsoft.AspNetCore.OpenApi 10.0.3 into the WebUi sample hosts. A patched Microsoft.OpenApi
+          (2.7.5+) EXISTS but cannot be force-upgraded here: AspNetCore.OpenApi 10.0.3's XML-comment
+          source generator is compiled against Microsoft.OpenApi Version=2.0.0.0 and fails to compile
+          (CS0012/CS0246 on OpenApiOperation/OpenApiSchema/IOpenApiParameter) against 2.7.x/2.9.x,
+          whose assembly identity and type surface changed. The real fix is an updated
+          Microsoft.AspNetCore.OpenApi from Microsoft; remove this suppression when that lands. -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-v5pm-xwqc-g5wc" />
+  </ItemGroup>
 
   <!-- SourceLink for source debugging -->
   <ItemGroup>

--- a/src/IntegratedS3/Directory.Packages.props
+++ b/src/IntegratedS3/Directory.Packages.props
@@ -21,10 +21,12 @@
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <!-- OpenTelemetry 1.16.0 line: clears GHSA-g94r-2vxg-569j (OpenTelemetry.Api NU1902) and
+         GHSA-4625-4j76-fww9 (OpenTelemetry.Exporter.OpenTelemetryProtocol NU1902), both patched in 1.15.3. -->
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>


### PR DESCRIPTION
## What this does

Closes the "zero automated CVE gating" gap from #130 by making a genuine package advisory **break the build**, and adds a dedicated CI security workflow.

### `src/IntegratedS3/Directory.Build.props`
- Removed `NU1901;NU1902;NU1903;NU1904` from `WarningsNotAsErrors`. With the existing `TreatWarningsAsErrors=true`, any package advisory now **fails `dotnet build`/restore** instead of being demoted to a silent warning.
- Enabled full audit: `NuGetAudit=true`, `NuGetAuditMode=all` (direct **and** transitive), `NuGetAuditLevel=low`.
- Added **exactly two** per-advisory `NuGetAuditSuppress` entries (URL-scoped, **not** a blanket `NU190x` waiver). Both are transitive-only, land solely in `IsPackable=false` projects (sample hosts / test project — never packed or published), and have no low-risk fixed version reachable today:
  - `GHSA-2m69-gcr7-jv3q` — `SQLitePCLRaw.lib.e_sqlite3` 2.1.11 (NU1903 high). **No patched 2.1.x release exists** (fix is upstream in SQLite 3.50.2); pulled by EF Core Sqlite into `IntegratedS3.Tests`.
  - `GHSA-v5pm-xwqc-g5wc` — `Microsoft.OpenApi` 2.0.0 (NU1903 high). A patched `2.7.5+` exists, **but it cannot be force-upgraded here**: `Microsoft.AspNetCore.OpenApi` 10.0.3's XML-comment source generator is compiled against `Microsoft.OpenApi, Version=2.0.0.0` and fails to compile (CS0012/CS0246 on `OpenApiOperation`/`OpenApiSchema`/`IOpenApiParameter`) against 2.7.x/2.9.x. The real fix is an updated `Microsoft.AspNetCore.OpenApi` from Microsoft.

### `src/IntegratedS3/Directory.Packages.props`
- Bumped the OpenTelemetry line **1.11.x → 1.16.0**, which **fully closes** two advisories (no suppression needed):
  - `GHSA-g94r-2vxg-569j` — `OpenTelemetry.Api` (NU1902), patched in 1.15.3
  - `GHSA-4625-4j76-fww9` — `OpenTelemetry.Exporter.OpenTelemetryProtocol` (NU1902), patched in 1.15.3

### `.github/workflows/security-scan.yml` (new)
- **`vulnerable-packages`** job: `dotnet restore` + `dotnet list package --vulnerable --include-transitive`. That command exits `0` even on findings and doesn't honour `NuGetAuditSuppress`, so the step parses the output itself and fails on any advisory outside the **same documented allowlist** as the build suppressions.
- **`codeql`** job: `github/codeql-action` for C# (warranted by the SigV4/auth surface).
- Triggers: `push`, `pull_request`, and a **weekly schedule** so a CVE disclosed against a pinned dep between commits is still caught.

## Deliberately skipped (with reasons)
- **Lock file** (`RestorePackagesWithLockFile` / `packages.lock.json`): a repo-wide lockfile is higher-risk to introduce and is not needed for the gate to function; the MSBuild audit already scans the full transitive graph on every restore. Left out to keep this change low-risk.
- **`dependabot.yml`**: unchanged. The existing weekly version-updates already pull fixes; the audit gate + CI scan are the actual enforcement layer.

## Verification
- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` → **0 warnings, 0 errors**.
- `dotnet test IntegratedS3.Tests` → **1049 passed, 0 failed**.
- **Gate is real**: temporarily removing a suppression reproduces a hard `error NU1903` and `Build FAILED` (restored after).
- Scan-script dry-run against live `dotnet list --vulnerable` output matches **only** the two allowlisted advisories → passes today, would fail on any new CVE.
- `security-scan.yml` validated as well-formed YAML.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)
