### PR TITLE
fix: track replica-repair dispatch and drain on shutdown (#142)

### DIFF
--- a/docs/host-maintenance-jobs.md
+++ b/docs/host-maintenance-jobs.md
@@ -59,6 +59,7 @@ The well-known names in `IntegratedS3MaintenanceJobNames` map to the Track F mai
 - `MirrorReplay`
   - build around `IStorageReplicaRepairBacklog`, provider descriptors, and any host-specific replay/remediation logic
   - the current backlog records divergence visibility, but it does **not** yet persist enough operation-specific intent to deliver a completely generic durable replay engine after process restarts
+  - the default in-process dispatcher tracks its dispatched repair tasks and ties them to the dispatcher lifetime: on graceful shutdown it cancels in-flight repairs, drains them with a bounded timeout, and reverts any interrupted entry from `InProgress` back to `Pending` (via `IStorageReplicaRepairBacklog.RevertToPendingAsync`) so it stays re-runnable. A durable backlog implementation should mirror this by reconciling any `InProgress` rows left over from a hard crash (no clean shutdown) back to `Pending`/`Failed` on boot, since those rows have no live task owner.
 - `OrphanDetection`
   - compare `IStorageCatalogStore` snapshots with one or more `IStorageBackend` listings and emit findings or cleanup actions through host-owned policy
 - `ChecksumVerification`

--- a/src/IntegratedS3/IntegratedS3.Core/IntegratedS3.Core.csproj
+++ b/src/IntegratedS3/IntegratedS3.Core/IntegratedS3.Core.csproj
@@ -13,5 +13,6 @@
 
   <ItemGroup>
     <InternalsVisibleTo Include="IntegratedS3.AspNetCore" />
+    <InternalsVisibleTo Include="IntegratedS3.Tests" />
   </ItemGroup>
 </Project>

--- a/src/IntegratedS3/IntegratedS3.Core/Services/IStorageReplicaRepairBacklog.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/IStorageReplicaRepairBacklog.cs
@@ -51,4 +51,13 @@ public interface IStorageReplicaRepairBacklog
     /// <param name="error">The <see cref="StorageError"/> describing the failure.</param>
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     ValueTask MarkFailedAsync(string repairId, StorageError error, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Reverts the specified repair entry to <see cref="StorageReplicaRepairStatus.Pending"/> so it becomes
+    /// re-runnable. Used when an in-progress repair is interrupted (for example by host shutdown) and must not
+    /// be stranded in <see cref="StorageReplicaRepairStatus.InProgress"/> with no live task owning it.
+    /// </summary>
+    /// <param name="repairId">The unique identifier of the repair entry.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    ValueTask RevertToPendingAsync(string repairId, CancellationToken cancellationToken = default);
 }

--- a/src/IntegratedS3/IntegratedS3.Core/Services/InMemoryStorageReplicaRepairBacklog.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/InMemoryStorageReplicaRepairBacklog.cs
@@ -141,6 +141,29 @@ internal sealed class InMemoryStorageReplicaRepairBacklog : IStorageReplicaRepai
         return ValueTask.CompletedTask;
     }
 
