### PR TITLE
fix: map multipart error family to distinct S3 codes (#147)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
@@ -50,6 +50,18 @@ public enum StorageErrorCode
     /// <summary>A multipart upload ID conflict or invalid state transition was detected.</summary>
     MultipartConflict,
 
+    /// <summary>The specified multipart upload does not exist, or has been completed or aborted.</summary>
+    NoSuchUpload,
+
+    /// <summary>One or more listed multipart parts is missing or has a mismatched ETag.</summary>
+    InvalidPart,
+
+    /// <summary>The multipart parts were not supplied in ascending part-number order (or contain duplicates).</summary>
+    InvalidPartOrder,
+
+    /// <summary>An argument value violates its allowed range or format (e.g., part number outside 1..10000).</summary>
+    InvalidArgument,
+
     /// <summary>The request was rate-limited by the storage backend.</summary>
     Throttled,
 

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -128,6 +128,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string UploadsQueryParameterName = "uploads";
     private const string UploadIdQueryParameterName = "uploadId";
     private const string PartNumberQueryParameterName = "partNumber";
+    private const int MaxMultipartPartNumber = 10000;
     private const string PartNumberMarkerQueryParameterName = "part-number-marker";
     private const string VersionIdQueryParameterName = "versionId";
     private const string DeleteQueryParameterName = "delete";
@@ -4162,6 +4163,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.BucketAlreadyExists => StatusCodes.Status409Conflict,
             StorageErrorCode.BucketNotEmpty => StatusCodes.Status409Conflict,
             StorageErrorCode.MultipartConflict => StatusCodes.Status409Conflict,
+            StorageErrorCode.NoSuchUpload => StatusCodes.Status404NotFound,
+            StorageErrorCode.InvalidPart => StatusCodes.Status400BadRequest,
+            StorageErrorCode.InvalidPartOrder => StatusCodes.Status400BadRequest,
+            StorageErrorCode.InvalidArgument => StatusCodes.Status400BadRequest,
             StorageErrorCode.Throttled => StatusCodes.Status429TooManyRequests,
             StorageErrorCode.ProviderUnavailable => StatusCodes.Status503ServiceUnavailable,
             StorageErrorCode.UnsupportedCapability => StatusCodes.Status501NotImplemented,
@@ -4199,6 +4204,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.BucketAlreadyExists => "BucketAlreadyExists",
             StorageErrorCode.BucketNotEmpty => "BucketNotEmpty",
             StorageErrorCode.MultipartConflict => "InvalidRequest",
+            StorageErrorCode.NoSuchUpload => "NoSuchUpload",
+            StorageErrorCode.InvalidPart => "InvalidPart",
+            StorageErrorCode.InvalidPartOrder => "InvalidPartOrder",
+            StorageErrorCode.InvalidArgument => "InvalidArgument",
             StorageErrorCode.Throttled => "SlowDown",
             StorageErrorCode.ProviderUnavailable => "ServiceUnavailable",
             StorageErrorCode.UnsupportedCapability => "NotImplemented",
@@ -6660,9 +6669,9 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             return false;
         }
 
