### PR TITLE
build: remove redundant Microsoft.SourceLink.GitHub reference

### DIFF
--- a/src/IntegratedS3/Directory.Build.props
+++ b/src/IntegratedS3/Directory.Build.props
@@ -69,11 +69,6 @@
     <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-v5pm-xwqc-g5wc" />
   </ItemGroup>
 
-  <!-- SourceLink for source debugging -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="All" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(IsPackable)' != 'false'">
     <None Include="$(MSBuildThisFileDirectory)..\..\README.md" Pack="true" PackagePath="\" Link="README.md" Visible="false" />
   </ItemGroup>

--- a/src/IntegratedS3/Directory.Packages.props
+++ b/src/IntegratedS3/Directory.Packages.props
@@ -20,7 +20,6 @@
     <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <!-- OpenTelemetry 1.16.0 line: clears GHSA-g94r-2vxg-569j (OpenTelemetry.Api NU1902) and
          GHSA-4625-4j76-fww9 (OpenTelemetry.Exporter.OpenTelemetryProtocol NU1902), both patched in 1.15.3. -->
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.16.0" />


### PR DESCRIPTION
## Summary

On the .NET 10 SDK, SourceLink for GitHub-hosted repos is bundled and imported implicitly. The explicit `<PackageReference Include="Microsoft.SourceLink.GitHub" .../>` in `Directory.Build.props` set `SuppressImplicitGitSourceLink=true`, which opted *out* of the SDK-integrated SourceLink and fell back to the pinned `8.0.0` line — redundant config surface plus extra Dependabot tracking with no functional benefit.

## Changes

- Removed the standalone `Microsoft.SourceLink.GitHub` `PackageReference` `ItemGroup` from `src/IntegratedS3/Directory.Build.props`.
- Removed the `PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0"` pin from `src/IntegratedS3/Directory.Packages.props`.
- Kept `PublishRepositoryUrl` / `EmbedUntrackedSources` / `ContinuousIntegrationBuild`, so the SDK now auto-imports the current bundled SourceLink.

## Verification

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — succeeded, 0 warnings / 0 errors (restore still succeeds after removing the package).
- `dotnet test IntegratedS3.Tests` — Passed! 1080/1080.
- Generated restore props (`obj/*.nuget.g.props`) no longer reference the standalone `microsoft.sourcelink.github\8.0.0` package; SDK-integrated SourceLink now applies.

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)