### PR TITLE
fix: translate S3 transport/service failures instead of leaking raw exceptions (#129)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
@@ -1,4 +1,7 @@
-using Amazon.S3;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using Amazon.Runtime;
 using IntegratedS3.Abstractions.Errors;
 
 namespace IntegratedS3.Provider.S3.Internal;
@@ -6,7 +9,7 @@ namespace IntegratedS3.Provider.S3.Internal;
 internal static class S3ErrorTranslator
 {
     public static StorageError Translate(
-        AmazonS3Exception ex,
+        AmazonServiceException ex,
         string providerName,
         string? bucketName = null,
         string? objectKey = null)
@@ -143,6 +146,19 @@ internal static class S3ErrorTranslator
                 (StorageErrorCode.Throttled,
                  $"S3 provider '{providerName}' is throttling requests: {ex.Message}"),
 
+            // Any other 5xx from the upstream (including a bare AmazonServiceException with a
+            // 500-class status but no recognized S3 error code) is a transient provider fault.
+            _ when (int)ex.StatusCode >= 500 =>
+                (StorageErrorCode.ProviderUnavailable,
+                 $"S3 provider '{providerName}' is temporarily unavailable: {ex.Message}"),
+
+            // A service exception with no HTTP status (StatusCode == 0) means the request never
+            // completed against the upstream — a transport-level failure (connection reset,
+            // timeout, DNS/TLS error) surfaced by the AWS SDK as AmazonServiceException.
+            _ when (int)ex.StatusCode == 0 =>
+                (StorageErrorCode.ProviderUnavailable,
+                 $"S3 provider '{providerName}' could not be reached: {ex.Message}"),
+
             _ => (StorageErrorCode.Unknown, ex.Message)
         };
 
@@ -153,7 +169,73 @@ internal static class S3ErrorTranslator
             BucketName = bucketName,
             ObjectKey = objectKey,
             ProviderName = providerName,
-            SuggestedHttpStatusCode = (int)ex.StatusCode
+            SuggestedHttpStatusCode = MapSuggestedStatus(code, (int)ex.StatusCode)
+        };
+    }
+
+    /// <summary>
+    /// Translates a raw transport-layer exception (connection reset, timeout, DNS/TLS failure)
+    /// that the AWS SDK surfaced without an <see cref="AmazonServiceException"/> wrapper — for
+    /// example <see cref="HttpRequestException"/>, <see cref="IOException"/>,
+    /// <see cref="SocketException"/>, or a non-cancellation <see cref="TaskCanceledException"/>
+    /// (request timeout) — into a retryable <see cref="StorageErrorCode.ProviderUnavailable"/>
+    /// error. The originating exception is preserved in the message so it is not swallowed.
+    /// </summary>
+    public static StorageError TranslateTransport(
+        Exception ex,
+        string providerName,
+        string? bucketName = null,
+        string? objectKey = null)
+    {
+        return new StorageError
+        {
+            Code = StorageErrorCode.ProviderUnavailable,
+            Message = $"S3 provider '{providerName}' could not be reached: {ex.Message}",
+            BucketName = bucketName,
+            ObjectKey = objectKey,
+            ProviderName = providerName,
+            SuggestedHttpStatusCode = 503
+        };
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="ex"/> is a raw transport-layer failure that should be
+    /// translated into a retryable provider error rather than propagated untranslated. Returns
+    /// <see langword="false"/> for cancellation triggered by the caller's
+    /// <paramref name="cancellationToken"/> so that genuine caller cancellation is re-thrown and
+    /// not misreported as a provider fault.
+    /// </summary>
+    public static bool IsTransportFailure(Exception ex, CancellationToken cancellationToken)
+    {
+        // Caller-initiated cancellation must not be swallowed or reclassified as a provider fault.
+        if (ex is OperationCanceledException && cancellationToken.IsCancellationRequested)
+            return false;
+
+        return ex switch
+        {
+            HttpRequestException => true,
+            SocketException => true,
+            IOException => true,
+            // A TaskCanceledException whose cancellation was NOT requested by the caller is an
+            // HttpClient request timeout, i.e. a transport failure.
+            TaskCanceledException => true,
+            OperationCanceledException => true,
+            _ => false
+        };
+    }
+
+    private static int MapSuggestedStatus(StorageErrorCode code, int httpStatus)
+    {
+        // A recognized transient failure with no usable upstream status (0) should still map to a
+        // sensible retryable HTTP status for the S3-compatible facade.
+        if (httpStatus > 0)
+            return httpStatus;
+
+        return code switch
+        {
+            StorageErrorCode.Throttled => 429,
+            StorageErrorCode.ProviderUnavailable => 503,
+            _ => 500
         };
     }
 }

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using Amazon.Runtime;
 using Amazon.S3;
 using IntegratedS3.Abstractions.Capabilities;
 using IntegratedS3.Abstractions.Errors;
