### PR TITLE
fix: verify signed x-amz-content-sha256 payload hash against received body (#131)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/ContentSha256MismatchException.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/ContentSha256MismatchException.cs
@@ -1,0 +1,11 @@
+namespace IntegratedS3.AspNetCore.Endpoints;
+
+/// <summary>
+/// Thrown when a request carries a concrete (non-sentinel) <c>x-amz-content-sha256</c> payload hash
+/// that does not match the SHA256 of the received request body. Maps to the S3
+/// <c>XAmzContentSHA256Mismatch</c> error (HTTP 400).
+/// </summary>
+internal sealed class ContentSha256MismatchException()
+    : Exception("The provided 'x-amz-content-sha256' header does not match what was computed.")
+{
+}

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -6986,6 +6986,15 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static async Task<PreparedRequestBody> PrepareRequestBodyAsync(HttpRequest request, CancellationToken cancellationToken)
     {
         if (!IsAwsChunkedContent(request)) {
+            // For non-streaming signed uploads the client may send a concrete lowercase-hex
+            // SHA256 of the payload in x-amz-content-sha256 and bind it into the SigV4 signature.
+            // The signature only proves the client declared that digest; S3 additionally recomputes
+            // the digest over the received bytes and rejects mismatches with XAmzContentSHA256Mismatch.
+            // Buffer the body (preserving it for the handler) and verify when a concrete digest is present.
+            if (TryGetConcretePayloadSha256(request, out var expectedSha256)) {
+                return await BufferAndVerifyPayloadSha256Async(request, expectedSha256!, cancellationToken);
+            }
+
             return new PreparedRequestBody(request.Body, request.ContentLength, tempFilePath: null, trailerHeaders: null, trailerHeaderEntries: null, finalChunkSignature: null);
         }
 
@@ -7010,6 +7019,71 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             }
 
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Returns <see langword="true"/> and the lowercase-hex digest when the request carries a concrete
+    /// (non-sentinel) <c>x-amz-content-sha256</c> value that S3 verifies against the received body.
+    /// Sentinels (<c>UNSIGNED-PAYLOAD</c>, the <c>STREAMING-*</c> payload hashes) and non-hex values are ignored.
+    /// </summary>
+    private static bool TryGetConcretePayloadSha256(HttpRequest request, out string? expectedSha256Lower)
+    {
+        expectedSha256Lower = null;
+        var headerValue = request.Headers[AwsContentSha256HeaderName].ToString().Trim();
+        if (headerValue.Length != 64) {
+            // Concrete SHA256 digests are exactly 64 hex characters; sentinels and blanks are longer/shorter.
+            return false;
+        }
+
+        for (var i = 0; i < headerValue.Length; i++) {
+            var c = headerValue[i];
+            var isHex = c is >= '0' and <= '9' or >= 'a' and <= 'f' or >= 'A' and <= 'F';
+            if (!isHex) {
+                return false;
+            }
+        }
+
+        expectedSha256Lower = headerValue.ToLowerInvariant();
+        return true;
+    }
+
+    private static async Task<PreparedRequestBody> BufferAndVerifyPayloadSha256Async(
+        HttpRequest request,
+        string expectedSha256Lower,
+        CancellationToken cancellationToken)
+    {
+        var buffer = new MemoryStream();
+        try {
+            using var sha256 = SHA256.Create();
+            var rented = System.Buffers.ArrayPool<byte>.Shared.Rent(81920);
+            try {
+                int read;
+                while ((read = await request.Body.ReadAsync(rented.AsMemory(0, rented.Length), cancellationToken)) > 0) {
+                    sha256.TransformBlock(rented, 0, read, null, 0);
+                    await buffer.WriteAsync(rented.AsMemory(0, read), cancellationToken);
+                }
+            }
+            finally {
+                System.Buffers.ArrayPool<byte>.Shared.Return(rented);
+            }
+
+            sha256.TransformFinalBlock([], 0, 0);
+            var actualSha256Lower = Convert.ToHexStringLower(sha256.Hash!);
+            if (!string.Equals(actualSha256Lower, expectedSha256Lower, StringComparison.Ordinal)) {
+                throw new ContentSha256MismatchException();
+            }
+
+            var contentLength = buffer.Length;
+            buffer.Position = 0;
+            var preparedBody = new PreparedRequestBody(buffer, contentLength, tempFilePath: null, trailerHeaders: null, trailerHeaderEntries: null, finalChunkSignature: null, ownsContent: true);
+            buffer = null!;
+            return preparedBody;
+        }
+        finally {
+            if (buffer is not null) {
+                await buffer.DisposeAsync();
+            }
         }
     }
 
@@ -9240,7 +9314,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? tempFilePath,
         IReadOnlyDictionary<string, string>? trailerHeaders,
         IReadOnlyList<KeyValuePair<string, string>>? trailerHeaderEntries,
-        string? finalChunkSignature) : IAsyncDisposable
+        string? finalChunkSignature,
+        bool ownsContent = false) : IAsyncDisposable
     {
         public Stream Content { get; } = content;
 
@@ -9254,12 +9329,14 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
         public async ValueTask DisposeAsync()
         {
-            if (tempFilePath is null) {
+            // The raw request body is owned by the framework and must not be disposed here.
+            // Temp-file-backed content and buffered (verified) content are ours to dispose.
+            if (tempFilePath is null && !ownsContent) {
                 return;
             }
 
             await Content.DisposeAsync();
-            if (File.Exists(tempFilePath)) {
+            if (tempFilePath is not null && File.Exists(tempFilePath)) {
                 File.Delete(tempFilePath);
             }
         }

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
@@ -89,6 +89,13 @@ internal sealed class IntegratedS3RequestAuthenticationEndpointFilter(
     /// </summary>
     private static (int StatusCode, string Code, string Message) MapException(Exception exception)
     {
+        if (exception is ContentSha256MismatchException) {
+            return (
+                StatusCodes.Status400BadRequest,
+                "XAmzContentSHA256Mismatch",
+                "The provided 'x-amz-content-sha256' header does not match what was computed.");
+        }
+
         if (exception is BadHttpRequestException badRequest) {
             return badRequest.StatusCode switch
             {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -902,6 +902,115 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task PutObject_WithSignedContentSha256MatchingBody_Persists()
+    {
+        const string accessKeyId = "sigv4-content-sha256-match-access";
+        const string secretAccessKey = "sigv4-content-sha256-match-secret";
+        const string bucketName = "content-sha256-match-bucket";
+        const string objectKey = "docs/content-sha256-match.txt";
+        var payloadBytes = Encoding.UTF8.GetBytes("hello from a correctly hashed payload");
+
+        await using var isolatedClient = await CreateSigV4AuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var createBucketRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Put, $"/integrated-s3/buckets/{bucketName}", accessKeyId, secretAccessKey);
+        Assert.Equal(HttpStatusCode.Created, (await client.SendAsync(createBucketRequest)).StatusCode);
+
+        var correctHash = Convert.ToHexStringLower(SHA256.HashData(payloadBytes));
+        using var putRequest = CreateSigV4BodySignedRequestWithContentSha256(
+            $"/integrated-s3/{bucketName}/{objectKey}", accessKeyId, secretAccessKey, payloadBytes, correctHash);
+
+        var putResponse = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        using var getRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Get, $"/integrated-s3/{bucketName}/{objectKey}", accessKeyId, secretAccessKey);
+        var getResponse = await client.SendAsync(getRequest);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal(payloadBytes, await getResponse.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public async Task PutObject_WithSignedContentSha256NotMatchingBody_ReturnsXAmzContentSHA256Mismatch()
+    {
+        const string accessKeyId = "sigv4-content-sha256-mismatch-access";
+        const string secretAccessKey = "sigv4-content-sha256-mismatch-secret";
+        const string bucketName = "content-sha256-mismatch-bucket";
+        const string objectKey = "docs/content-sha256-mismatch.txt";
+        var payloadBytes = Encoding.UTF8.GetBytes("this is the body that will actually be sent");
+
+        await using var isolatedClient = await CreateSigV4AuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var createBucketRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Put, $"/integrated-s3/buckets/{bucketName}", accessKeyId, secretAccessKey);
+        Assert.Equal(HttpStatusCode.Created, (await client.SendAsync(createBucketRequest)).StatusCode);
+
+        // Sign the request with a concrete SHA256 of a *different* payload. The signature is
+        // internally consistent (it covers the wrong hash), so only recomputing the body digest
+        // detects the divergence — exactly the XAmzContentSHA256Mismatch case.
+        var wrongHash = Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes("a different payload")));
+        using var putRequest = CreateSigV4BodySignedRequestWithContentSha256(
+            $"/integrated-s3/{bucketName}/{objectKey}", accessKeyId, secretAccessKey, payloadBytes, wrongHash);
+
+        var response = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("XAmzContentSHA256Mismatch", GetRequiredElementValue(document, "Code"));
+
+        // The object must not have been persisted.
+        using var getRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Get, $"/integrated-s3/{bucketName}/{objectKey}", accessKeyId, secretAccessKey);
+        Assert.Equal(HttpStatusCode.NotFound, (await client.SendAsync(getRequest)).StatusCode);
+    }
+
+    [Fact]
+    public async Task PutObject_WithUnsignedPayloadSentinel_SkipsContentSha256Verification()
+    {
+        const string accessKeyId = "sigv4-content-sha256-unsigned-access";
+        const string secretAccessKey = "sigv4-content-sha256-unsigned-secret";
+        const string bucketName = "content-sha256-unsigned-bucket";
+        const string objectKey = "docs/content-sha256-unsigned.txt";
+        var payloadBytes = Encoding.UTF8.GetBytes("body sent under UNSIGNED-PAYLOAD sentinel");
+
+        await using var isolatedClient = await CreateSigV4AuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var createBucketRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Put, $"/integrated-s3/buckets/{bucketName}", accessKeyId, secretAccessKey);
+        Assert.Equal(HttpStatusCode.Created, (await client.SendAsync(createBucketRequest)).StatusCode);
+
+        // UNSIGNED-PAYLOAD is a sentinel, not a concrete digest, so the body is stored without a
+        // digest comparison even though the bytes obviously do not hash to that literal string.
+        using var putRequest = CreateSigV4BodySignedRequestWithContentSha256(
+            $"/integrated-s3/{bucketName}/{objectKey}", accessKeyId, secretAccessKey, payloadBytes, "UNSIGNED-PAYLOAD");
+
+        var putResponse = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        using var getRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Get, $"/integrated-s3/{bucketName}/{objectKey}", accessKeyId, secretAccessKey);
+        var getResponse = await client.SendAsync(getRequest);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal(payloadBytes, await getResponse.Content.ReadAsByteArrayAsync());
+    }
+
+    private static HttpRequestMessage CreateSigV4BodySignedRequestWithContentSha256(
+        string pathAndQuery,
+        string accessKeyId,
+        string secretAccessKey,
+        byte[] payloadBytes,
+        string contentSha256HeaderValue,
+        string host = "localhost")
+    {
+        var request = new HttpRequestMessage(HttpMethod.Put, pathAndQuery)
+        {
+            Content = new ByteArrayContent(payloadBytes)
+        };
+        request.Content.Headers.TryAddWithoutValidation("Content-Type", "text/plain");
+
+        SignSigV4HeaderRequest(request, pathAndQuery, accessKeyId, secretAccessKey, contentSha256HeaderValue, host: host);
+        return request;
+    }
+
+    [Fact]
     public async Task PutObject_WithAwsChunkedTrailerChecksumWithoutTrailerDeclaration_ReturnsInvalidRequest()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary

Closes #131.

For non-streaming signed uploads (`PutObject`, `UploadPart`, and other body-bearing requests) the AWS SDK sends a concrete lowercase-hex SHA256 of the payload in `x-amz-content-sha256`, lists it in `SignedHeaders`, and binds the *claimed* hash into the SigV4 signature. IntegratedS3 previously took that header value verbatim into the canonical request for signature verification but never recomputed SHA256 over the received body. A request carrying a wrong-but-consistently-signed hash was therefore accepted, whereas real S3 rejects it with `400 XAmzContentSHA256Mismatch`.

## Fix

- `PrepareRequestBodyAsync` now recomputes SHA256 over the received body whenever `x-amz-content-sha256` is a concrete 64-char hex digest — i.e. **not** `UNSIGNED-PAYLOAD` and **not** one of the `STREAMING-*` payload-hash sentinels. The body is buffered incrementally (`SHA256.TransformBlock` while copying into a `MemoryStream`) so it is fully preserved for the handler; nothing is consumed destructively.
- On divergence it throws a new internal `ContentSha256MismatchException`, which the central endpoint filter (`IntegratedS3RequestAuthenticationEndpointFilter`) maps to `400 XAmzContentSHA256Mismatch`. Because the check lives in the shared body-preparation path + shared filter, it covers every body-bearing endpoint (PutObject, UploadPart, DeleteObjects, etc.) uniformly.
- `PreparedRequestBody` gained an `ownsContent` flag so the buffered stream is disposed while the raw framework request body is still never disposed here.
- Sentinel (`UNSIGNED-PAYLOAD`) and `aws-chunked`/`STREAMING-*` requests are unaffected.

## Tests

Added to `IntegratedS3HttpEndpointsTests`:
- matching hash → `200`, body persisted and byte-for-byte retrievable;
- wrong-but-signed hash → `400 XAmzContentSHA256Mismatch`, object **not** persisted;
- `UNSIGNED-PAYLOAD` sentinel → verification skipped, body stored.

Fails-before / passes-after confirmed (with the digest comparison disabled the mismatch test returns `200 OK`, matching the pre-fix behavior). Full suite green: **1126 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)