### PR TITLE
Enforce S3 minimum part size (EntityTooSmall) on disk CompleteMultipartUpload

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -28,6 +28,14 @@ internal sealed class DiskStorageService(
     private const string MultipartUploadsDirectoryName = ".integrateds3-multipart";
     private const string MultipartStateFileName = "upload.json";
     private const int MaxMultipartPartNumber = 10000;
+
+    /// <summary>
+    /// The minimum size, in bytes, that every multipart part except the last must meet.
+    /// AWS S3 rejects a CompleteMultipartUpload with <c>EntityTooSmall</c> when any non-final
+    /// part is smaller than 5 MiB (5 * 1024 * 1024 = 5,242,880 bytes).
+    /// </summary>
+    private const long MinimumMultipartPartSizeBytes = 5L * 1024 * 1024;
+
     private const string Md5ChecksumAlgorithm = "md5";
     private const string Sha256ChecksumAlgorithm = "sha256";
     private const string Sha1ChecksumAlgorithm = "sha1";
@@ -2927,14 +2935,31 @@ internal sealed class DiskStorageService(
         }
 
         try {
+            // The last element of request.Parts is the highest-numbered part because the list has
+            // already been validated to be in strictly ascending part-number order above.
+            var lastPartIndex = request.Parts.Count - 1;
             await using (var destinationStream = new FileStream(tempObjectPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
-                foreach (var requestedPart in request.Parts) {
+                for (var partIndex = 0; partIndex < request.Parts.Count; partIndex++) {
+                    var requestedPart = request.Parts[partIndex];
                     var partPath = GetMultipartPartPath(uploadState.UploadDirectoryPath, requestedPart.PartNumber);
                     if (!File.Exists(partPath)) {
                         return StorageResult<ObjectInfo>.Failure(InvalidPart(
                             $"One or more of the specified parts could not be found. Part '{requestedPart.PartNumber}' was not uploaded for upload '{request.UploadId}'.",
                             request.BucketName,
                             request.Key));
+                    }
+
+                    // Enforce the S3 minimum part size: every part except the last must be at least
+                    // 5 MiB. AWS rejects such completions with EntityTooSmall (HTTP 400). Mirror the
+                    // S3 backend, which surfaces the upstream EntityTooSmall as MultipartConflict.
+                    if (partIndex != lastPartIndex) {
+                        var partSizeBytes = new FileInfo(partPath).Length;
+                        if (partSizeBytes < MinimumMultipartPartSizeBytes) {
+                            return StorageResult<ObjectInfo>.Failure(MultipartInvalidRequest(
+                                $"Your proposed upload is smaller than the minimum allowed size. Part '{requestedPart.PartNumber}' is {partSizeBytes} bytes, but every part except the last must be at least {MinimumMultipartPartSizeBytes} bytes.",
+                                request.BucketName,
+                                request.Key));
+                        }
                     }
 
                     var actualETag = BuildETag(new FileInfo(partPath));

--- a/src/IntegratedS3/IntegratedS3.Testing/StorageProviderContractTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Testing/StorageProviderContractTests.cs
@@ -1487,13 +1487,15 @@ public abstract class StorageProviderContractTests
         Assert.Equal(initiatedUpload.UploadId, listedUpload.UploadId);
         Assert.Equal("docs/assembled.txt", listedUpload.Key);
 
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         var part1 = RequireSuccess(await storage.UploadMultipartPartAsync(new UploadMultipartPartRequest
         {
             BucketName = "contract-multipart",
             Key = "docs/assembled.txt",
             UploadId = initiatedUpload.UploadId,
             PartNumber = 1,
-            Content = CreateUtf8Stream("hello ")
+            Content = CreateUtf8Stream(part1Payload)
         }));
 
         var part2 = RequireSuccess(await storage.UploadMultipartPartAsync(new UploadMultipartPartRequest
@@ -1524,7 +1526,7 @@ public abstract class StorageProviderContractTests
             Key = "docs/assembled.txt"
         }));
         await using (assembledObject) {
-            Assert.Equal("hello world", await ReadUtf8Async(assembledObject));
+            Assert.Equal(part1Payload + "world", await ReadUtf8Async(assembledObject));
             if (Supports(capabilities.ObjectMetadata)) {
                 Assert.Equal("multipart", assembledObject.Object.Metadata!["source"]);
             }
@@ -1761,13 +1763,15 @@ public abstract class StorageProviderContractTests
         var listedUpload = Assert.Single(uploads);
         Assert.Equal(initiatedUpload.UploadId, listedUpload.UploadId);
 
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         var part1 = RequireSuccess(await storage.UploadMultipartPartAsync(new UploadMultipartPartRequest
         {
             BucketName = "contract-platform-multipart",
             Key = "docs/assembled.txt",
             UploadId = initiatedUpload.UploadId,
             PartNumber = 1,
-            Content = CreateUtf8Stream("hello ")
+            Content = CreateUtf8Stream(part1Payload)
         }));
 
         var part2 = RequireSuccess(await storage.UploadMultipartPartAsync(new UploadMultipartPartRequest

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -1940,9 +1940,10 @@ public sealed class DiskStorageServiceTests
 
         const string sourceKey = "docs/source.txt";
         const string destinationKey = "docs/copied.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
-        const string fullPayload = part1Payload + part2Payload;
+        var fullPayload = part1Payload + part2Payload;
 
         var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
         {
@@ -2783,7 +2784,9 @@ public sealed class DiskStorageServiceTests
 
         Assert.True(initiateResult.IsSuccess);
 
-        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes("hello "));
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
+        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes(part1Payload));
         var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
         {
             BucketName = "multipart",
@@ -2830,10 +2833,137 @@ public sealed class DiskStorageServiceTests
         Assert.True(getResult.IsSuccess);
         await using var response = getResult.Value!;
         using var reader = new StreamReader(response.Content, Encoding.UTF8);
-        Assert.Equal("hello world", await reader.ReadToEndAsync());
+        Assert.Equal(part1Payload + "world", await reader.ReadToEndAsync());
         Assert.Equal("multipart", response.Object.Metadata!["source"]);
         Assert.Equal("multipart", response.Object.Tags!["upload"]);
         Assert.Equal(multipartChecksum, response.Object.Checksums!["sha256"]);
+    }
+
+    [Fact]
+    public async Task DiskStorage_MultipartUpload_RejectsUndersizedNonFinalPartWithEntityTooSmall()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "multipart-small" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "multipart-small",
+            Key = "docs/tiny.bin",
+            ContentType = "application/octet-stream"
+        });
+
+        Assert.True(initiateResult.IsSuccess);
+
+        // Part 1 is a non-final part smaller than the S3 minimum of 5 MiB.
+        await using var part1Stream = new MemoryStream(new byte[1024]);
+        var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "multipart-small",
+            Key = "docs/tiny.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 1,
+            Content = part1Stream
+        });
+
+        await using var part2Stream = new MemoryStream(new byte[1024]);
+        var part2 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "multipart-small",
+            Key = "docs/tiny.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 2,
+            Content = part2Stream
+        });
+
+        Assert.True(part1.IsSuccess);
+        Assert.True(part2.IsSuccess);
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "multipart-small",
+            Key = "docs/tiny.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            Parts = [part1.Value!, part2.Value!]
+        });
+
+        Assert.False(completeResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.MultipartConflict, completeResult.Error!.Code);
+        Assert.Equal(400, completeResult.Error.SuggestedHttpStatusCode);
+        Assert.Contains("minimum", completeResult.Error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("'1'", completeResult.Error.Message, StringComparison.Ordinal);
+
+        // The object must not have been created.
+        var headResult = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = "multipart-small",
+            Key = "docs/tiny.bin"
+        });
+
+        Assert.False(headResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.ObjectNotFound, headResult.Error!.Code);
+    }
+
+    [Fact]
+    public async Task DiskStorage_MultipartUpload_AllowsSmallFinalPartWhenEarlierPartsMeetMinimum()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "multipart-lastsmall" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "multipart-lastsmall",
+            Key = "docs/assembled.bin",
+            ContentType = "application/octet-stream"
+        });
+
+        Assert.True(initiateResult.IsSuccess);
+
+        // Part 1 exactly meets the 5 MiB minimum; part 2 (the last part) is deliberately tiny.
+        var firstPartBytes = new byte[5 * 1024 * 1024];
+        await using var part1Stream = new MemoryStream(firstPartBytes);
+        var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "multipart-lastsmall",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 1,
+            Content = part1Stream
+        });
+
+        await using var part2Stream = new MemoryStream(new byte[16]);
+        var part2 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "multipart-lastsmall",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 2,
+            Content = part2Stream
+        });
+
+        Assert.True(part1.IsSuccess);
+        Assert.True(part2.IsSuccess);
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "multipart-lastsmall",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            Parts = [part1.Value!, part2.Value!]
+        });
+
+        Assert.True(completeResult.IsSuccess);
+
+        var getResult = await storageService.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = "multipart-lastsmall",
+            Key = "docs/assembled.bin"
+        });
+
+        Assert.True(getResult.IsSuccess);
+        await using var response = getResult.Value!;
+        Assert.Equal((5 * 1024 * 1024) + 16, response.Object.ContentLength);
     }
 
     [Fact]
