### PR TITLE
fix: cap aws-chunked chunk-header/trailer line length to prevent memory-exhaustion DoS (#116)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -105,6 +105,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string StartAfterQueryParameterName = "start-after";
     private const string MaxKeysQueryParameterName = "max-keys";
     private const int MaxKeysLimit = 1000;
+    private const int MaxAwsChunkedLineLength = 16 * 1024;
     private const string MaxUploadsQueryParameterName = "max-uploads";
     private const string MaxPartsQueryParameterName = "max-parts";
     private const string ContinuationTokenQueryParameterName = "continuation-token";
@@ -7063,6 +7064,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     }
 
                     return Encoding.ASCII.GetString(buffer, 0, position);
+                }
+
+                if (position >= MaxAwsChunkedLineLength) {
+                    throw new FormatException(
+                        $"The aws-chunked request body contains a line longer than the {MaxAwsChunkedLineLength}-byte limit.");
                 }
 
                 if (position >= buffer.Length) {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -422,6 +422,41 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task PutObject_WithAwsChunkedLineExceedingLengthCap_ReturnsBadRequestWithoutUnboundedBuffering()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        const string bucketName = "aws-chunked-oversized-line-bucket";
+        const string objectKey = "docs/oversized-line.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // A chunk-size line that never contains a CRLF. Before the fix, ReadLineAsync doubled its
+        // rented buffer without any cap, so this run of bytes forced unbounded managed-heap growth.
+        // The fix caps a single aws-chunked line at 16 KiB and rejects longer lines with a 400.
+        var oversizedLine = new byte[64 * 1024];
+        Array.Fill(oversizedLine, (byte)'0');
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new ByteArrayContent(oversizedLine)
+        };
+        putRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        putRequest.Content.Headers.ContentEncoding.Add("aws-chunked");
+        putRequest.Headers.TryAddWithoutValidation("x-amz-decoded-content-length", "0");
+        putRequest.Headers.TryAddWithoutValidation("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+
+        var response = await client.SendAsync(putRequest);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(document, "Code"));
+        Assert.Contains("16384-byte limit", GetRequiredElementValue(document, "Message"));
+    }
+
+    [Fact]
     public async Task PutObject_WithUnsignedTrailerBackedPayloadHashWithoutTrailerSignature_Succeeds()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary

`ReadLineAsync`, used by the `aws-chunked` request-body parser to read chunk-size lines and trailer headers, doubled a rented `ArrayPool<byte>` buffer on every byte until a CRLF was seen, with **no length cap**. A client that sends a chunk-size line or trailer header with no CRLF (a continuous stream of non-`\r` bytes) forces the buffer to grow into a single large contiguous managed-heap allocation.

This is **not** reliably bounded by the request-body size limit: `MaxObjectSizeBytes` defaults to `null`, and the upload endpoints set `MaxRequestBodySize = null`, removing Kestrel's per-request cap. Parsing happens before chunk-signature verification, so a malicious/malformed upload can drive growth up to OOM in the default configuration.

## Fix

- Enforce a strict **16 KiB** cap (`MaxAwsChunkedLineLength`) on a single aws-chunked line in `ReadLineAsync` — far more than S3 needs for a chunk-size line plus `chunk-signature` extension, or for a trailer header.
- Lines exceeding the cap throw `FormatException`, which the upload handlers already map to `400 InvalidArgument`, instead of growing without bound.

## Test

Adds `PutObject_WithAwsChunkedLineExceedingLengthCap_ReturnsBadRequestWithoutUnboundedBuffering`: sends a 64 KiB chunk-size line with no CRLF and asserts a `400 InvalidArgument` response with the limit message. Verified fails-before (buffer grows / different error) and passes-after. Full suite: 1081 passed, 0 failed.

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)