### PR TITLE
fix: ListObjectVersions pagination/shape AWS conformance (#159)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -3553,6 +3553,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             var maxKeys = ParseMaxKeys(httpContext.Request);
             var encodingType = ParseEncodingType(httpContext.Request);
 
+            // AWS requires key-marker when version-id-marker is supplied.
+            if (!string.IsNullOrEmpty(versionIdMarker) && string.IsNullOrEmpty(keyMarker)) {
+                return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "A version-id marker cannot be specified without a key marker.", BuildObjectResource(bucketName, null), bucketName);
+            }
+
             return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
                 var bucketResult = await storageService.HeadBucketAsync(bucketName, innerCancellationToken);
                 if (!bucketResult.IsSuccess) {
@@ -3583,7 +3588,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         versionIdMarker,
                         encodingType,
                         requestedPageSize,
-                        versions);
+                        versions,
+                        ResolveS3ListingIdentity(httpContext.User));
 
                     return new XmlContentResult(S3XmlResponseWriter.WriteListObjectVersionsResult(response), StatusCodes.Status200OK, XmlContentType);
                 }
@@ -4568,7 +4574,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? versionIdMarker,
         string? encodingType,
         int maxKeys,
-        IReadOnlyList<ObjectInfo> versions)
+        IReadOnlyList<ObjectInfo> versions,
+        S3BucketOwner owner)
     {
         var normalizedPrefix = prefix ?? string.Empty;
         var normalizedDelimiter = string.IsNullOrEmpty(delimiter) ? null : delimiter;
@@ -4589,7 +4596,6 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 var delimiterIndex = suffix.IndexOf(normalizedDelimiter, StringComparison.Ordinal);
                 if (delimiterIndex >= 0) {
                     var commonPrefix = normalizedPrefix + suffix[..(delimiterIndex + normalizedDelimiter.Length)];
-                    var lastVersion = currentVersion;
 
                     while (index + 1 < versions.Count) {
                         var nextVersion = versions[index + 1];
@@ -4597,11 +4603,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                             break;
                         }
 
-                        lastVersion = nextVersion;
                         index++;
                     }
 
-                    entries.Add(ListObjectVersionsResultEntry.ForCommonPrefix(commonPrefix, lastVersion.Key, lastVersion.VersionId));
+                    // AWS uses the grouped common-prefix string as the continuation NextKeyMarker
+                    // (and omits NextVersionIdMarker) when the truncation boundary is a CommonPrefix.
+                    entries.Add(ListObjectVersionsResultEntry.ForCommonPrefix(commonPrefix, commonPrefix, null));
                     continue;
                 }
             }
@@ -4628,7 +4635,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             IsTruncated = isTruncated,
             Versions = page
                 .Where(static entry => entry.Version is not null)
-                .Select(static entry => new S3ObjectVersionEntry
+                .Select(entry => new S3ObjectVersionEntry
                 {
                     Key = entry.Version!.Key,
                     VersionId = entry.Version.VersionId ?? string.Empty,
@@ -4636,7 +4643,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     IsDeleteMarker = entry.Version.IsDeleteMarker,
                     ETag = entry.Version.ETag,
                     Size = entry.Version.ContentLength,
-                    LastModifiedUtc = entry.Version.LastModifiedUtc
+                    LastModifiedUtc = entry.Version.LastModifiedUtc,
+                    Owner = owner
                 })
                 .ToArray(),
             CommonPrefixes = page

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3ListObjectVersionsResult.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3ListObjectVersionsResult.cs
@@ -70,4 +70,7 @@ public sealed class S3ObjectVersionEntry
 
     /// <summary>The storage class of the object version.</summary>
     public string StorageClass { get; init; } = "STANDARD";
+
+    /// <summary>The owner of the object version.</summary>
+    public S3BucketOwner? Owner { get; init; }
 }

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -467,6 +467,10 @@ public static class S3XmlResponseWriter
                 xmlWriter.WriteElementString("StorageClass", version.StorageClass);
             }
 