@@ -113,9 +114,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 Headers = BuildDirectPresignHeaders(request)
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<StorageDirectObjectAccessGrant>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<StorageDirectObjectAccessGrant>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -157,9 +162,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 CreatedAtUtc = entry.CreatedAtUtc
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -176,9 +185,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                     : entry.LocationConstraint
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketLocationInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketLocationInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -193,9 +206,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 Status = entry.Status
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketVersioningInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketVersioningInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -210,9 +227,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 Status = entry.Status
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketVersioningInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketVersioningInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -228,9 +249,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<BucketCorsConfiguration>.Success(ToBucketCorsConfiguration(bucketName, entry));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketCorsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketCorsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -244,9 +269,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketCorsConfiguration>.Success(ToBucketCorsConfiguration(request.BucketName, entry));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketCorsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketCorsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -257,9 +286,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketCorsAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -274,9 +307,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
         {
             return StorageResult<BucketDefaultEncryptionConfiguration>.Failure(StorageError.Unsupported(ex.Message, bucketName));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketDefaultEncryptionConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketDefaultEncryptionConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -291,9 +328,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
         {
             return StorageResult<BucketDefaultEncryptionConfiguration>.Failure(StorageError.Unsupported(ex.Message, request.BucketName));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketDefaultEncryptionConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketDefaultEncryptionConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -304,9 +345,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketDefaultEncryptionAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -321,9 +366,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketTaggingAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketTaggingConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketTaggingConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketTaggingConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -334,9 +383,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketTaggingAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketTaggingConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketTaggingConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketTaggingConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -347,9 +400,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketTaggingAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -364,9 +421,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketLoggingAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketLoggingConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketLoggingConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketLoggingConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -377,9 +438,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketLoggingAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketLoggingConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketLoggingConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketLoggingConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -394,9 +459,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketWebsiteAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketWebsiteConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketWebsiteConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketWebsiteConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -407,9 +476,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketWebsiteAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketWebsiteConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketWebsiteConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketWebsiteConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -420,9 +493,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketWebsiteAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -437,9 +514,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketRequestPaymentAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketRequestPaymentConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketRequestPaymentConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketRequestPaymentConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -450,9 +531,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketRequestPaymentAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketRequestPaymentConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketRequestPaymentConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketRequestPaymentConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -467,9 +552,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketAccelerateAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketAccelerateConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketAccelerateConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketAccelerateConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -480,9 +569,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketAccelerateAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketAccelerateConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketAccelerateConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketAccelerateConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -497,9 +590,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketLifecycleAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketLifecycleConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketLifecycleConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketLifecycleConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -510,9 +607,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketLifecycleAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketLifecycleConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketLifecycleConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketLifecycleConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -523,9 +624,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketLifecycleAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -540,9 +645,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketReplicationAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketReplicationConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketReplicationConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketReplicationConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -553,9 +662,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketReplicationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketReplicationConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketReplicationConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketReplicationConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -566,9 +679,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketReplicationAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -583,9 +700,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketNotificationConfigurationAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketNotificationConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketNotificationConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketNotificationConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -596,9 +717,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketNotificationConfigurationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketNotificationConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketNotificationConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketNotificationConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -613,9 +738,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetObjectLockConfigurationAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<ObjectLockConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectLockConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectLockConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -626,9 +755,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutObjectLockConfigurationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<ObjectLockConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectLockConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectLockConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -643,9 +776,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketAnalyticsConfigurationAsync(bucketName, id, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketAnalyticsConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketAnalyticsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketAnalyticsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -656,9 +793,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketAnalyticsConfigurationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketAnalyticsConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketAnalyticsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketAnalyticsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -669,9 +810,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketAnalyticsConfigurationAsync(request.BucketName, request.Id, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -682,9 +827,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var configs = await _client.ListBucketAnalyticsConfigurationsAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<IReadOnlyList<BucketAnalyticsConfiguration>>.Success(configs);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<IReadOnlyList<BucketAnalyticsConfiguration>>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<IReadOnlyList<BucketAnalyticsConfiguration>>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -699,9 +848,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketMetricsConfigurationAsync(bucketName, id, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketMetricsConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketMetricsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketMetricsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -712,9 +865,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketMetricsConfigurationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketMetricsConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketMetricsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketMetricsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -725,9 +882,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketMetricsConfigurationAsync(request.BucketName, request.Id, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -738,9 +899,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var configs = await _client.ListBucketMetricsConfigurationsAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<IReadOnlyList<BucketMetricsConfiguration>>.Success(configs);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<IReadOnlyList<BucketMetricsConfiguration>>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<IReadOnlyList<BucketMetricsConfiguration>>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -755,9 +920,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketInventoryConfigurationAsync(bucketName, id, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketInventoryConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketInventoryConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketInventoryConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -768,9 +937,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketInventoryConfigurationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketInventoryConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketInventoryConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketInventoryConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -781,9 +954,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketInventoryConfigurationAsync(request.BucketName, request.Id, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -794,9 +971,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var configs = await _client.ListBucketInventoryConfigurationsAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<IReadOnlyList<BucketInventoryConfiguration>>.Success(configs);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<IReadOnlyList<BucketInventoryConfiguration>>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<IReadOnlyList<BucketInventoryConfiguration>>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -811,9 +992,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.GetBucketIntelligentTieringConfigurationAsync(bucketName, id, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketIntelligentTieringConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketIntelligentTieringConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketIntelligentTieringConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -824,9 +1009,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var config = await _client.PutBucketIntelligentTieringConfigurationAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<BucketIntelligentTieringConfiguration>.Success(config);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketIntelligentTieringConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketIntelligentTieringConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -837,9 +1026,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketIntelligentTieringConfigurationAsync(request.BucketName, request.Id, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -850,9 +1043,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var configs = await _client.ListBucketIntelligentTieringConfigurationsAsync(bucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult<IReadOnlyList<BucketIntelligentTieringConfiguration>>.Success(configs);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<IReadOnlyList<BucketIntelligentTieringConfiguration>>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<IReadOnlyList<BucketIntelligentTieringConfiguration>>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -867,9 +1064,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var result = await _client.PutObjectRetentionAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<ObjectRetentionInfo>.Success(result);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectRetentionInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectRetentionInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -880,9 +1081,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var result = await _client.PutObjectLegalHoldAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<ObjectLegalHoldInfo>.Success(result);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectLegalHoldInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectLegalHoldInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -901,9 +1106,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 RestoreOutputPath = result.RestoreOutputPath
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<RestoreObjectResponse>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<RestoreObjectResponse>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -922,9 +1131,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 ContentType = result.ContentType
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<SelectObjectContentResponse>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<SelectObjectContentResponse>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -951,9 +1164,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 CreatedAtUtc = entry.CreatedAtUtc
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<BucketInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
         }
     }
 
@@ -964,9 +1181,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             await _client.DeleteBucketAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
         }
     }
 
@@ -997,10 +1218,15 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                     remaining,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (AmazonS3Exception ex)
+            catch (AmazonServiceException ex)
             {
                 throw new InvalidOperationException(
                     S3ErrorTranslator.Translate(ex, Name, request.BucketName).Message, ex);
+            }
+            catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+            {
+                throw new InvalidOperationException(
+                    S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName).Message, ex);
             }
 
             foreach (var entry in page.Entries)
@@ -1047,10 +1273,15 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                     remaining,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (AmazonS3Exception ex)
+            catch (AmazonServiceException ex)
             {
                 throw new InvalidOperationException(
                     S3ErrorTranslator.Translate(ex, Name, request.BucketName).Message, ex);
+            }
+            catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+            {
+                throw new InvalidOperationException(
+                    S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName).Message, ex);
             }
 
             foreach (var entry in page.Entries)
@@ -1097,10 +1328,15 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                     remaining,
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (AmazonS3Exception ex)
+            catch (AmazonServiceException ex)
             {
                 throw new InvalidOperationException(
                     S3ErrorTranslator.Translate(ex, Name, request.BucketName).Message, ex);
+            }
+            catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+            {
+                throw new InvalidOperationException(
+                    S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName).Message, ex);
             }
 
             foreach (var entry in page.Entries)
@@ -1152,10 +1388,15 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             {
                 yield break;
             }
-            catch (AmazonS3Exception ex)
+            catch (AmazonServiceException ex)
             {
                 throw new InvalidOperationException(
                     S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key).Message, ex);
+            }
+            catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+            {
+                throw new InvalidOperationException(
+                    S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key).Message, ex);
             }
 
             foreach (var entry in page.Entries)
@@ -1203,9 +1444,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<ObjectInfo>.Success(info);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ServerSideEncryptionNotSupportedException ex)
         {
@@ -1276,9 +1521,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 return StorageResult<GetObjectResponse>.Failure(StorageError.Unsupported(objectLockEx.Message, request.BucketName, request.Key));
             }
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<GetObjectResponse>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<GetObjectResponse>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ServerSideEncryptionNotSupportedException ex)
         {
@@ -1297,9 +1546,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var retention = await _client.GetObjectRetentionAsync(request.BucketName, request.Key, request.VersionId, cancellationToken).ConfigureAwait(false);
             return StorageResult<ObjectRetentionInfo>.Success(retention);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectRetentionInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectRetentionInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ObjectLockNotSupportedException ex)
         {
@@ -1314,9 +1567,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var legalHold = await _client.GetObjectLegalHoldAsync(request.BucketName, request.Key, request.VersionId, cancellationToken).ConfigureAwait(false);
             return StorageResult<ObjectLegalHoldInfo>.Success(legalHold);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectLegalHoldInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectLegalHoldInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ObjectLockNotSupportedException ex)
         {
@@ -1331,9 +1588,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var response = await _client.GetObjectAttributesAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<GetObjectAttributesResponse>.Success(response);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<GetObjectAttributesResponse>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<GetObjectAttributesResponse>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1376,9 +1637,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<ObjectInfo>.Success(EntryToObjectInfo(request.BucketName, entry));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ServerSideEncryptionNotSupportedException ex)
         {
@@ -1402,9 +1667,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 IsDeleteMarker = result.IsDeleteMarker
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<DeleteObjectResult>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<DeleteObjectResult>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1425,9 +1694,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 Tags = tags
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectTagSet>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectTagSet>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1444,9 +1717,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 Tags = request.Tags
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectTagSet>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectTagSet>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1463,9 +1740,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
                 Tags = new Dictionary<string, string>(StringComparer.Ordinal)
             });
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectTagSet>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectTagSet>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1538,9 +1819,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<ObjectInfo>.Success(EntryToObjectInfo(request.DestinationBucketName, enrichedEntry));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectInfo>.Failure(TranslateCopyObjectError(ex, request));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.DestinationBucketName, request.DestinationKey));
         }
         catch (S3ServerSideEncryptionNotSupportedException ex)
         {
@@ -1583,9 +1868,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<MultipartUploadInfo>.Success(upload);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<MultipartUploadInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<MultipartUploadInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ServerSideEncryptionNotSupportedException ex)
         {
@@ -1635,12 +1924,16 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<MultipartUploadPart>.Success(part);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<MultipartUploadPart>.Failure(
                 !string.IsNullOrWhiteSpace(request.CopySourceBucketName) && !string.IsNullOrWhiteSpace(request.CopySourceKey)
                     ? TranslateCopyMultipartPartError(ex, request)
                     : S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<MultipartUploadPart>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1661,9 +1954,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
             var part = await _client.UploadPartCopyAsync(request, cancellationToken).ConfigureAwait(false);
             return StorageResult<MultipartUploadPart>.Success(part);
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<MultipartUploadPart>.Failure(TranslateCopyPartError(ex, request));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<MultipartUploadPart>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (NotSupportedException ex)
         {
@@ -1693,9 +1990,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult<ObjectInfo>.Success(EntryToObjectInfo(request.BucketName, enrichedEntry));
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<ObjectInfo>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
         catch (S3ServerSideEncryptionNotSupportedException ex)
         {
@@ -1717,9 +2018,13 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
 
             return StorageResult.Success();
         }
-        catch (AmazonS3Exception ex)
+        catch (AmazonServiceException ex)
         {
             return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName, request.Key));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName, request.Key));
         }
     }
 