@@ -2853,7 +2983,8 @@ public sealed class DiskStorageServiceTests
 
         Assert.True(initiateResult.IsSuccess);
 
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         var part1Checksum = ComputeCrc32cBase64(part1Payload);
         await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes(part1Payload));
         var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
@@ -2913,7 +3044,7 @@ public sealed class DiskStorageServiceTests
         Assert.True(getResult.IsSuccess);
         await using var response = getResult.Value!;
         using var reader = new StreamReader(response.Content, Encoding.UTF8);
-        Assert.Equal("hello world", await reader.ReadToEndAsync());
+        Assert.Equal(part1Payload + "world", await reader.ReadToEndAsync());
         Assert.Equal(compositeChecksum, response.Object.Checksums!["crc32c"]);
     }
 
@@ -4042,7 +4173,9 @@ public sealed class DiskStorageServiceTests
         Assert.Equal(uploadId, listedUpload.UploadId);
         Assert.Equal("docs/assembled.txt", listedUpload.Key);
 
-        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes("hello "));
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
+        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes(part1Payload));
         var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
         {
             BucketName = "multipart-external",
@@ -4884,7 +5017,9 @@ public sealed class DiskStorageServiceTests
         });
         Assert.True(initiate.IsSuccess);
 
-        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes("hello "));
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB so that
+        // completion reaches the caller's intended validation (missing part, ETag mismatch, ...).
+        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes(new string('a', 5 * 1024 * 1024)));
         var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
         {
             BucketName = bucketName,

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3AwsSdkCompatibilityTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3AwsSdkCompatibilityTests.cs
@@ -2095,7 +2095,9 @@ public sealed class IntegratedS3AwsSdkCompatibilityTests : IClassFixture<WebUiAp
     {
         const string accessKeyId = "aws-sdk-multipart-access";
         const string secretAccessKey = "aws-sdk-multipart-secret";
-        const string completedPayload = "hello world";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var firstPartPayload = new string('a', 5 * 1024 * 1024);
+        var completedPayload = firstPartPayload + "world";
 
         await using var isolatedClient = await CreateAuthenticatedLoopbackClientAsync(accessKeyId, secretAccessKey);
         using var s3Client = CreateS3Client(isolatedClient.BaseAddress!, accessKeyId, secretAccessKey);
@@ -2117,7 +2119,7 @@ public sealed class IntegratedS3AwsSdkCompatibilityTests : IClassFixture<WebUiAp
         });
         Assert.Equal(HttpStatusCode.OK, initiateResponse.HttpStatusCode);
 
