### PR TITLE
fix: preserve object tags during async replica repair re-PUT (#107)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
@@ -282,6 +282,7 @@ internal sealed class StorageReplicaRepairService(
             ContentLength = sourceResponse.Object.ContentLength,
             ContentType = sourceResponse.Object.ContentType,
             Metadata = CloneMetadata(sourceResponse.Object.Metadata),
+            Tags = CloneTags(sourceResponse.Object.Tags),
             Checksums = CloneChecksums(sourceResponse.Object.Checksums),
             OverwriteIfExists = true
         }, cancellationToken);

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
@@ -2782,6 +2782,73 @@ public sealed class IntegratedS3CoreOrchestrationTests
     }
 
     [Fact]
+    public async Task StorageReplicaRepairService_RepairReplicaObject_PreservesPrimaryObjectTags()
+    {
+        var primaryBackend = new InMemoryStorageBackend("primary-memory", isPrimary: true);
+        var replicaBackend = new InMemoryStorageBackend("replica-memory");
+
+        await using var fixture = new CoreStorageFixture(overrideCatalogStore: true, addDefaultDiskStorage: false, configureServices: services => {
+            services.AddSingleton<IStorageBackend>(primaryBackend);
+            services.AddSingleton<IStorageBackend>(replicaBackend);
+        });
+
+        var repairService = fixture.Services.GetRequiredService<IStorageReplicaRepairService>();
+
+        Assert.True((await primaryBackend.CreateBucketAsync(new CreateBucketRequest { BucketName = "tagged-bucket" })).IsSuccess);
+        Assert.True((await replicaBackend.CreateBucketAsync(new CreateBucketRequest { BucketName = "tagged-bucket" })).IsSuccess);
+
+        // Primary carries an object with a non-empty tag set.
+        primaryBackend.AddObject("tagged-bucket", "docs/tagged.txt", "primary payload");
+        Assert.True((await primaryBackend.PutObjectTagsAsync(new PutObjectTagsRequest
+        {
+            BucketName = "tagged-bucket",
+            Key = "docs/tagged.txt",
+            Tags = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["environment"] = "production",
+                ["owner"] = "copilot"
+            }
+        })).IsSuccess);
+
+        // Replica holds a stale, tagless copy of the same key that must be healed.
+        replicaBackend.AddObject("tagged-bucket", "docs/tagged.txt", "stale payload");
+
+        var repair = CreateRepairEntry(
+            StorageReplicaRepairOrigin.Reconciliation,
+            StorageReplicaRepairStatus.Pending,
+            StorageOperationType.PutObject,
+            primaryBackend.Name,
+            replicaBackend.Name,
+            "tagged-bucket",
+            "docs/tagged.txt");
+
+        var repairError = await repairService.RepairAsync(repair);
+        Assert.Null(repairError);
+
+        // Content is healed to the primary copy.
+        var repairedObject = await replicaBackend.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = "tagged-bucket",
+            Key = "docs/tagged.txt"
+        });
+        Assert.True(repairedObject.IsSuccess);
+        await using (var repairedContent = repairedObject.Value!) {
+            Assert.Equal("primary payload", await ReadContentAsStringAsync(repairedContent.Content));
+        }
+
+        // Regression: the repaired replica must carry the primary's tag set, not an empty one.
+        var repairedTags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "tagged-bucket",
+            Key = "docs/tagged.txt"
+        });
+        Assert.True(repairedTags.IsSuccess);
+        Assert.Equal(2, repairedTags.Value!.Tags.Count);
+        Assert.Equal("production", repairedTags.Value.Tags["environment"]);
+        Assert.Equal("copilot", repairedTags.Value.Tags["owner"]);
+    }
+
+    [Fact]
     public async Task OrchestratedStorageService_WriteThroughAll_ReplicatesBucketsAndObjects()
     {
         await using var fixture = new CoreStorageFixture(configureServices: services => {
@@ -4654,7 +4721,9 @@ public sealed class IntegratedS3CoreOrchestrationTests
                 ETag = $"{request.BucketName}:{request.Key}:{bytes.Length}",
                 LastModifiedUtc = DateTimeOffset.UtcNow,
                 Metadata = request.Metadata,
-                Tags = null,
+                Tags = request.Tags is null || request.Tags.Count == 0
+                    ? null
+                    : new Dictionary<string, string>(request.Tags, StringComparer.Ordinal),
                 Checksums = request.Checksums
             };
             _objects[(request.BucketName, request.Key)] = new StoredObject


### PR DESCRIPTION
## Summary

Fixes #107. `StorageReplicaRepairService.RepairReplicaObjectFromPrimaryAsync` re-uploaded the primary object body to a replica to heal a divergence, but built the `PutObjectRequest` **without** the object's tag set. Because `PutObject` is a full object write that replaces the entire tag set (e.g. the disk provider persists `NormalizeTags(request.Tags)`, and `NormalizeTags(null) => null`), the automated repair silently stripped **all** object tags from the repaired replica copy — a durable, silent data-integrity divergence introduced by the very machinery meant to eliminate divergence.

The orchestrator's synchronous write-through helper (`OrchestratedStorageService.RepairReplicaObjectFromPrimaryAsync`) already carried the tags via `Tags = CloneTags(sourceResponse.Object.Tags)`; the two copies of this logic had drifted. The `CloneTags` helper already existed in this service and was used elsewhere — it was simply not applied here.

## Changes

- **`StorageReplicaRepairService.cs`**: add `Tags = CloneTags(sourceResponse.Object.Tags)` to the repair `PutObjectRequest`, matching the orchestrator's correct helper. This is the smallest correct fix.
- **`IntegratedS3CoreOrchestrationTests.cs`**:
  - Make the test `InMemoryStorageBackend.PutObjectAsync` honor `request.Tags` (it previously hardcoded `Tags = null`, unlike real providers such as the disk backend), so repair-through-PutObject tag propagation is observable.
  - Add regression test `StorageReplicaRepairService_RepairReplicaObject_PreservesPrimaryObjectTags`: a tagged primary object repaired onto a stale/tagless replica must leave the replica carrying the primary's tag set.

## Verification

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — succeeds, 0 warnings.
- Full suite: **1124 passed / 0 failed**.
- Confirmed fails-before / passes-after: with the tag clone reverted, the new test fails with `Expected: 2 / Actual: 0` (tags dropped); with the fix, it passes.

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)