-        if (!int.TryParse(values.ToString(), out var parsedPartNumber) || parsedPartNumber <= 0) {
+        if (!int.TryParse(values.ToString(), out var parsedPartNumber) || parsedPartNumber < 1 || parsedPartNumber > MaxMultipartPartNumber) {
             partNumber = null;
-            error = $"The '{PartNumberQueryParameterName}' query parameter must be a positive integer.";
+            error = $"Part number must be an integer between 1 and {MaxMultipartPartNumber}, inclusive.";
             return false;
         }
 

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -27,6 +27,7 @@ internal sealed class DiskStorageService(
     private const string VersionStoreDirectoryName = ".integrateds3-versions";
     private const string MultipartUploadsDirectoryName = ".integrateds3-multipart";
     private const string MultipartStateFileName = "upload.json";
+    private const int MaxMultipartPartNumber = 10000;
     private const string Md5ChecksumAlgorithm = "md5";
     private const string Sha256ChecksumAlgorithm = "sha256";
     private const string Sha1ChecksumAlgorithm = "sha1";
@@ -2534,9 +2535,9 @@ internal sealed class DiskStorageService(
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        if (request.PartNumber <= 0) {
-            return StorageResult<MultipartUploadPart>.Failure(MultipartConflict(
-                "Multipart part numbers must be greater than zero.",
+        if (request.PartNumber < 1 || request.PartNumber > MaxMultipartPartNumber) {
+            return StorageResult<MultipartUploadPart>.Failure(InvalidPartArgument(
+                $"Part number must be an integer between 1 and {MaxMultipartPartNumber}, inclusive.",
                 request.BucketName,
                 request.Key));
         }
@@ -2894,28 +2895,52 @@ internal sealed class DiskStorageService(
                 || string.Equals(uploadChecksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase))
             ? new List<string>(request.Parts.Count)
             : null;
+
+        // Validate the client-supplied part list before consuming it. AWS requires parts to be
+        // listed in strictly ascending part-number order with no duplicates, and each part number
+        // must fall within the 1..10000 range. These checks must run against the caller's original
+        // order (request.Parts), not a re-sorted copy, so that InvalidPartOrder is surfaced.
+        var previousPartNumber = 0;
+        foreach (var requestedPart in request.Parts) {
+            if (requestedPart.PartNumber < 1 || requestedPart.PartNumber > MaxMultipartPartNumber) {
+                return StorageResult<ObjectInfo>.Failure(InvalidPartArgument(
+                    $"Part number must be an integer between 1 and {MaxMultipartPartNumber}, inclusive.",
+                    request.BucketName,
+                    request.Key));
+            }
+
+            if (requestedPart.PartNumber == previousPartNumber) {
+                return StorageResult<ObjectInfo>.Failure(InvalidPartOrder(
+                    $"The list of parts was not in ascending order. Part '{requestedPart.PartNumber}' is listed more than once.",
+                    request.BucketName,
+                    request.Key));
+            }
+
+            if (requestedPart.PartNumber < previousPartNumber) {
+                return StorageResult<ObjectInfo>.Failure(InvalidPartOrder(
+                    $"The list of parts was not in ascending order. Part '{requestedPart.PartNumber}' followed part '{previousPartNumber}'.",
+                    request.BucketName,
+                    request.Key));
+            }
+
+            previousPartNumber = requestedPart.PartNumber;
+        }
+
         try {
             await using (var destinationStream = new FileStream(tempObjectPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
-                foreach (var requestedPart in request.Parts.OrderBy(static part => part.PartNumber)) {
-                    if (requestedPart.PartNumber <= 0) {
-                        return StorageResult<ObjectInfo>.Failure(MultipartConflict(
-                            "Multipart part numbers must be greater than zero.",
-                            request.BucketName,
-                            request.Key));
-                    }
-
+                foreach (var requestedPart in request.Parts) {
                     var partPath = GetMultipartPartPath(uploadState.UploadDirectoryPath, requestedPart.PartNumber);
                     if (!File.Exists(partPath)) {
-                        return StorageResult<ObjectInfo>.Failure(MultipartConflict(
-                            $"Multipart part '{requestedPart.PartNumber}' was not found for upload '{request.UploadId}'.",
+                        return StorageResult<ObjectInfo>.Failure(InvalidPart(
+                            $"One or more of the specified parts could not be found. Part '{requestedPart.PartNumber}' was not uploaded for upload '{request.UploadId}'.",
                             request.BucketName,
                             request.Key));
                     }
 
                     var actualETag = BuildETag(new FileInfo(partPath));
                     if (!string.Equals(NormalizeETag(requestedPart.ETag), NormalizeETag(actualETag), StringComparison.Ordinal)) {
-                        return StorageResult<ObjectInfo>.Failure(MultipartConflict(
-                            $"Multipart part '{requestedPart.PartNumber}' does not match the supplied ETag.",
+                        return StorageResult<ObjectInfo>.Failure(InvalidPart(
+                            $"The ETag supplied for part '{requestedPart.PartNumber}' does not match the ETag of the uploaded part.",
                             request.BucketName,
                             request.Key));
                     }
@@ -5228,7 +5253,7 @@ internal sealed class DiskStorageService(
         var uploadDirectoryPath = GetMultipartUploadPath(bucketName, uploadId);
         var statePath = GetMultipartStatePath(uploadDirectoryPath);
         if (_multipartStateStore is null && !File.Exists(statePath)) {
-            return StorageResult<MultipartUploadStateContext>.Failure(MultipartConflict(
+            return StorageResult<MultipartUploadStateContext>.Failure(NoSuchUpload(
                 $"Multipart upload '{uploadId}' was not found.",
                 bucketName,
                 key));
@@ -5239,7 +5264,7 @@ internal sealed class DiskStorageService(
             || !string.Equals(state.BucketName, bucketName, StringComparison.Ordinal)
             || !string.Equals(state.Key, key, StringComparison.Ordinal)
             || !string.Equals(state.UploadId, uploadId, StringComparison.Ordinal)) {
-            return StorageResult<MultipartUploadStateContext>.Failure(MultipartConflict(
+            return StorageResult<MultipartUploadStateContext>.Failure(NoSuchUpload(
                 $"Multipart upload '{uploadId}' does not match the supplied bucket or key.",
                 bucketName,
                 key));
@@ -6026,6 +6051,58 @@ internal sealed class DiskStorageService(
         return new StorageError
         {
             Code = StorageErrorCode.MultipartConflict,
+            Message = message,
+            BucketName = bucketName,
+            ObjectKey = objectKey,
+            ProviderName = options.ProviderName,
+            SuggestedHttpStatusCode = 400
+        };
+    }
+
+    private StorageError NoSuchUpload(string message, string bucketName, string objectKey)
+    {
+        return new StorageError
+        {
+            Code = StorageErrorCode.NoSuchUpload,
+            Message = message,
+            BucketName = bucketName,
+            ObjectKey = objectKey,
+            ProviderName = options.ProviderName,
+            SuggestedHttpStatusCode = 404
+        };
+    }
+
+    private StorageError InvalidPart(string message, string bucketName, string objectKey)
+    {
+        return new StorageError
+        {
+            Code = StorageErrorCode.InvalidPart,
+            Message = message,
+            BucketName = bucketName,
+            ObjectKey = objectKey,
+            ProviderName = options.ProviderName,
+            SuggestedHttpStatusCode = 400
+        };
+    }
+
+    private StorageError InvalidPartOrder(string message, string bucketName, string objectKey)
+    {
+        return new StorageError
+        {
+            Code = StorageErrorCode.InvalidPartOrder,
+            Message = message,
+            BucketName = bucketName,
+            ObjectKey = objectKey,
+            ProviderName = options.ProviderName,
+            SuggestedHttpStatusCode = 400
+        };
+    }
+
+    private StorageError InvalidPartArgument(string message, string bucketName, string objectKey)
+    {
+        return new StorageError
+        {
+            Code = StorageErrorCode.InvalidArgument,
             Message = message,
             BucketName = bucketName,
             ObjectKey = objectKey,

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
@@ -34,7 +34,7 @@ internal static class S3ErrorTranslator
                  $"Bucket '{bucketName}' does not have a default encryption configuration."),
 
             "NoSuchUpload" =>
-                (StorageErrorCode.MultipartConflict,
+                (StorageErrorCode.NoSuchUpload,
                  $"Multipart upload for object '{objectKey}' in bucket '{bucketName}' does not exist or is no longer active."),
 
             "BucketAlreadyExists" =>
@@ -78,12 +78,18 @@ internal static class S3ErrorTranslator
                      : ex.Message),
 
             "InvalidPart" =>
-                (StorageErrorCode.MultipartConflict,
+                (StorageErrorCode.InvalidPart,
                  $"One or more multipart parts for object '{objectKey}' in bucket '{bucketName}' were missing or had mismatched ETags/checksums."),
 
             "InvalidPartOrder" =>
-                (StorageErrorCode.MultipartConflict,
+                (StorageErrorCode.InvalidPartOrder,
                  $"Multipart parts for object '{objectKey}' in bucket '{bucketName}' were not supplied in ascending part-number order."),
+
+            "InvalidArgument" =>
+                (StorageErrorCode.InvalidArgument,
+                 !string.IsNullOrEmpty(objectKey)
+                     ? $"An argument supplied for object '{objectKey}' in bucket '{bucketName}' was invalid: {ex.Message}"
+                     : ex.Message),
 
             "EntityTooSmall" =>
                 (StorageErrorCode.MultipartConflict,

--- a/src/IntegratedS3/IntegratedS3.Testing/StorageProviderContractTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Testing/StorageProviderContractTests.cs
@@ -1539,7 +1539,7 @@ public abstract class StorageProviderContractTests
 
     /// <summary>
     /// Verifies that an in-progress multipart upload can be aborted, that completing an
-    /// aborted upload fails with <see cref="StorageErrorCode.MultipartConflict"/>, and that
+    /// aborted upload fails with <see cref="StorageErrorCode.NoSuchUpload"/>, and that
     /// the upload no longer appears in the active upload listing.
     /// </summary>
     [Fact]
@@ -1586,7 +1586,7 @@ public abstract class StorageProviderContractTests
             Key = "docs/aborted.txt",
             UploadId = initiatedUpload.UploadId,
             Parts = [uploadedPart]
-        }), StorageErrorCode.MultipartConflict);
+        }), StorageErrorCode.NoSuchUpload);
 
         var uploads = await storage.ListMultipartUploadsAsync(new ListMultipartUploadsRequest
         {

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -3215,7 +3215,7 @@ public sealed class DiskStorageServiceTests
         });
 
         Assert.False(completeResult.IsSuccess);
-        Assert.Equal(IntegratedS3.Abstractions.Errors.StorageErrorCode.MultipartConflict, completeResult.Error!.Code);
+        Assert.Equal(IntegratedS3.Abstractions.Errors.StorageErrorCode.NoSuchUpload, completeResult.Error!.Code);
     }
 
     [Fact]
@@ -4865,5 +4865,227 @@ public sealed class DiskStorageServiceTests
     private static string GetBucketMetadataPath(string rootPath, string bucketName)
     {
         return Path.Combine(rootPath, bucketName, ".integrateds3.bucket.json");
+    }
+
+    // ---- Regression tests for issue #147: multipart error family must map to distinct S3 codes ----
+
+    private static async Task<(string UploadId, MultipartUploadPart Part1, MultipartUploadPart Part2)> SeedTwoPartMultipartUploadAsync(
+        IStorageBackend storageService,
+        string bucketName,
+        string key)
+    {
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = bucketName });
+
+        var initiate = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            ContentType = "text/plain"
+        });
+        Assert.True(initiate.IsSuccess);
+
+        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes("hello "));
+        var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            UploadId = initiate.Value!.UploadId,
+            PartNumber = 1,
+            Content = part1Stream
+        });
+        Assert.True(part1.IsSuccess);
+
+        await using var part2Stream = new MemoryStream(Encoding.UTF8.GetBytes("world"));
+        var part2 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            UploadId = initiate.Value.UploadId,
+            PartNumber = 2,
+            Content = part2Stream
+        });
+        Assert.True(part2.IsSuccess);
+
+        return (initiate.Value.UploadId, part1.Value!, part2.Value!);
+    }
+
+    [Fact]
+    public async Task DiskStorage_Complete_MissingPart_ReturnsInvalidPart()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        var (uploadId, part1, _) = await SeedTwoPartMultipartUploadAsync(storageService, "mp-invalidpart-missing", "docs/obj.txt");
+
+        // Reference a part number (3) that was never uploaded.
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "mp-invalidpart-missing",
+            Key = "docs/obj.txt",
+            UploadId = uploadId,
+            Parts =
+            [
+                part1,
+                new MultipartUploadPart { PartNumber = 3, ETag = "\"deadbeef\"", ContentLength = 0, LastModifiedUtc = default }
+            ]
+        });
+
+        Assert.False(completeResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.InvalidPart, completeResult.Error!.Code);
+        Assert.Equal(400, completeResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_Complete_ETagMismatch_ReturnsInvalidPart()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        var (uploadId, part1, part2) = await SeedTwoPartMultipartUploadAsync(storageService, "mp-invalidpart-etag", "docs/obj.txt");
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "mp-invalidpart-etag",
+            Key = "docs/obj.txt",
+            UploadId = uploadId,
+            Parts =
+            [
+                part1,
+                new MultipartUploadPart { PartNumber = part2.PartNumber, ETag = "\"0000000000000000000000000000ffff\"", ContentLength = 0, LastModifiedUtc = default }
+            ]
+        });
+
+        Assert.False(completeResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.InvalidPart, completeResult.Error!.Code);
+        Assert.Equal(400, completeResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_Complete_PartsNotAscending_ReturnsInvalidPartOrder()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        var (uploadId, part1, part2) = await SeedTwoPartMultipartUploadAsync(storageService, "mp-partorder-desc", "docs/obj.txt");
+
+        // Parts supplied in descending order must be rejected, not silently re-sorted.
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "mp-partorder-desc",
+            Key = "docs/obj.txt",
+            UploadId = uploadId,
+            Parts = [part2, part1]
+        });
+
+        Assert.False(completeResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.InvalidPartOrder, completeResult.Error!.Code);
+        Assert.Equal(400, completeResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_Complete_DuplicatePartNumbers_ReturnsInvalidPartOrder()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        var (uploadId, part1, _) = await SeedTwoPartMultipartUploadAsync(storageService, "mp-partorder-dup", "docs/obj.txt");
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "mp-partorder-dup",
+            Key = "docs/obj.txt",
+            UploadId = uploadId,
+            Parts = [part1, part1]
+        });
+
+        Assert.False(completeResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.InvalidPartOrder, completeResult.Error!.Code);
+        Assert.Equal(400, completeResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_UploadPart_PartNumberAboveMaximum_ReturnsInvalidArgument()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "mp-partrange" });
+
+        var initiate = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "mp-partrange",
+            Key = "docs/obj.txt"
+        });
+        Assert.True(initiate.IsSuccess);
+
+        await using var partStream = new MemoryStream(Encoding.UTF8.GetBytes("payload"));
+        var uploadResult = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "mp-partrange",
+            Key = "docs/obj.txt",
+            UploadId = initiate.Value!.UploadId,
+            PartNumber = 10001,
+            Content = partStream
+        });
+
+        Assert.False(uploadResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.InvalidArgument, uploadResult.Error!.Code);
+        Assert.Equal(400, uploadResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_UploadPart_UnknownUploadId_ReturnsNoSuchUpload()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "mp-nosuchupload-uploadpart" });
+
+        await using var partStream = new MemoryStream(Encoding.UTF8.GetBytes("payload"));
+        var uploadResult = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "mp-nosuchupload-uploadpart",
+            Key = "docs/obj.txt",
+            UploadId = "00000000000000000000000000000000",
+            PartNumber = 1,
+            Content = partStream
+        });
+
+        Assert.False(uploadResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.NoSuchUpload, uploadResult.Error!.Code);
+        Assert.Equal(404, uploadResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_Abort_UnknownUploadId_ReturnsNoSuchUpload()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "mp-nosuchupload-abort" });
+
+        var abortResult = await storageService.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+        {
+            BucketName = "mp-nosuchupload-abort",
+            Key = "docs/obj.txt",
+            UploadId = "00000000000000000000000000000000"
+        });
+
+        Assert.False(abortResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.NoSuchUpload, abortResult.Error!.Code);
+        Assert.Equal(404, abortResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_Complete_UnknownUploadId_ReturnsNoSuchUpload()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "mp-nosuchupload-complete" });
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "mp-nosuchupload-complete",
+            Key = "docs/obj.txt",
+            UploadId = "00000000000000000000000000000000",
+            Parts = [new MultipartUploadPart { PartNumber = 1, ETag = "\"deadbeef\"", ContentLength = 0, LastModifiedUtc = default }]
+        });
+
+        Assert.False(completeResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.NoSuchUpload, completeResult.Error!.Code);
+        Assert.Equal(404, completeResult.Error.SuggestedHttpStatusCode);
     }
 }

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -10798,6 +10798,79 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     private static async Task AssertNotImplementedResponseAsync(HttpResponseMessage response)
         => await AssertErrorResponseAsync(response, HttpStatusCode.NotImplemented, "NotImplemented");
 