+            if (version.Owner is not null) {
+                WriteOwner(xmlWriter, "Owner", version.Owner);
+            }
+
             xmlWriter.WriteEndElement();
         }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -9603,6 +9603,82 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task ListObjectVersions_VersionIdMarkerWithoutKeyMarker_ReturnsInvalidArgument()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/vid-marker-no-key-bucket", content: null)).StatusCode);
+        await EnableBucketVersioningAsync(client, "vid-marker-no-key-bucket");
+
+        // AWS rejects a version-id-marker supplied without a key-marker with 400 InvalidArgument.
+        var response = await client.GetAsync(
+            "/integrated-s3/vid-marker-no-key-bucket?versions&version-id-marker=some-version-id");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("InvalidArgument", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("key marker", GetRequiredElementValue(errorDocument, "Message"), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task ListObjectVersions_EmitsOwnerOnEachVersionEntry()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/owner-versions-bucket", content: null)).StatusCode);
+        await EnableBucketVersioningAsync(client, "owner-versions-bucket");
+
+        await client.PutAsync(
+            "/integrated-s3/owner-versions-bucket/docs/file.txt",
+            new StringContent("v1", Encoding.UTF8, "text/plain"));
+
+        var listResponse = await client.GetAsync("/integrated-s3/owner-versions-bucket?versions");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var document = XDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+
+        var version = Assert.Single(document.Root!.Elements(S3Ns + "Version"));
+        var owner = version.Element(S3Ns + "Owner");
+        Assert.NotNull(owner);
+        Assert.False(string.IsNullOrWhiteSpace(owner!.Element(S3Ns + "ID")?.Value));
+    }
+
+    [Fact]
+    public async Task ListObjectVersions_TruncatedOnCommonPrefixBoundary_NextKeyMarkerIsCommonPrefix()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/prefix-boundary-versions-bucket", content: null)).StatusCode);
+        await EnableBucketVersioningAsync(client, "prefix-boundary-versions-bucket");
+
+        // Two grouped common prefixes under a delimiter: alpha/ and beta/.
+        await client.PutAsync(
+            "/integrated-s3/prefix-boundary-versions-bucket/alpha/one.txt",
+            new StringContent("a", Encoding.UTF8, "text/plain"));
+        await client.PutAsync(
+            "/integrated-s3/prefix-boundary-versions-bucket/alpha/two.txt",
+            new StringContent("a", Encoding.UTF8, "text/plain"));
+        await client.PutAsync(
+            "/integrated-s3/prefix-boundary-versions-bucket/beta/one.txt",
+            new StringContent("b", Encoding.UTF8, "text/plain"));
+
+        // max-keys=1 with a delimiter truncates right after the first CommonPrefix (alpha/).
+        var response = await client.GetAsync(
+            "/integrated-s3/prefix-boundary-versions-bucket?versions&delimiter=/&max-keys=1");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+
+        Assert.Equal("true", GetRequiredElementValue(document, "IsTruncated"));
+        var commonPrefix = Assert.Single(document.Root!.Elements(S3Ns + "CommonPrefixes"));
+        Assert.Equal("alpha/", commonPrefix.Element(S3Ns + "Prefix")?.Value);
+
+        // AWS sets NextKeyMarker to the common-prefix string (not an underlying object key)
+        // and omits NextVersionIdMarker at a CommonPrefix truncation boundary.
+        Assert.Equal("alpha/", GetRequiredElementValue(document, "NextKeyMarker"));
+        Assert.Empty(document.Root!.Elements(S3Ns + "NextVersionIdMarker"));
+    }
+
+    [Fact]
     public async Task ListObjectVersions_DeleteMarkerNotInGetResponse_OnlyInVersionsList()
     {
         using var client = await _factory.CreateClientAsync();

--- a/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
@@ -263,4 +263,53 @@ public sealed class S3XmlResponseWriterTests
                 Assert.Equal(S3XmlTestHelper.CanonicalS3Namespace, element.Name.NamespaceName));
         }
     }