-        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes("hello "));
+        await using var part1Stream = new MemoryStream(Encoding.UTF8.GetBytes(firstPartPayload));
         var part1Response = await s3Client.UploadPartAsync(new UploadPartRequest
         {
             BucketName = bucketName,
@@ -2660,7 +2662,8 @@ public sealed class IntegratedS3AwsSdkCompatibilityTests : IClassFixture<WebUiAp
         const string bucketName = "aws-sdk-multipart-checksum-bucket";
         const string objectKey = "docs/multipart-checksum.txt";
         const string copiedObjectKey = "docs/multipart-checksum-copy.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
 
         Assert.Equal(HttpStatusCode.OK, (await s3Client.PutBucketAsync(new PutBucketRequest
@@ -2889,7 +2892,8 @@ public sealed class IntegratedS3AwsSdkCompatibilityTests : IClassFixture<WebUiAp
         const string bucketName = "aws-sdk-multipart-sha1-bucket";
         const string objectKey = "docs/multipart-sha1.txt";
         const string copiedObjectKey = "docs/multipart-sha1-copy.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
 
         Assert.Equal(HttpStatusCode.OK, (await s3Client.PutBucketAsync(new PutBucketRequest
@@ -3014,7 +3018,8 @@ public sealed class IntegratedS3AwsSdkCompatibilityTests : IClassFixture<WebUiAp
         const string bucketName = "aws-sdk-multipart-crc32c-bucket";
         const string objectKey = "docs/multipart-crc32c.txt";
         const string copiedObjectKey = "docs/multipart-crc32c-copy.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
 
         Assert.Equal(HttpStatusCode.OK, (await s3Client.PutBucketAsync(new PutBucketRequest

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ClientTransferTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ClientTransferTests.cs
@@ -207,7 +207,8 @@ public sealed class IntegratedS3ClientTransferTests(WebUiApplicationFactory fact
     {
         const string bucketName = "transfer-uploadpart-bucket";
         const string objectKey = "docs/transfer-uploadpart.bin";
-        const string firstPartPayload = "first transfer part payload|";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var firstPartPayload = new string('a', 5 * 1024 * 1024);
         const string secondPartPayload = "second transfer part payload";
 
         await using var isolatedClient = await _factory.CreateIsolatedClientAsync(ConfigurePresignHost("transfer-uploadpart-access", "transfer-uploadpart-secret"));

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -4484,7 +4484,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         const string secretAccessKey = "first-party-presign-part-secret";
         const string bucketName = "first-party-presign-part-bucket";
         const string objectKey = "docs/client-presigned-multipart.bin";
-        const string firstPartPayload = "first presigned part payload|";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var firstPartPayload = new string('a', 5 * 1024 * 1024);
         const string secondPartPayload = "second presigned part payload";
 
         await using var isolatedClient = await _factory.CreateIsolatedClientAsync(builder => {
@@ -5798,7 +5799,9 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     {
         using var client = await _factory.CreateClientAsync();
         var expiresUtc = new DateTimeOffset(2026, 3, 14, 17, 0, 0, TimeSpan.Zero);
-        const string completedPayload = "hello world";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var firstPartPayload = new string('a', 5 * 1024 * 1024);
+        var completedPayload = firstPartPayload + "world";
         var expectedChecksumSha256 = ComputeSha256Base64(completedPayload);
         var expectedChecksumCrc32c = ChecksumTestAlgorithms.ComputeCrc32cBase64(completedPayload);
 
@@ -5830,7 +5833,7 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         var part1Response = await client.PutAsync(
                 $"/integrated-s3/multipart-bucket/docs/multipart.txt?partNumber=1&uploadId={Uri.EscapeDataString(uploadId)}",
-                new StringContent("hello ", Encoding.UTF8, "text/plain"));
+                new StringContent(firstPartPayload, Encoding.UTF8, "text/plain"));
         Assert.Equal(HttpStatusCode.OK, part1Response.StatusCode);
         var part1ETag = part1Response.Headers.ETag?.Tag ?? throw new Xunit.Sdk.XunitException("Expected multipart part ETag header.");
 
@@ -6829,7 +6832,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         const string bucketName = "multipart-checksum-bucket";
         const string objectKey = "docs/checksum.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
 
         Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
@@ -6917,7 +6921,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         const string bucketName = "multipart-sha1-checksum-bucket";
         const string objectKey = "docs/sha1-checksum.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
 
         Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
@@ -7013,7 +7018,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         const string bucketName = "multipart-crc32c-checksum-bucket";
         const string objectKey = "docs/crc32c-checksum.txt";
-        const string part1Payload = "hello ";
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1Payload = new string('a', 5 * 1024 * 1024);
         const string part2Payload = "world";
 
         Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);

--- a/src/IntegratedS3/IntegratedS3.Tests/RcloneS3MultipartEncodingCompatibilityTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/RcloneS3MultipartEncodingCompatibilityTests.cs
@@ -155,9 +155,10 @@ public sealed class RcloneS3MultipartEncodingCompatibilityTests : IClassFixture<
         Assert.Equal(key, El(initiateDoc, "Key"));
         Assert.False(string.IsNullOrWhiteSpace(uploadId));
 
-        // Upload 3 distinct parts (~1KB each)
-        var part1Data = Repeat(0x41, 1024); // AAA...
-        var part2Data = Repeat(0x42, 1024); // BBB...
+        // Upload 3 distinct parts. Every non-final part must be at least the S3 minimum of 5 MiB;
+        // the last part may be smaller.
+        var part1Data = Repeat(0x41, 5 * 1024 * 1024); // AAA...
+        var part2Data = Repeat(0x42, 5 * 1024 * 1024); // BBB...
         var part3Data = Repeat(0x43, 1024); // CCC...
 
         var etag1 = await UploadPartAsync(client, bucket, key, uploadId, 1, part1Data);
@@ -198,7 +199,8 @@ public sealed class RcloneS3MultipartEncodingCompatibilityTests : IClassFixture<
             ["x-amz-meta-source"] = "rclone"
         });
 
-        var part1 = Repeat(0x61, 512);
+        // The first (non-final) part must be at least the S3 minimum of 5 MiB.
+        var part1 = Repeat(0x61, 5 * 1024 * 1024);
         var part2 = Repeat(0x62, 512);
         var etag1 = await UploadPartAsync(client, bucket, key, uploadId, 1, part1);
         var etag2 = await UploadPartAsync(client, bucket, key, uploadId, 2, part2);
@@ -373,8 +375,9 @@ public sealed class RcloneS3MultipartEncodingCompatibilityTests : IClassFixture<
         await CreateBucketAsync(client, bucket);
 
         var uploadId = await InitiateMultipartAsync(client, bucket, key);
-        var etag1 = await UploadPartAsync(client, bucket, key, uploadId, 1, Repeat(0x10, 512));
-        var etag2 = await UploadPartAsync(client, bucket, key, uploadId, 2, Repeat(0x20, 512));
+        // Every non-final part must be at least the S3 minimum of 5 MiB; the last part may be smaller.
+        var etag1 = await UploadPartAsync(client, bucket, key, uploadId, 1, Repeat(0x10, 5 * 1024 * 1024));
+        var etag2 = await UploadPartAsync(client, bucket, key, uploadId, 2, Repeat(0x20, 5 * 1024 * 1024));
         var etag3 = await UploadPartAsync(client, bucket, key, uploadId, 3, Repeat(0x30, 512));
 
         var completeResp = await CompleteMultipartAsync(client, bucket, key, uploadId,
@@ -678,8 +681,10 @@ public sealed class RcloneS3MultipartEncodingCompatibilityTests : IClassFixture<
         await CreateBucketAsync(client, bucket);
 
         var uploadId = await InitiateMultipartAsync(client, bucket, key);
-        var part1Data = Encoding.UTF8.GetBytes("FIRST");
-        var part2Data = Encoding.UTF8.GetBytes("SECOND");
+        // Parts 1 and 2 are non-final, so they must be at least the S3 minimum of 5 MiB; the
+        // last part may be smaller. Use distinct fill bytes so the reassembly check is meaningful.
+        var part1Data = Repeat(0x46, 5 * 1024 * 1024); // 'F'
+        var part2Data = Repeat(0x53, 5 * 1024 * 1024); // 'S'
         var part3Data = Encoding.UTF8.GetBytes("THIRD");
 
         var etag1 = await UploadPartAsync(client, bucket, key, uploadId, 1, part1Data);


### PR DESCRIPTION
## Summary

The disk storage provider's `CompleteMultipartUpload` validated part existence, ETag match, and per-part checksums, but never enforced the S3 rule that **every part except the last must be at least 5 MiB** (5 × 1024 × 1024 = 5,242,880 bytes). As a result, multipart uploads with tiny non-final parts completed successfully against the disk backend, diverging from real AWS S3 (which rejects such completions with `EntityTooSmall` / HTTP 400) and from the S3 backend (which surfaces the upstream `EntityTooSmall` as `StorageErrorCode.MultipartConflict`).

Closes #137.

## Changes

- **`IntegratedS3.Provider.Disk/DiskStorageService.cs`**: During the assembly loop in `CompleteMultipartUploadCoreAsync`, the size of each non-final part is now checked (`new FileInfo(partPath).Length`). If any part other than the highest-numbered (last) part is smaller than the 5 MiB minimum, completion fails with `MultipartConflict` (HTTP 400) — identifying the offending part number and its size — before the temp object is renamed into place. This mirrors the S3 backend's translated error code for cross-backend parity, matching AWS's 400 status. A `MinimumMultipartPartSizeBytes` constant documents the rule. The part-order/duplicate/range validation still runs first, so `InvalidPartOrder`/`InvalidArgument` remain surfaced ahead of the size check.
- **Regression tests** (`DiskStorageServiceTests.cs`):
  - `DiskStorage_MultipartUpload_RejectsUndersizedNonFinalPartWithEntityTooSmall` — two 1 KiB parts → `MultipartConflict`/400, message names the offending part, and no object is created. (Verified fails-before / passes-after.)
  - `DiskStorage_MultipartUpload_AllowsSmallFinalPartWhenEarlierPartsMeetMinimum` — 5 MiB first part + tiny last part → succeeds and reassembles.
- **Pre-existing multipart tests** across `DiskStorageServiceTests`, `StorageProviderContractTests`, `IntegratedS3ClientTransferTests`, `RcloneS3MultipartEncodingCompatibilityTests`, `IntegratedS3AwsSdkCompatibilityTests`, and `IntegratedS3HttpEndpointsTests` used tiny non-final parts for convenience; their non-final parts were bumped to ≥ 5 MiB (last part may stay small), with content/checksum/reassembly assertions updated consistently. No assertions were weakened.

## Verification

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` → 0 warnings, 0 errors.
- `dotnet test IntegratedS3.Tests` → **1098 passed, 0 failed, 0 skipped**.
- Confirmed the new reject test fails against the unpatched provider and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
