### PR TITLE
fix: flush write-path data to stable storage before atomic rename (#121)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -2167,6 +2167,7 @@ internal sealed class DiskStorageService(
             await using (var sourceStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
             await using (var destinationStream = new FileStream(tempDestinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 await sourceStream.CopyToAsync(destinationStream, cancellationToken);
+                await FlushToStableStorageAsync(destinationStream, cancellationToken);
             }
 
             var sourceMetadata = sourceObject.Metadata;
@@ -2307,6 +2308,7 @@ internal sealed class DiskStorageService(
         try {
             await using (var tempStream = new FileStream(tempFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 await request.Content.CopyToAsync(tempStream, cancellationToken);
+                await FlushToStableStorageAsync(tempStream, cancellationToken);
             }
 
             var actualChecksums = await ComputeChecksumsAsync(tempFilePath, cancellationToken);
@@ -2644,6 +2646,8 @@ internal sealed class DiskStorageService(
                     else {
                         await sourceStream.CopyToAsync(tempStream, cancellationToken);
                     }
+
+                    await FlushToStableStorageAsync(tempStream, cancellationToken);
                 }
 
                 File.Move(tempPartPath, partPath, overwrite: true);
@@ -2668,6 +2672,7 @@ internal sealed class DiskStorageService(
             try {
                 await using (var tempStream = new FileStream(tempPartPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                     await request.Content.CopyToAsync(tempStream, cancellationToken);
+                    await FlushToStableStorageAsync(tempStream, cancellationToken);
                 }
 
                 File.Move(tempPartPath, partPath, overwrite: true);
@@ -2796,6 +2801,8 @@ internal sealed class DiskStorageService(
                 else {
                     await sourceStream.CopyToAsync(tempStream, cancellationToken);
                 }
+
+                await FlushToStableStorageAsync(tempStream, cancellationToken);
             }
 
             File.Move(tempPartPath, partPath, overwrite: true);
@@ -2996,6 +3003,8 @@ internal sealed class DiskStorageService(
                     await using var sourceStream = new FileStream(partPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
                     await sourceStream.CopyToAsync(destinationStream, cancellationToken);
                 }
+
+                await FlushToStableStorageAsync(destinationStream, cancellationToken);
             }
 
             if (await HasCurrentVersionStateAsync(request.BucketName, request.Key, cancellationToken)
@@ -5250,6 +5259,7 @@ internal sealed class DiskStorageService(
         try {
             await using (var stream = new FileStream(tempBucketMetadataPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 await JsonSerializer.SerializeAsync(stream, metadata, DiskStorageJsonSerializerContext.Default.DiskBucketMetadata, cancellationToken);
+                await FlushToStableStorageAsync(stream, cancellationToken);
             }
 
             File.Move(tempBucketMetadataPath, bucketMetadataPath, overwrite: true);
@@ -5327,6 +5337,7 @@ internal sealed class DiskStorageService(
         try {
             await using (var stream = new FileStream(tempStatePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 await JsonSerializer.SerializeAsync(stream, diskState, DiskStorageJsonSerializerContext.Default.DiskMultipartUploadState, cancellationToken);
+                await FlushToStableStorageAsync(stream, cancellationToken);
             }
 
             File.Move(tempStatePath, statePath, overwrite: true);
@@ -5389,6 +5400,31 @@ internal sealed class DiskStorageService(
         }
     }
 
+    /// <summary>
+    /// Forces the buffered contents of a write-path temp file to stable storage before the caller
+    /// publishes it with an atomic <see cref="File.Move(string, string, bool)"/> rename.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Disposing a <see cref="FileStream"/> flushes user-space buffers into the OS page cache, but it
+    /// does not force the data blocks onto physical media. <see cref="File.Move(string, string, bool)"/>
+    /// then publishes the final name while those blocks may still be volatile, so a crash or power loss
+    /// can leave a renamed-but-empty/torn object or an unparseable JSON sidecar.
+    /// </para>
+    /// <para>
+    /// Calling this before the rename first drains any user-space buffers with
+    /// <see cref="Stream.FlushAsync(CancellationToken)"/> and then issues
+    /// <see cref="FileStream.Flush(bool)"/> with <c>flushToDisk: true</c>, which asks the OS to push the
+    /// file's data to disk. The call must happen while the stream is still open (before the enclosing
+    /// <c>await using</c> block disposes it).
+    /// </para>
+    /// </remarks>
+    private static async ValueTask FlushToStableStorageAsync(FileStream stream, CancellationToken cancellationToken)
+    {
+        await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
+        stream.Flush(flushToDisk: true);
+    }
+
     private static async Task WriteMetadataAsync(string objectPath, DiskObjectMetadata metadata, CancellationToken cancellationToken)
     {
         var metadataPath = GetMetadataPath(objectPath);
@@ -5401,6 +5437,7 @@ internal sealed class DiskStorageService(
         try {
             await using (var stream = new FileStream(tempMetadataPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 await JsonSerializer.SerializeAsync(stream, metadata, DiskStorageJsonSerializerContext.Default.DiskObjectMetadata, cancellationToken);
+                await FlushToStableStorageAsync(stream, cancellationToken);
             }
 
             File.Move(tempMetadataPath, metadataPath, overwrite: true);

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageDurableFlushTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageDurableFlushTests.cs
@@ -1,0 +1,100 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression guard for issue #121: the disk provider must force every write-path temp file to
+/// stable storage (<c>Flush(flushToDisk: true)</c>) before it publishes the file with an atomic
+/// <c>File.Move(..., overwrite: true)</c> rename. Without the flush, a crash or power loss between the
+/// rename and the OS flushing the page cache can publish a zero-length/torn object or an unparseable
+/// JSON sidecar.
+/// </summary>
+/// <remarks>
+/// The write paths construct their <see cref="System.IO.FileStream"/>s inline with <c>new FileStream(...)</c>,
+/// so there is no injectable stream factory to spy on. This test therefore pins the durability contract
+/// at the source level: it asserts (1) the shared flush helper actually forces the OS buffer to disk and
+/// (2) every write-path atomic rename is preceded by a flush-to-stable-storage call in the same method.
+/// If a future edit adds a new temp-file + <c>File.Move</c> publish path without flushing first, this test
+/// fails.
+/// </remarks>
+public sealed class DiskStorageDurableFlushTests
+{
+    private static readonly Regex TempRenameRegex = new(
+        @"File\.Move\(\s*(?<temp>\w*[Tt]emp\w*)\s*,[^;]*overwrite:\s*true",
+        RegexOptions.Compiled);
+
+    [Fact]
+    public void FlushHelper_ForcesBuffersToDisk()
+    {
+        var source = ReadDiskStorageServiceSource();
+
+        // The helper must both drain user-space buffers and force the OS page cache to physical media.
+        Assert.Contains("FlushAsync(cancellationToken)", source, StringComparison.Ordinal);
+        Assert.Contains("Flush(flushToDisk: true)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryWritePathAtomicRename_IsPrecededByFlushToStableStorage()
+    {
+        var lines = File.ReadAllLines(GetDiskStorageServiceSourcePath());
+
+        var renameLines = new List<int>();
+        for (var i = 0; i < lines.Length; i++) {
+            if (TempRenameRegex.IsMatch(lines[i])) {
+                renameLines.Add(i);
+            }
+        }
+
+        // Sanity: the write paths (put, copy, multipart part/complete, and the JSON sidecars) mean there
+        // are several temp-file publish sites. If this drops to zero the detection regex has drifted.
+        Assert.True(
+            renameLines.Count >= 8,
+            $"Expected to find the disk provider's temp-file atomic renames, but found {renameLines.Count}. " +
+            "The detection regex may be stale.");
+
+        foreach (var renameLine in renameLines) {
+            // Look back within the enclosing write block for the durable-flush call. A generous window
+            // covers the CompleteMultipartUpload assembly loop, which flushes after concatenating parts.
+            var windowStart = Math.Max(0, renameLine - 60);
+            var flushed = false;
+            for (var i = renameLine - 1; i >= windowStart; i--) {
+                if (lines[i].Contains("FlushToStableStorageAsync(", StringComparison.Ordinal)) {
+                    flushed = true;
+                    break;
+                }
+            }
+
+            Assert.True(
+                flushed,
+                $"The atomic rename on line {renameLine + 1} of DiskStorageService.cs " +
+                $"('{lines[renameLine].Trim()}') is not preceded by a FlushToStableStorageAsync call. " +
+                "Write-path temp files must be flushed to stable storage before the rename (issue #121).");
+        }
+    }
+
+    private static string ReadDiskStorageServiceSource()
+        => File.ReadAllText(GetDiskStorageServiceSourcePath());
+
+    private static string GetDiskStorageServiceSourcePath()
+        => Path.Combine(
+            GetRepositoryRoot(),
+            "src", "IntegratedS3", "IntegratedS3.Provider.Disk", "DiskStorageService.cs");
+
+    private static string GetRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+
+        while (directory is not null) {
+            if (File.Exists(Path.Combine(directory.FullName, "LICENSE"))
+                && Directory.Exists(Path.Combine(directory.FullName, "docs"))
+                && Directory.Exists(Path.Combine(directory.FullName, "src"))) {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the repository root for durable-flush validation.");
+    }
+}


### PR DESCRIPTION
## Summary

Closes #121.

The disk storage provider published every write with a temp-file + `File.Move(..., overwrite: true)` pattern but never forced the temp file's contents to **stable storage** before the rename. Disposing a `FileStream` (via `await using`) only drains user-space buffers into the OS page cache; it does not push the data blocks to physical media. `File.Move` provides an atomic *name* swap but not *durability*, so a crash or power loss between the rename and the OS flushing the page cache could publish:

- a **zero-length / truncated / stale** object (single-part put, copy, multipart part, multipart complete), served silently because checksums are only computed at write time; or
- an **empty / partial JSON sidecar** (`WriteMetadataAsync`, `WriteBucketMetadataAsync`, `WriteMultipartStateAndReturnAsync`), which then throws `JsonException` on the next read.

## Fix

Added a shared helper:

```csharp
private static async ValueTask FlushToStableStorageAsync(FileStream stream, CancellationToken cancellationToken)
{
    await stream.FlushAsync(cancellationToken).ConfigureAwait(false);
    stream.Flush(flushToDisk: true);
}
```

`FlushAsync` drains user-space buffers; `Flush(flushToDisk: true)` forces the OS buffer to disk. It is invoked inside every write block (while the stream is still open) immediately before the enclosing block closes and `File.Move` runs, covering all 9 write-path publish sites:

- `PutObjectCoreAsync` (object data)
- `CopyObjectAsync` (destination data)
- multipart `UploadPart` (content + copy/range) — both code paths
- multipart part copy (second range site)
- `CompleteMultipartUploadAsync` (assembled object)
- `WriteBucketMetadataAsync`, `WriteMultipartStateAndReturnAsync`, `WriteMetadataAsync` (JSON sidecars)

Per the issue, directory fsync is intentionally omitted — it is not portable on Windows; the fix focuses on flushing the file(s) with `flushToDisk: true` before the atomic `Move`.

## Test

The write paths construct their `FileStream`s inline (`new FileStream(...)`), so there is no injectable stream factory to spy on. `DiskStorageDurableFlushTests` therefore pins the durability contract at the source level (matching the repo's existing source-reading test pattern):

1. the helper actually forces the OS buffer to disk (`Flush(flushToDisk: true)`), and
2. every write-path atomic rename (`File.Move(temp…, …, overwrite: true)`) is preceded by a `FlushToStableStorageAsync` call.

If a future edit adds a new temp-file + rename publish path without flushing first, the test fails.

## Verification

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — 0 warnings, 0 errors
- `dotnet test IntegratedS3.Tests` — **1125 passed**, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)