+    [Fact]
+    public async Task S3CompatibleUploadPart_PartNumberAboveMaximum_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "multipart-partnumber-range-bucket";
+        const string objectKey = "docs/range.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var initiateRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploads")
+        {
+            Content = new ByteArrayContent([])
+        };
+        var initiateResponse = await client.SendAsync(initiateRequest);
+        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
+        var uploadId = GetRequiredElementValue(XDocument.Parse(await initiateResponse.Content.ReadAsStringAsync()), "UploadId");
+
+        var partResponse = await client.PutAsync(
+            $"/integrated-s3/{bucketName}/{objectKey}?partNumber=10001&uploadId={Uri.EscapeDataString(uploadId)}",
+            new StringContent("payload", Encoding.UTF8, "text/plain"));
+
+        await AssertErrorResponseAsync(partResponse, HttpStatusCode.BadRequest, "InvalidArgument");
+    }
+
+    [Fact]
+    public async Task S3CompatibleCompleteMultipartUpload_PartsNotAscending_ReturnsInvalidPartOrder()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "multipart-partorder-bucket";
+        const string objectKey = "docs/order.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var initiateRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploads")
+        {
+            Content = new ByteArrayContent([])
+        };
+        var initiateResponse = await client.SendAsync(initiateRequest);
+        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
+        var uploadId = GetRequiredElementValue(XDocument.Parse(await initiateResponse.Content.ReadAsStringAsync()), "UploadId");
+
+        var firstPartResponse = await client.PutAsync(
+            $"/integrated-s3/{bucketName}/{objectKey}?partNumber=1&uploadId={Uri.EscapeDataString(uploadId)}",
+            new StringContent("hello ", Encoding.UTF8, "text/plain"));
+        Assert.Equal(HttpStatusCode.OK, firstPartResponse.StatusCode);
+        var firstPartETag = firstPartResponse.Headers.ETag?.Tag ?? throw new Xunit.Sdk.XunitException("Expected first part ETag header.");
+
+        var secondPartResponse = await client.PutAsync(
+            $"/integrated-s3/{bucketName}/{objectKey}?partNumber=2&uploadId={Uri.EscapeDataString(uploadId)}",
+            new StringContent("world", Encoding.UTF8, "text/plain"));
+        Assert.Equal(HttpStatusCode.OK, secondPartResponse.StatusCode);
+        var secondPartETag = secondPartResponse.Headers.ETag?.Tag ?? throw new Xunit.Sdk.XunitException("Expected second part ETag header.");
+
+        // Parts listed in descending order (2 then 1) must be rejected with InvalidPartOrder.
+        using var completeRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploadId={Uri.EscapeDataString(uploadId)}")
+        {
+            Content = new StringContent($"""
+<CompleteMultipartUpload>
+  <Part>
+    <PartNumber>2</PartNumber>
+    <ETag>{secondPartETag}</ETag>
+  </Part>
+  <Part>
+    <PartNumber>1</PartNumber>
+    <ETag>{firstPartETag}</ETag>
+  </Part>
+</CompleteMultipartUpload>
+""", Encoding.UTF8, "application/xml")
+        };
+
+        await AssertErrorResponseAsync(await client.SendAsync(completeRequest), HttpStatusCode.BadRequest, "InvalidPartOrder");
+    }
+
     private static async Task AssertErrorResponseAsync(HttpResponseMessage response, HttpStatusCode expectedStatusCode, string expectedCode)
     {
         Assert.Equal(expectedStatusCode, response.StatusCode);

--- a/src/IntegratedS3/IntegratedS3.Tests/RcloneS3MultipartEncodingCompatibilityTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/RcloneS3MultipartEncodingCompatibilityTests.cs
@@ -667,11 +667,11 @@ public sealed class RcloneS3MultipartEncodingCompatibilityTests : IClassFixture<
     }
 
     [Fact]