+
+    [Fact]
+    public void WriteListObjectVersionsResult_EmitsOwnerOnVersionAndDeleteMarkerEntries()
+    {
+        var timestamp = new DateTimeOffset(2026, 03, 14, 09, 00, 00, TimeSpan.Zero);
+        var owner = new S3BucketOwner { Id = "owner-id-123", DisplayName = "owner-name" };
+
+        var xml = S3XmlResponseWriter.WriteListObjectVersionsResult(new S3ListObjectVersionsResult
+        {
+            Name = "bucket",
+            MaxKeys = 2,
+            Versions =
+            [
+                new S3ObjectVersionEntry
+                {
+                    Key = "docs/a.txt",
+                    VersionId = "version-1",
+                    IsLatest = true,
+                    ETag = "etag-1",
+                    Size = 10,
+                    LastModifiedUtc = timestamp,
+                    Owner = owner
+                },
+                new S3ObjectVersionEntry
+                {
+                    Key = "docs/deleted.txt",
+                    VersionId = "version-2",
+                    IsDeleteMarker = true,
+                    LastModifiedUtc = timestamp,
+                    Owner = owner
+                }
+            ],
+            CommonPrefixes = []
+        });
+
+        var document = XDocument.Parse(xml);
+        var ns = S3XmlTestHelper.CanonicalS3Namespace;
+
+        var version = Assert.Single(document.Root!.Elements(XName.Get("Version", ns)));
+        var versionOwner = version.Element(XName.Get("Owner", ns));
+        Assert.NotNull(versionOwner);
+        Assert.Equal("owner-id-123", versionOwner!.Element(XName.Get("ID", ns))?.Value);
+        Assert.Equal("owner-name", versionOwner.Element(XName.Get("DisplayName", ns))?.Value);
+
+        var deleteMarker = Assert.Single(document.Root!.Elements(XName.Get("DeleteMarker", ns)));
+        var deleteMarkerOwner = deleteMarker.Element(XName.Get("Owner", ns));
+        Assert.NotNull(deleteMarkerOwner);
+        Assert.Equal("owner-id-123", deleteMarkerOwner!.Element(XName.Get("ID", ns))?.Value);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes three `ListObjectVersions` divergences from the AWS reference (issue #159):

1. **NextKeyMarker on a CommonPrefix truncation boundary.** When the last emitted entry is a grouped `CommonPrefix` (delimiter listing) and the page is truncated, AWS sets `NextKeyMarker` to the common-prefix string and omits `NextVersionIdMarker`. Previously the code stored the underlying object's `Key`/`VersionId`, so continuation could skip or repeat keys. Now emits the common-prefix string with no version-id marker.
2. **`version-id-marker` without `key-marker`.** AWS returns `400 InvalidArgument` ("A version-id marker cannot be specified without a key marker."). This cross-check was missing and is now enforced before listing.
3. **`<Owner>` omitted.** Each `<Version>`/`<DeleteMarker>` now includes `<Owner>` (ID + optional DisplayName), sourced from the request identity via `ResolveS3ListingIdentity` — the same source used for `fetch-owner` object listings. ListObjectVersions always includes Owner per AWS.

## Tests

Regression tests added (fail-before, pass-after, all verified by temporarily reverting each fix):

- `ListObjectVersions_TruncatedOnCommonPrefixBoundary_NextKeyMarkerIsCommonPrefix` — NextKeyMarker = `alpha/`, NextVersionIdMarker absent.
- `ListObjectVersions_VersionIdMarkerWithoutKeyMarker_ReturnsInvalidArgument` — 400 InvalidArgument.
- `ListObjectVersions_EmitsOwnerOnEachVersionEntry` — HTTP-level Owner presence.
- `WriteListObjectVersionsResult_EmitsOwnerOnVersionAndDeleteMarkerEntries` — XML writer Owner on both Version and DeleteMarker.

Full suite: build clean, 1100/1100 tests pass.

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)