+    public ValueTask RevertToPendingAsync(string repairId, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(repairId);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        UpdateEntry(repairId, existing => existing with
+        {
+            Status = StorageReplicaRepairStatus.Pending,
+            LastErrorCode = null,
+            LastErrorMessage = null,
+            UpdatedAtUtc = _timeProvider.GetUtcNow()
+        });
+        if (_entries.TryGetValue(repairId, out var entry)) {
+            _logger.LogInformation(
+                "Replica repair {RepairId} for {ReplicaBackend} reverted to Pending after interruption. AttemptCount {AttemptCount}.",
+                repairId,
+                entry.ReplicaBackendName,
+                entry.AttemptCount);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
     private IEnumerable<Measurement<long>> ObserveBacklogSize()
     {
         return _entries.Values

--- a/src/IntegratedS3/IntegratedS3.Core/Services/InProcessStorageReplicaRepairDispatcher.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/InProcessStorageReplicaRepairDispatcher.cs
@@ -9,17 +9,50 @@ using Microsoft.Extensions.Options;
 
 namespace IntegratedS3.Core.Services;
 
-internal sealed class InProcessStorageReplicaRepairDispatcher(
-    IStorageReplicaRepairBacklog repairBacklog,
-    IOptions<IntegratedS3CoreOptions> options,
-    ILogger<InProcessStorageReplicaRepairDispatcher> logger) : IStorageReplicaRepairDispatcher
+internal sealed class InProcessStorageReplicaRepairDispatcher : IStorageReplicaRepairDispatcher, IAsyncDisposable
 {
+    /// <summary>Maximum time <see cref="DisposeAsync"/> waits for in-flight repairs to drain before giving up.</summary>
+    internal static readonly TimeSpan DefaultDrainTimeout = TimeSpan.FromSeconds(10);
+
     private static readonly Histogram<double> ReplicaRepairDuration = IntegratedS3Observability.Meter.CreateHistogram<double>(
         IntegratedS3Observability.Metrics.ReplicaRepairDuration,
         unit: "ms",
         description: "Duration of in-process replica repair executions.");
 
+    private readonly IStorageReplicaRepairBacklog _repairBacklog;
+    private readonly IOptions<IntegratedS3CoreOptions> _options;
+    private readonly ILogger<InProcessStorageReplicaRepairDispatcher> _logger;
+
     private readonly ConcurrentDictionary<string, SemaphoreSlim> _dispatchLocks = new(StringComparer.Ordinal);
+
+    // Tracks outstanding dispatch tasks so shutdown can drain them instead of abandoning in-flight repairs.
+    private readonly ConcurrentDictionary<Task, byte> _outstandingDispatches = new();
+
+    // Signalled on shutdown/dispose; linked into every dispatched repair so they observe application-stopping.
+    private readonly CancellationTokenSource _shutdownCts = new();
+
+    private readonly TimeSpan _drainTimeout;
+    private int _disposed;
+
+    public InProcessStorageReplicaRepairDispatcher(
+        IStorageReplicaRepairBacklog repairBacklog,
+        IOptions<IntegratedS3CoreOptions> options,
+        ILogger<InProcessStorageReplicaRepairDispatcher> logger)
+        : this(repairBacklog, options, logger, DefaultDrainTimeout)
+    {
+    }
+
+    internal InProcessStorageReplicaRepairDispatcher(
+        IStorageReplicaRepairBacklog repairBacklog,
+        IOptions<IntegratedS3CoreOptions> options,
+        ILogger<InProcessStorageReplicaRepairDispatcher> logger,
+        TimeSpan drainTimeout)
+    {
+        _repairBacklog = repairBacklog;
+        _options = options;
+        _logger = logger;
+        _drainTimeout = drainTimeout;
+    }
 
     public async ValueTask DispatchAsync(
         StorageReplicaRepairEntry entry,
@@ -29,8 +62,8 @@ internal sealed class InProcessStorageReplicaRepairDispatcher(
         ArgumentNullException.ThrowIfNull(entry);
         ArgumentNullException.ThrowIfNull(repairOperation);
 
-        await repairBacklog.AddAsync(entry, cancellationToken);
-        logger.LogInformation(
+        await _repairBacklog.AddAsync(entry, cancellationToken);
+        _logger.LogInformation(
             "Dispatching replica repair {RepairId} for {ReplicaBackend}. Origin {Origin}.",
             entry.Id,
             entry.ReplicaBackendName,
@@ -42,12 +75,31 @@ internal sealed class InProcessStorageReplicaRepairDispatcher(
             entry.ReplicaBackendName,
             entry.Origin,
             entry.Status);
-        if (!options.Value.Replication.AttemptInProcessAsyncReplicaWrites) {
+        if (!_options.Value.Replication.AttemptInProcessAsyncReplicaWrites) {
+            return;
+        }
+
+        // If the dispatcher is already shutting down, do not start new background work; the entry stays
+        // Pending in the backlog so a replay job (or the next boot) can pick it up.
+        if (_shutdownCts.IsCancellationRequested) {
+            _logger.LogInformation(
+                "Skipping in-process dispatch for replica repair {RepairId} because the dispatcher is shutting down. Entry left Pending.",
+                entry.Id);
             return;
         }
 
         var dispatchLock = _dispatchLocks.GetOrAdd(entry.ReplicaBackendName, static _ => new SemaphoreSlim(1, 1));
-        _ = Task.Run(() => RunDispatchAsync(entry, dispatchLock, repairOperation));
+
+        // Track the dispatched task so DisposeAsync can await it on shutdown, then prune it from the
+        // tracking set once it finishes so the set does not grow unbounded over the process lifetime.
+        var dispatch = Task.Run(() => RunDispatchAsync(entry, dispatchLock, repairOperation), CancellationToken.None);
+        _outstandingDispatches.TryAdd(dispatch, 0);
+        _ = dispatch.ContinueWith(
+            static (completed, state) => ((ConcurrentDictionary<Task, byte>)state!).TryRemove(completed, out _),
+            _outstandingDispatches,
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default);
     }
 
     private async Task RunDispatchAsync(
@@ -55,18 +107,36 @@ internal sealed class InProcessStorageReplicaRepairDispatcher(
         SemaphoreSlim dispatchLock,
         Func<CancellationToken, ValueTask<StorageError?>> repairOperation)
     {
+        var repairToken = _shutdownCts.Token;
         using var activity = StartRepairActivity(entry);
         var startedAt = Stopwatch.GetTimestamp();
         StorageError? observedError = null;
         var succeeded = false;
 
-        await dispatchLock.WaitAsync(CancellationToken.None);
         try {
             try {
-                await repairBacklog.MarkInProgressAsync(entry.Id, CancellationToken.None);
+                await dispatchLock.WaitAsync(repairToken);
+            }
+            catch (OperationCanceledException) {
+                // Shutdown observed before we ever marked the entry in-progress; it is still Pending, nothing to revert.
+                _logger.LogInformation(
+                    "Replica repair {RepairId} for {ReplicaBackend} was not started because the dispatcher is shutting down. Entry left Pending.",
+                    entry.Id,
+                    entry.ReplicaBackendName);
+                return;
+            }
+
+            try {
+                await _repairBacklog.MarkInProgressAsync(entry.Id, CancellationToken.None);
 
                 try {
-                    observedError = await repairOperation(CancellationToken.None);
+                    observedError = await repairOperation(repairToken);
+                }
+                catch (OperationCanceledException) when (repairToken.IsCancellationRequested) {
+                    // Interrupted by shutdown after being marked in-progress: revert to a re-runnable state so the
+                    // entry is never stranded InProgress with no live owner.
+                    await RevertInterruptedAsync(entry);
+                    return;
                 }
                 catch (Exception ex) {
                     observedError = CreateDispatchError(entry, ex);
@@ -74,9 +144,9 @@ internal sealed class InProcessStorageReplicaRepairDispatcher(
 
                 if (observedError is null) {
                     succeeded = true;
-                    await repairBacklog.MarkCompletedAsync(entry.Id, CancellationToken.None);
+                    await _repairBacklog.MarkCompletedAsync(entry.Id, CancellationToken.None);
                     activity?.SetTag(IntegratedS3Observability.Tags.Result, "success");
-                    logger.LogInformation(
+                    _logger.LogInformation(
                         "Replica repair {RepairId} completed successfully for {ReplicaBackend}.",
                         entry.Id,
                         entry.ReplicaBackendName);
@@ -84,27 +154,30 @@ internal sealed class InProcessStorageReplicaRepairDispatcher(
                 }
 
                 IntegratedS3CoreTelemetry.MarkFailure(activity, observedError);
-                await repairBacklog.MarkFailedAsync(entry.Id, observedError, CancellationToken.None);
-                logger.LogWarning(
+                await _repairBacklog.MarkFailedAsync(entry.Id, observedError, CancellationToken.None);
+                _logger.LogWarning(
                     "Replica repair {RepairId} failed for {ReplicaBackend}. ErrorCode {ErrorCode}.",
                     entry.Id,
                     entry.ReplicaBackendName,
                     observedError.Code);
             }
+            catch (OperationCanceledException) when (repairToken.IsCancellationRequested) {
+                await RevertInterruptedAsync(entry);
+            }
             catch (Exception ex) {
                 observedError ??= CreateDispatchError(entry, ex);
                 IntegratedS3CoreTelemetry.MarkFailure(activity, observedError);
-                logger.LogError(
+                _logger.LogError(
                     ex,
                     "In-process replica repair dispatch for repair {RepairId} targeting provider {ReplicaBackend} failed unexpectedly.",
                     entry.Id,
                     entry.ReplicaBackendName);
 
                 try {
-                    await repairBacklog.MarkFailedAsync(entry.Id, observedError, CancellationToken.None);
+                    await _repairBacklog.MarkFailedAsync(entry.Id, observedError, CancellationToken.None);
                 }
                 catch (Exception backlogException) {
-                    logger.LogError(
+                    _logger.LogError(
                         backlogException,
                         "Failed to mark replica repair {RepairId} as failed after an unexpected dispatch exception.",
                         entry.Id);
@@ -115,6 +188,73 @@ internal sealed class InProcessStorageReplicaRepairDispatcher(
             RecordRepairDuration(entry, succeeded, observedError, Stopwatch.GetElapsedTime(startedAt));
             dispatchLock.Release();
         }
+    }
+
+    /// <summary>
+    /// Reverts an in-progress repair that was interrupted by shutdown back to <see cref="StorageReplicaRepairStatus.Pending"/>
+    /// so it is never stranded in <see cref="StorageReplicaRepairStatus.InProgress"/> with no live task owning it.
+    /// </summary>
+    private async Task RevertInterruptedAsync(StorageReplicaRepairEntry entry)
+    {
+        _logger.LogInformation(
+            "Replica repair {RepairId} for {ReplicaBackend} was interrupted by shutdown; reverting to Pending so it can be retried.",
+            entry.Id,
+            entry.ReplicaBackendName);
+
+        try {
+            await _repairBacklog.RevertToPendingAsync(entry.Id, CancellationToken.None);
+        }
+        catch (Exception ex) {
+            _logger.LogError(
+                ex,
+                "Failed to revert interrupted replica repair {RepairId} to Pending during shutdown.",
+                entry.Id);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (Interlocked.Exchange(ref _disposed, 1) != 0) {
+            return;
+        }
+
+        // Signal every in-flight repair to observe application-stopping.
+        await _shutdownCts.CancelAsync();
+
+        var outstanding = _outstandingDispatches.Keys.ToArray();
+        if (outstanding.Length > 0) {
+            _logger.LogInformation(
+                "Draining {OutstandingCount} in-flight replica repair dispatch task(s) during shutdown.",
+                outstanding.Length);
+
+            try {
+                var drain = Task.WhenAll(outstanding);
+                var completed = await Task.WhenAny(drain, Task.Delay(_drainTimeout)).ConfigureAwait(false);
+                if (completed != drain) {
+                    _logger.LogWarning(
+                        "Timed out after {DrainTimeout} draining in-flight replica repair dispatch tasks during shutdown; " +
+                        "any still-running entries may remain InProgress until reconciled.",
+                        _drainTimeout);
+                }
+                else {
+                    // Observe faulted tasks without rethrowing (each task already handles its own errors).
+                    await drain.ConfigureAwait(false);
+                }
+            }
+            catch (Exception ex) {
+                _logger.LogWarning(
+                    ex,
+                    "One or more replica repair dispatch tasks faulted while draining during shutdown.");
+            }
+        }
+
+        foreach (var dispatchLock in _dispatchLocks.Values) {
+            dispatchLock.Dispose();
+        }
+
+        _dispatchLocks.Clear();
+        _outstandingDispatches.Clear();
+        _shutdownCts.Dispose();
     }
 
     private static Activity? StartRepairActivity(StorageReplicaRepairEntry entry)

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -10641,6 +10641,23 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
             return ValueTask.CompletedTask;
         }
+
+        public ValueTask RevertToPendingAsync(string repairId, CancellationToken cancellationToken = default)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(repairId);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (_entries.TryGetValue(repairId, out var entry)) {
+                _entries[repairId] = entry with
+                {
+                    Status = StorageReplicaRepairStatus.Pending,
+                    LastErrorCode = null,
+                    LastErrorMessage = null
+                };
+            }
+
+            return ValueTask.CompletedTask;
+        }
     }
 
     private static void ConfigureTestHeaderRoutePolicies(IServiceCollection services, params (string PolicyName, string RequiredScope)[] policies)

--- a/src/IntegratedS3/IntegratedS3.Tests/ReplicaRepairDispatcherShutdownTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/ReplicaRepairDispatcherShutdownTests.cs
@@ -1,0 +1,152 @@
+using IntegratedS3.Abstractions.Errors;
+using IntegratedS3.Core.Models;
+using IntegratedS3.Core.Options;
+using IntegratedS3.Core.Services;
+using IntegratedS3.Tests.Infrastructure;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression tests for issue #142: the in-process replica-repair dispatcher must track its
+/// dispatched tasks, tie them to the dispatcher/host lifetime, and never strand a backlog entry in
+/// <see cref="StorageReplicaRepairStatus.InProgress"/> when a repair is interrupted by shutdown.
+/// </summary>
+[Collection(ObservabilityTestCollection.Name)]
+public sealed class ReplicaRepairDispatcherShutdownTests
+{
+    private static StorageReplicaRepairEntry CreateEntry(string id = "repair-1") => new()
+    {
+        Id = id,
+        Origin = StorageReplicaRepairOrigin.AsyncReplication,
+        Status = StorageReplicaRepairStatus.Pending,
+        Operation = StorageOperationType.PutObject,
+        PrimaryBackendName = "primary",
+        ReplicaBackendName = "replica",
+        BucketName = "bucket",
+        ObjectKey = "key",
+        CreatedAtUtc = DateTimeOffset.UnixEpoch,
+        UpdatedAtUtc = DateTimeOffset.UnixEpoch
+    };
+
+    private static InMemoryStorageReplicaRepairBacklog CreateBacklog()
+        => new(TimeProvider.System, NullLogger<InMemoryStorageReplicaRepairBacklog>.Instance);
+
+    private static InProcessStorageReplicaRepairDispatcher CreateDispatcher(
+        IStorageReplicaRepairBacklog backlog,
+        TimeSpan? drainTimeout = null)
+        => new(
+            backlog,
+            Options.Create(new IntegratedS3CoreOptions()),
+            NullLogger<InProcessStorageReplicaRepairDispatcher>.Instance,
+            drainTimeout ?? TimeSpan.FromSeconds(10));
+
+    [Fact]
+    public async Task RepairInterruptedByShutdown_RevertsBacklogEntryToPending_NotStrandedInProgress()
+    {
+        var backlog = CreateBacklog();
+        await using var dispatcher = CreateDispatcher(backlog);
+        var entry = CreateEntry();
+
+        var repairStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        // The repair blocks until the dispatcher-supplied token (host application-stopping) is cancelled.
+        await dispatcher.DispatchAsync(entry, async ct =>
+        {
+            repairStarted.TrySetResult();
+            await Task.Delay(Timeout.Infinite, ct);
+            return null; // unreachable: the delay throws on cancellation.
+        });
+
+        // Ensure the repair actually began and the entry was marked InProgress before we shut down.
+        await repairStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await WaitForStatusAsync(backlog, entry.Id, StorageReplicaRepairStatus.InProgress);
+
+        // Shutdown: cancels the linked token and drains the in-flight repair.
+        await dispatcher.DisposeAsync();
+
+        var outstanding = await backlog.ListOutstandingAsync();
+        var reverted = Assert.Single(outstanding);
+        Assert.Equal(entry.Id, reverted.Id);
+        Assert.Equal(StorageReplicaRepairStatus.Pending, reverted.Status);
+        Assert.NotEqual(StorageReplicaRepairStatus.InProgress, reverted.Status);
+    }
+
+    [Fact]
+    public async Task DispatchedTasks_AreTrackedAndAwaitedOnShutdown()
+    {
+        var backlog = CreateBacklog();
+        await using var dispatcher = CreateDispatcher(backlog);
+        var entry = CreateEntry();
+
+        var repairStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var observedCancellation = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await dispatcher.DispatchAsync(entry, async ct =>
+        {
+            repairStarted.TrySetResult();
+            try {
+                await Task.Delay(Timeout.Infinite, ct);
+            }
+            catch (OperationCanceledException) {
+                observedCancellation.TrySetResult();
+                throw;
+            }
+
+            return null;
+        });
+
+        await repairStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // DisposeAsync must not return until the tracked, in-flight dispatch has drained.
+        await dispatcher.DisposeAsync();
+
+        // If DisposeAsync had returned without draining, this would still be incomplete.
+        Assert.True(observedCancellation.Task.IsCompletedSuccessfully);
+    }
+
+    [Fact]
+    public async Task SuccessfulRepair_MarksEntryCompleted()
+    {
+        var backlog = CreateBacklog();
+        await using var dispatcher = CreateDispatcher(backlog);
+        var entry = CreateEntry();
+
+        var completed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await dispatcher.DispatchAsync(entry, _ =>
+        {
+            completed.TrySetResult();
+            return ValueTask.FromResult<StorageError?>(null);
+        });
+
+        await completed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Draining also guarantees the task finished before we assert.
+        await dispatcher.DisposeAsync();
+
+        var outstanding = await backlog.ListOutstandingAsync();
+        Assert.Empty(outstanding); // Completed entries are removed from the in-memory backlog.
+    }
+
+    private static async Task WaitForStatusAsync(
+        IStorageReplicaRepairBacklog backlog,
+        string repairId,
+        StorageReplicaRepairStatus expected)
+    {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (DateTime.UtcNow < deadline) {
+            var outstanding = await backlog.ListOutstandingAsync();
+            var entry = outstanding.FirstOrDefault(e => e.Id == repairId);
+            if (entry is not null && entry.Status == expected) {
+                return;
+            }
+
+            await Task.Delay(10);
+        }
+
+        Assert.Fail($"Repair {repairId} did not reach status {expected} within the timeout.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #142. The default in-process replica-repair dispatcher
(`InProcessStorageReplicaRepairDispatcher`) launched the actual replica write on a discarded
`Task.Run(...)` and threaded `CancellationToken.None` into every downstream backlog/repair call.
On graceful shutdown, in-flight repairs were abandoned mid-flight and their backlog entries could
be stranded in `InProgress` with no path back to a re-runnable state.

## Changes

- **Tracked, lifetime-bound dispatch.** `InProcessStorageReplicaRepairDispatcher` now implements
  `IAsyncDisposable`, tracks every dispatched `Task`, owns a shutdown `CancellationTokenSource`, and
  threads that token into each repair (replacing `CancellationToken.None` on the repair operation and
  the dispatch-lock wait). Completed tasks prune themselves from the tracking set.
- **Shutdown drain.** `DisposeAsync` cancels the shutdown token, drains outstanding dispatch tasks
  with a bounded timeout (default 10s), disposes the per-backend `SemaphoreSlim` instances, and clears
  state. Because the dispatcher is a container-owned singleton, host/container disposal on shutdown
  drives the drain — no extra `Microsoft.Extensions.Hosting` dependency added to Core.
- **No more stranded `InProgress`.** When a repair is interrupted by shutdown after being marked
  in-progress, it is reverted to `Pending` (new `IStorageReplicaRepairBacklog.RevertToPendingAsync`)
  so it stays re-runnable. If shutdown is observed before the entry is marked in-progress, it is simply
  left `Pending`, and no new work is started once shutdown has begun.
- **Docs.** `docs/host-maintenance-jobs.md` now describes the drain/revert behavior and the
  reconciliation expectation for durable backlog implementations after a hard crash.

## Tests

New `ReplicaRepairDispatcherShutdownTests` (isolated, real dispatcher + real in-memory backlog):
1. A repair interrupted mid-flight by shutdown reverts to `Pending` (not stuck `InProgress`).
2. Dispatched tasks are tracked and awaited on shutdown (drain waits for the in-flight repair).
3. Happy path still marks the entry `Completed`.

Tests 1 and 2 were verified to **fail before** the fix (entry left `InProgress`; drain does not observe
cancellation) and **pass after**. Full suite: **1099 passed, 0 failed**.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)