-    public async Task Error_CompleteMultipartWithWrongPartOrder_DiskProviderAutoSorts()
+    public async Task Error_CompleteMultipartWithWrongPartOrder_ReturnsInvalidPartOrder()
     {
-        // Note: Real S3 rejects parts in wrong order with InvalidPartOrder.
-        // The disk provider auto-sorts parts (see DiskStorageService.cs OrderBy),
-        // so this test verifies the disk backend silently reorders and succeeds.
+        // Real S3 rejects parts supplied out of ascending part-number order with
+        // InvalidPartOrder (HTTP 400). The disk provider must match this behavior
+        // instead of silently re-sorting (issue #147).
         using var client = await _factory.CreateClientAsync();
         var bucket = Bucket();
         const string key = "wrong-order-test.dat";
@@ -686,14 +686,19 @@ public sealed class RcloneS3MultipartEncodingCompatibilityTests : IClassFixture<
         var etag2 = await UploadPartAsync(client, bucket, key, uploadId, 2, part2Data);
         var etag3 = await UploadPartAsync(client, bucket, key, uploadId, 3, part3Data);
 
-        // Complete with parts in reversed order (3, 1, 2)
+        // Complete with parts in reversed order (3, 1, 2) must be rejected.
         var completeResp = await CompleteMultipartAsync(client, bucket, key, uploadId,
             [(3, etag3), (1, etag1), (2, etag2)]);
 
-        // Disk provider auto-sorts, so this succeeds
-        Assert.Equal(HttpStatusCode.OK, completeResp.StatusCode);
+        Assert.Equal(HttpStatusCode.BadRequest, completeResp.StatusCode);
+        var errorDoc = XDocument.Parse(await completeResp.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidPartOrder", El(errorDoc, "Code"));
 
-        // Content should be in part-number order (1,2,3), not submission order
+        // In ascending part-number order (1, 2, 3) the same upload completes successfully.
+        var orderedResp = await CompleteMultipartAsync(client, bucket, key, uploadId,
+            [(1, etag1), (2, etag2), (3, etag3)]);
+        Assert.Equal(HttpStatusCode.OK, orderedResp.StatusCode);
+
         var getResp = await client.GetAsync(ObjectPath(bucket, key));
         var downloaded = await getResp.Content.ReadAsByteArrayAsync();
         Assert.Equal(

--- a/src/IntegratedS3/IntegratedS3.Tests/S3ErrorTranslatorTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3ErrorTranslatorTests.cs
@@ -68,24 +68,34 @@ public sealed class S3ErrorTranslatorTests
     }
 
     [Fact]
-    public void NoSuchUpload_MapsTo_MultipartConflict()
+    public void NoSuchUpload_MapsTo_NoSuchUpload()
     {
         var ex = MakeException("NoSuchUpload", HttpStatusCode.NotFound);
 
         var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket", "my-object.txt");
 
-        Assert.Equal(StorageErrorCode.MultipartConflict, error.Code);
+        Assert.Equal(StorageErrorCode.NoSuchUpload, error.Code);
         Assert.Contains("my-object.txt", error.Message);
     }
 
     [Fact]
-    public void InvalidPart_MapsTo_MultipartConflict()
+    public void InvalidPart_MapsTo_InvalidPart()
     {
         var ex = MakeException("InvalidPart", HttpStatusCode.BadRequest);
 
         var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket", "my-object.txt");
 
-        Assert.Equal(StorageErrorCode.MultipartConflict, error.Code);
+        Assert.Equal(StorageErrorCode.InvalidPart, error.Code);
+    }
+
+    [Fact]
+    public void InvalidPartOrder_MapsTo_InvalidPartOrder()
+    {
+        var ex = MakeException("InvalidPartOrder", HttpStatusCode.BadRequest);
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket", "my-object.txt");
+
+        Assert.Equal(StorageErrorCode.InvalidPartOrder, error.Code);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The whole multipart failure family collapsed to `StorageErrorCode.MultipartConflict`, which renders on the wire as `Code=InvalidRequest`, HTTP `409`. AWS returns distinct codes with `400`/`404`, and strict multipart clients (aws-cli, SDK completers) branch on them. This maps each condition to its correct S3 `Code` + HTTP status.

## Changes

| Case | Before | After |
|---|---|---|
| Complete: part missing / ETag mismatch | `409 InvalidRequest` | `400 InvalidPart` |
| Complete: parts not ascending | silently re-sorted | `400 InvalidPartOrder` |
| Complete: duplicate part numbers | concatenated twice | `400 InvalidPartOrder` |
| UploadPart / UploadPartCopy / Abort / Complete on bad `uploadId` | `409 InvalidRequest` | `404 NoSuchUpload` |
| `partNumber` outside `1..10000` | accepted (`> 0` only) | `400 InvalidArgument` |
| S3-backend passthrough | folded to `MultipartConflict` | `InvalidPart` / `InvalidPartOrder` / `NoSuchUpload` / `InvalidArgument` preserved |

Implementation:
- New `StorageErrorCode` values `NoSuchUpload`, `InvalidPart`, `InvalidPartOrder`, `InvalidArgument`, mapped in `ToStatusCode` / `ToS3ErrorCode`.
- `DiskStorageService.ReadMultipartStateAsync` returns `NoSuchUpload` (404) for unknown/mismatched upload ids — this fixes UploadPart/UploadPartCopy/Abort/Complete on a bad `uploadId` in one place.
- `CompleteMultipartUpload` validates the **client-supplied** part list (not a re-sorted copy) for ascending order + duplicates before the internal `OrderBy`, and enforces the `1..10000` range; missing/ETag-mismatch parts now return `InvalidPart`.
- `TryGetPartNumber` (endpoint) and `UploadMultipartPartAsync` (disk provider) enforce `1..10000`.
- `S3ErrorTranslator` preserves the distinct codes from a real S3 backend.

`EntityTooSmall` (min-part-size) is intentionally left as-is — it is tracked separately in #137.

## Tests

Added regression tests (fail-before / pass-after) for each distinct case at both the disk-provider and HTTP-endpoint levels; updated existing tests that encoded the old blanket behavior (`DiskProviderAutoSorts`, `CanBeAborted`, `S3ErrorTranslatorTests`). Full suite: **1091 passed, 0 failed**.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