@@ -1770,7 +2075,7 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
         }
     }
 
-    private StorageError TranslateCopyObjectError(AmazonS3Exception exception, CopyObjectRequest request)
+    private StorageError TranslateCopyObjectError(AmazonServiceException exception, CopyObjectRequest request)
     {
         if (string.Equals(exception.ErrorCode, "NoSuchKey", StringComparison.OrdinalIgnoreCase))
         {
@@ -1794,7 +2099,7 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
         return S3ErrorTranslator.Translate(exception, Name, request.DestinationBucketName, request.DestinationKey);
     }
 
-    private StorageError TranslateCopyPartError(AmazonS3Exception exception, UploadPartCopyRequest request)
+    private StorageError TranslateCopyPartError(AmazonServiceException exception, UploadPartCopyRequest request)
     {
         if (string.Equals(exception.ErrorCode, "NoSuchKey", StringComparison.OrdinalIgnoreCase)
             || string.Equals(exception.ErrorCode, "NoSuchVersion", StringComparison.OrdinalIgnoreCase)
@@ -1810,7 +2115,7 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
         return S3ErrorTranslator.Translate(exception, Name, request.BucketName, request.Key);
     }
 
-    private StorageError TranslateCopyMultipartPartError(AmazonS3Exception exception, UploadMultipartPartRequest request)
+    private StorageError TranslateCopyMultipartPartError(AmazonServiceException exception, UploadMultipartPartRequest request)
     {
         var sourceBucketName = request.CopySourceBucketName!;
         var sourceKey = request.CopySourceKey!;

--- a/src/IntegratedS3/IntegratedS3.Tests/S3ErrorTranslatorTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3ErrorTranslatorTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using Amazon.Runtime;
 using Amazon.S3;
 using IntegratedS3.Abstractions.Errors;
@@ -116,5 +118,93 @@ public sealed class S3ErrorTranslatorTests
         var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket", "my-object.txt");
 
         Assert.Equal(StorageErrorCode.InvalidTag, error.Code);
+    }
+
+    // --- Transport / service-level failure translation (issue #129) ---
+
+    [Fact]
+    public void ServiceException_With503_MapsTo_ProviderUnavailable()
+    {
+        var ex = new AmazonServiceException("Service Unavailable")
+        {
+            StatusCode = HttpStatusCode.ServiceUnavailable
+        };
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket");
+
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, error.Code);
+        Assert.Equal(503, error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public void ServiceException_WithGeneric500_MapsTo_ProviderUnavailable()
+    {
+        var ex = new AmazonServiceException("Internal Server Error")
+        {
+            StatusCode = HttpStatusCode.InternalServerError
+        };
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket");
+
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, error.Code);
+    }
+
+    [Fact]
+    public void ServiceException_WithNoHttpStatus_MapsTo_ProviderUnavailable()
+    {
+        // StatusCode defaults to 0 when the request never completed against the upstream.
+        var ex = new AmazonServiceException("The endpoint could not be reached.");
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket");
+
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, error.Code);
+        Assert.Equal(503, error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public void TranslateTransport_MapsTo_ProviderUnavailable_AndPreservesMessage()
+    {
+        var ex = new HttpRequestException("Connection reset by peer.");
+
+        var error = S3ErrorTranslator.TranslateTransport(ex, "test-provider", "my-bucket", "my-object.txt");
+
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, error.Code);
+        Assert.Equal(503, error.SuggestedHttpStatusCode);
+        Assert.Equal("my-bucket", error.BucketName);
+        Assert.Equal("my-object.txt", error.ObjectKey);
+        Assert.Contains("Connection reset by peer.", error.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(typeof(HttpRequestException))]
+    [InlineData(typeof(SocketException))]
+    [InlineData(typeof(IOException))]
+    [InlineData(typeof(TaskCanceledException))]
+    public void IsTransportFailure_ReturnsTrue_ForTransportExceptions(Type exceptionType)
+    {
+        var ex = exceptionType == typeof(SocketException)
+            ? new SocketException((int)SocketError.HostNotFound)
+            : (Exception)Activator.CreateInstance(exceptionType)!;
+
+        Assert.True(S3ErrorTranslator.IsTransportFailure(ex, CancellationToken.None));
+    }
+
+    [Fact]
+    public void IsTransportFailure_ReturnsFalse_ForCallerCancellation()
+    {
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var ex = new OperationCanceledException(cts.Token);
+
+        Assert.False(S3ErrorTranslator.IsTransportFailure(ex, cts.Token));
+    }
+
+    [Fact]
+    public void IsTransportFailure_ReturnsTrue_ForTimeoutTaskCanceled_WhenCallerDidNotCancel()
+    {
+        // HttpClient request timeout: a TaskCanceledException with no caller cancellation.
+        var ex = new TaskCanceledException("timeout");
+
+        Assert.True(S3ErrorTranslator.IsTransportFailure(ex, CancellationToken.None));
     }
 }

--- a/src/IntegratedS3/IntegratedS3.Tests/S3StorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3StorageServiceTests.cs
@@ -1,4 +1,6 @@
 using System.Net;
+using System.Net.Http;
+using System.Net.Sockets;
 using System.Text;
 using Amazon.Runtime;
 using Amazon.S3;
@@ -1447,6 +1449,157 @@ public sealed class S3StorageServiceTests
         Assert.Equal(StorageErrorCode.BucketNotFound, result.Error!.Code);
     }
 
+    // --- Transport / transient failure translation (issue #129) ---
+    // Regression: transport-layer failures (HTTP timeouts, socket resets, DNS/TLS errors, 5xx
+    // without an S3 error body) must be translated into a well-typed, retryable StorageResult
+    // failure instead of escaping the provider as a raw, unclassified exception.
+
+    [Fact]
+    public async Task PutObjectAsync_TranslatesHttpRequestException_ToProviderUnavailable()
+    {
+        var fake = new FakeS3Client
+        {
+            PutObjectException = new HttpRequestException("Connection reset by peer.")
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "b",
+            Key = "k",
+            Content = Stream.Null
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+        Assert.Equal(503, result.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task PutObjectAsync_TranslatesSocketException_ToProviderUnavailable()
+    {
+        var fake = new FakeS3Client
+        {
+            PutObjectException = new SocketException((int)SocketError.HostNotFound)
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "b",
+            Key = "k",
+            Content = Stream.Null
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+    }
+
+    [Fact]
+    public async Task PutObjectAsync_TranslatesRequestTimeout_ToProviderUnavailable()
+    {
+        // An HttpClient request timeout surfaces as a TaskCanceledException whose token the caller
+        // never cancelled. It must NOT be treated as caller cancellation.
+        var fake = new FakeS3Client
+        {
+            PutObjectException = new TaskCanceledException("The request was canceled due to the configured HttpClient.Timeout.")
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "b",
+            Key = "k",
+            Content = Stream.Null
+        });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+    }
+
+    [Fact]
+    public async Task GetObjectAsync_TranslatesServiceExceptionWithoutStatus_ToProviderUnavailable()
+    {
+        // A bare AmazonServiceException (no S3 error body, no HTTP status) models a transport-level
+        // failure surfaced by the AWS SDK — e.g. the request never reached the upstream.
+        var fake = new FakeS3Client
+        {
+            GetObjectException = new AmazonServiceException("Unable to reach the endpoint.")
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.GetObjectAsync(new GetObjectRequest { BucketName = "b", Key = "k" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+    }
+
+    [Fact]
+    public async Task GetObjectAsync_TranslatesService503_ToProviderUnavailable()
+    {
+        var fake = new FakeS3Client
+        {
+            GetObjectException = new AmazonServiceException("Service Unavailable")
+            {
+                StatusCode = HttpStatusCode.ServiceUnavailable
+            }
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.GetObjectAsync(new GetObjectRequest { BucketName = "b", Key = "k" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+        Assert.Equal(503, result.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task GetObjectAsync_TranslatesHttpRequestException_ToProviderUnavailable()
+    {
+        var fake = new FakeS3Client
+        {
+            GetObjectException = new HttpRequestException("Name or service not known.")
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.GetObjectAsync(new GetObjectRequest { BucketName = "b", Key = "k" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+    }
+
+    [Fact]
+    public async Task GetObjectAsync_RethrowsCallerCancellation_NotTranslatedAsProviderFault()
+    {
+        // Caller-initiated cancellation must propagate as OperationCanceledException, not be
+        // reclassified into a provider failure.
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+        var fake = new FakeS3Client
+        {
+            GetObjectException = new OperationCanceledException(cts.Token)
+        };
+        var svc = BuildService(fake);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+            await svc.GetObjectAsync(new GetObjectRequest { BucketName = "b", Key = "k" }, cts.Token));
+    }
+
+    [Fact]
+    public async Task CreateBucketAsync_TranslatesHttpRequestException_ToProviderUnavailable()
+    {
+        var fake = new FakeS3Client
+        {
+            CreateBucketException = new HttpRequestException("The SSL connection could not be established.")
+        };
+        var svc = BuildService(fake);
+
+        var result = await svc.CreateBucketAsync(new CreateBucketRequest { BucketName = "b" });
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal(StorageErrorCode.ProviderUnavailable, result.Error!.Code);
+    }
+
     // --- DeleteObjectAsync ---
 
     [Fact]
@@ -2621,7 +2774,7 @@ public sealed class S3StorageServiceTests
 internal sealed class FakeS3Client : IS3StorageClient
 {
     public List<S3BucketEntry> Buckets { get; } = [];
-    public AmazonS3Exception? CreateBucketException { get; set; }
+    public Exception? CreateBucketException { get; set; }
     public bool HeadBucketReturnsNull { get; set; }
     public AmazonS3Exception? DeleteBucketException { get; set; }
 
@@ -2693,7 +2846,7 @@ internal sealed class FakeS3Client : IS3StorageClient
 
     // Get object
     public S3GetObjectResult? GetObjectResult { get; set; }
-    public AmazonS3Exception? GetObjectException { get; set; }
+    public Exception? GetObjectException { get; set; }
     public BucketTaggingConfiguration? BucketTaggingResult { get; set; }
     public bool DeleteBucketTaggingCalled { get; private set; }
     public PutBucketTaggingRequest? LastPutBucketTaggingRequest { get; private set; }
@@ -2714,7 +2867,7 @@ internal sealed class FakeS3Client : IS3StorageClient
 
     // Put object
     public S3ObjectEntry? PutObjectResult { get; set; }
-    public AmazonS3Exception? PutObjectException { get; set; }
+    public Exception? PutObjectException { get; set; }
     public PutObjectRequest? LastPutObjectRequest { get; private set; }
     public ObjectServerSideEncryptionSettings? LastPutObjectServerSideEncryption { get; private set; }
     public ObjectCustomerEncryptionSettings? LastPutObjectCustomerEncryption { get; private set; }


### PR DESCRIPTION
## Summary

The S3 passthrough provider (`S3StorageService`) only caught `AmazonS3Exception`, routing it through `S3ErrorTranslator`. Transport- and service-level failures against the upstream S3 — HTTP timeouts, socket resets, connection refused, DNS/TLS errors, and 5xx responses without an S3 error body — surface from the AWS SDK as `AmazonServiceException` / `HttpRequestException` / `TaskCanceledException` / `SocketException` / `IOException`, none of which derive from `AmazonS3Exception`. These bypassed the try/catch, were re-thrown unchanged by every wrapping layer, and reached the ASP.NET pipeline as raw, unclassified exceptions instead of a well-typed, retryable `StorageResult.Failure`.

## Changes

- **`S3ErrorTranslator.Translate`** now accepts the base `AmazonServiceException` (still binds `AmazonS3Exception`) and maps bare 5xx / status-less service faults to `StorageErrorCode.ProviderUnavailable`. Added `MapSuggestedStatus` so a transient failure with no upstream HTTP status still yields a sensible retryable status (429/503).
- **`S3ErrorTranslator.TranslateTransport`** + **`IsTransportFailure`**: classify raw transport exceptions (`HttpRequestException`, `SocketException`, `IOException`, request-timeout `TaskCanceledException`) as `ProviderUnavailable`, preserving the inner exception's message. **Caller-initiated cancellation is re-thrown, not reclassified** as a provider fault.
- **`S3StorageService`**: every unfiltered `catch (AmazonS3Exception ex)` broadened to `catch (AmazonServiceException ex)`, with a `catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))` transport clause added after each — covering all operations, including the copy/multipart paths and the `IAsyncEnumerable` list paths (which wrap into `InvalidOperationException`). The three S3-specific filtered catches (304 not-modified, `NoSuchUpload`, default-encryption not-found) are preserved.

## Tests

- `S3StorageServiceTests`: mocked backend throwing `HttpRequestException` / `TaskCanceledException` (timeout) / `SocketException` / bare `AmazonServiceException` / 503 → surfaces as a translated `ProviderUnavailable` `StorageResult.Failure` (not a raw leak). Caller cancellation still propagates as `OperationCanceledException`.
- `S3ErrorTranslatorTests`: direct coverage of `Translate` service-fault mapping, `TranslateTransport`, and `IsTransportFailure`.
- Full suite green: **1114 passed, 0 failed**.

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)