### PR TITLE
fix: S3 response wire-format nits (JSON bodies, stray ETag header, HostId, Location) (#163)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -1280,7 +1280,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         HttpRequest request,
         IIntegratedS3RequestContextAccessor requestContextAccessor,
         IStorageService storageService,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool s3CompatibleResponse = false)
     {
         ApplyObjectUploadBodySizeLimit(httpContext);
 
@@ -1427,7 +1428,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         ApplyChecksumAlgorithmHeader(httpContext.Response, checksumAlgorithm);
                     }
 
-                    return TypedResults.Ok(result.Value);
+                    // AWS S3 PutObject returns an empty body (the ETag travels in the response
+                    // header only). The S3-compatible surface must therefore not emit the JSON
+                    // ObjectInfo DTO; the native /buckets/.../objects/... API keeps returning it.
+                    return s3CompatibleResponse
+                        ? TypedResults.Ok()
+                        : TypedResults.Ok(result.Value);
                 }, cancellationToken);
             }
             finally {
@@ -2375,9 +2381,13 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 }
             }
 
-            return result.IsSuccess
-                ? TypedResults.Ok()
-                : ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+            if (!result.IsSuccess) {
+                return ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+            }
+
+            // AWS S3 CreateBucket returns a Location response header pointing at the new bucket.
+            httpContext.Response.Headers.Location = $"/{bucketName}";
+            return TypedResults.Ok();
         }
         catch (EndpointStorageAuthorizationException exception) {
             return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
@@ -2440,7 +2450,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "POST" when TryGetMultipartUploadId(httpContext.Request, out _, out _) => await CompleteMultipartUploadAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when TryGetMultipartUploadId(httpContext.Request, out _, out _) => await AbortMultipartUploadAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" => await GetObjectAsync(resolvedRequest.BucketName, key, httpContext, httpContext.Request, requestContextAccessor, storageService, cancellationToken),
-                "PUT" => await PutObjectAsync(resolvedRequest.BucketName, key, httpContext, httpContext.Request, requestContextAccessor, storageService, cancellationToken),
+                "PUT" => await PutObjectAsync(resolvedRequest.BucketName, key, httpContext, httpContext.Request, requestContextAccessor, storageService, cancellationToken, s3CompatibleResponse: true),
                 "HEAD" => await HeadObjectAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" => await DeleteObjectAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 _ => TypedResults.StatusCode(StatusCodes.Status405MethodNotAllowed)
@@ -3196,6 +3206,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
                 var completedObject = result.Value!;
                 ApplyObjectIdentityHeaders(httpContext.Response, completedObject);
+                // AWS does not set a top-level ETag response header on CompleteMultipartUpload:
+                // the ETag lives inside the <CompleteMultipartUploadResult> body because the body
+                // may instead carry a delayed error after the 200 status line.
+                httpContext.Response.Headers.Remove(HeaderNames.ETag);
                 return new XmlContentResult(
                     S3XmlResponseWriter.WriteCompleteMultipartUploadResult(new S3CompleteMultipartUploadResult
                     {
@@ -4045,6 +4059,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 Message = message,
                 Resource = resource,
                 RequestId = httpContext.TraceIdentifier,
+                HostId = httpContext.TraceIdentifier,
                 BucketName = bucketName,
                 Key = key
             }),
@@ -4098,6 +4113,9 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static IResult ToCopyObjectResult(HttpContext httpContext, ObjectInfo @object, string? sourceVersionId)
     {
         ApplyObjectResultHeaders(httpContext.Response, @object);
+        // AWS does not set a top-level ETag response header on CopyObject: the ETag lives inside
+        // the <CopyObjectResult> body because the body may instead carry a delayed error.
+        httpContext.Response.Headers.Remove(HeaderNames.ETag);
         ApplyChecksumAlgorithmHeader(httpContext.Response, GetResponseChecksumAlgorithm(@object.Checksums));
         if (!string.IsNullOrWhiteSpace(sourceVersionId)) {
             httpContext.Response.Headers[CopySourceVersionIdHeaderName] = sourceVersionId;

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
@@ -37,7 +37,8 @@ internal sealed class IntegratedS3RequestAuthenticationEndpointFilter(
                                 Code = authenticationResult.ErrorCode ?? "AccessDenied",
                                 Message = authenticationResult.ErrorMessage ?? "Request authentication failed.",
                                 Resource = httpContext.Request.PathBase.Add(httpContext.Request.Path).Value,
-                                RequestId = httpContext.TraceIdentifier
+                                RequestId = httpContext.TraceIdentifier,
+                                HostId = httpContext.TraceIdentifier
                             }));
                     }
 
@@ -76,7 +77,8 @@ internal sealed class IntegratedS3RequestAuthenticationEndpointFilter(
                     Code = errorCode,
                     Message = message,
                     Resource = httpContext.Request.PathBase.Add(httpContext.Request.Path).Value,
-                    RequestId = httpContext.TraceIdentifier
+                    RequestId = httpContext.TraceIdentifier,
+                    HostId = httpContext.TraceIdentifier
                 }));
         }
     }

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3ErrorResponse.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3ErrorResponse.cs
@@ -17,6 +17,9 @@ public sealed class S3ErrorResponse
     /// <summary>The request ID assigned by S3 for debugging purposes.</summary>
     public string? RequestId { get; init; }
 
+    /// <summary>The host ID (mirrors the <c>x-amz-id-2</c> response header) used for debugging.</summary>
+    public string? HostId { get; init; }
+
     /// <summary>The name of the bucket related to the error, if applicable.</summary>
     public string? BucketName { get; init; }
 

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -177,6 +177,10 @@ public static class S3XmlResponseWriter
             xmlWriter.WriteElementString("RequestId", response.RequestId);
         }
 
+        if (!string.IsNullOrWhiteSpace(response.HostId)) {
+            xmlWriter.WriteElementString("HostId", response.HostId);
+        }
+
         if (!string.IsNullOrWhiteSpace(response.BucketName)) {
             xmlWriter.WriteElementString("BucketName", response.BucketName);
         }

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -10855,6 +10855,117 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task PutObject_S3CompatiblePath_ReturnsEmptyBodyAndEtagHeader()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "wire-put-empty-body-bucket";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        var response = await client.PutAsync(
+            $"/integrated-s3/{bucketName}/docs/put-empty.txt",
+            new StringContent("wire format payload", Encoding.UTF8, "text/plain"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // AWS S3 PutObject: ETag travels only in the response header, body is empty (never JSON).
+        Assert.False(string.IsNullOrWhiteSpace(response.Headers.ETag?.Tag), "PutObject must set the ETag response header.");
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Equal(string.Empty, body);
+        Assert.NotEqual("application/json", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task CopyObject_S3CompatiblePath_OmitsEtagResponseHeaderAndKeepsBodyEtag()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "wire-copy-no-etag-header-bucket";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await client.PutAsync(
+            $"/integrated-s3/{bucketName}/docs/copy-source.txt",
+            new StringContent("copy source payload", Encoding.UTF8, "text/plain"))).StatusCode);
+
+        using var copyRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/docs/copy-dest.txt");
+        copyRequest.Headers.TryAddWithoutValidation("x-amz-copy-source", $"/{bucketName}/docs/copy-source.txt");
+        var copyResponse = await client.SendAsync(copyRequest);
+
+        Assert.Equal(HttpStatusCode.OK, copyResponse.StatusCode);
+        // AWS does not set a top-level ETag header on CopyObject; the ETag is only in the body.
+        Assert.Null(copyResponse.Headers.ETag);
+        Assert.False(copyResponse.Headers.Contains("ETag"), "CopyObject must not emit an ETag response header.");
+
+        var copyDocument = XDocument.Parse(await copyResponse.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(copyDocument, "CopyObjectResult");
+        Assert.False(string.IsNullOrWhiteSpace(GetRequiredElementValue(copyDocument, "ETag")), "CopyObjectResult body must carry the ETag.");
+    }
+
+    [Fact]
+    public async Task CompleteMultipartUpload_OmitsEtagResponseHeaderAndBodyHasLocation()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "wire-complete-mpu-bucket";
+        const string objectKey = "docs/complete-mpu.dat";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var initiateRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploads")
+        {
+            Content = new ByteArrayContent([])
+        };
+        var initiateResponse = await client.SendAsync(initiateRequest);
+        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
+        var uploadId = XDocument.Parse(await initiateResponse.Content.ReadAsStringAsync()).Root!.S3Element("UploadId")!.Value;
+
+        // A single part is the final part, so it is exempt from the S3 minimum part-size rule.
+        var partResponse = await client.PutAsync(
+            $"/integrated-s3/{bucketName}/{objectKey}?partNumber=1&uploadId={Uri.EscapeDataString(uploadId)}",
+            new ByteArrayContent(Encoding.UTF8.GetBytes("only part payload")));
+        Assert.Equal(HttpStatusCode.OK, partResponse.StatusCode);
+        var partETag = partResponse.Headers.ETag?.Tag ?? throw new Xunit.Sdk.XunitException("Expected UploadPart ETag header.");
+
+        using var completeRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploadId={Uri.EscapeDataString(uploadId)}")
+        {
+            Content = new StringContent($"""
+<CompleteMultipartUpload>
+  <Part>
+    <PartNumber>1</PartNumber>
+    <ETag>{partETag}</ETag>
+  </Part>
+</CompleteMultipartUpload>
+""", Encoding.UTF8, "application/xml")
+        };
+        var completeResponse = await client.SendAsync(completeRequest);
+
+        Assert.Equal(HttpStatusCode.OK, completeResponse.StatusCode);
+        // AWS does not set a top-level ETag header on CompleteMultipartUpload.
+        Assert.Null(completeResponse.Headers.ETag);
+        Assert.False(completeResponse.Headers.Contains("ETag"), "CompleteMultipartUpload must not emit an ETag response header.");
+
+        var completeDocument = XDocument.Parse(await completeResponse.Content.ReadAsStringAsync());
+        S3XmlTestHelper.AssertRoot(completeDocument, "CompleteMultipartUploadResult");
+        Assert.False(string.IsNullOrWhiteSpace(GetRequiredElementValue(completeDocument, "Location")), "CompleteMultipartUploadResult body must include <Location>.");
+        Assert.False(string.IsNullOrWhiteSpace(GetRequiredElementValue(completeDocument, "ETag")), "CompleteMultipartUploadResult body must carry the ETag.");
+    }
+
+    [Fact]
+    public async Task S3ErrorResponse_Body_IncludesHostIdMirroringHeader()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        var errorResponse = await client.GetAsync("/integrated-s3/nonexistent-hostid-bucket/doc.txt");
+        Assert.Equal(HttpStatusCode.NotFound, errorResponse.StatusCode);
+
+        var hostIdHeader = errorResponse.Headers.GetValues("x-amz-id-2").Single();
+
+        var errorDocument = XDocument.Parse(await errorResponse.Content.ReadAsStringAsync());
+        Assert.Equal(S3Ns + "Error", errorDocument.Root!.Name);
+        var bodyHostId = GetRequiredElementValue(errorDocument, "HostId");
+        Assert.False(string.IsNullOrWhiteSpace(bodyHostId), "Error body must include <HostId>.");
+        Assert.Equal(hostIdHeader, bodyHostId);
+    }
+
+    [Fact]
     public async Task ListObjectVersions_WithEncodingTypeUrl_ReturnsUrlEncodedKeyFields()
     {
         using var client = await _factory.CreateClientAsync();

--- a/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
@@ -312,4 +312,40 @@ public sealed class S3XmlResponseWriterTests
         Assert.NotNull(deleteMarkerOwner);
         Assert.Equal("owner-id-123", deleteMarkerOwner!.Element(XName.Get("ID", ns))?.Value);
     }
+
+    [Fact]
+    public void WriteError_EmitsHostId_WhenProvided()
+    {
+        var ns = S3XmlTestHelper.CanonicalS3Namespace;
+
+        var xml = S3XmlResponseWriter.WriteError(new S3ErrorResponse
+        {
+            Code = "NoSuchBucket",
+            Message = "The specified bucket does not exist.",
+            Resource = "/bucket/key",
+            RequestId = "request-id-123",
+            HostId = "host-id-456"
+        });
+
+        var document = XDocument.Parse(xml);
+        S3XmlTestHelper.AssertRoot(document, "Error");
+        Assert.Equal("host-id-456", document.Root!.Element(XName.Get("HostId", ns))?.Value);
+        Assert.Equal("request-id-123", document.Root!.Element(XName.Get("RequestId", ns))?.Value);
+    }
+
+    [Fact]
+    public void WriteError_OmitsHostId_WhenNotProvided()
+    {
+        var ns = S3XmlTestHelper.CanonicalS3Namespace;
+
+        var xml = S3XmlResponseWriter.WriteError(new S3ErrorResponse
+        {
+            Code = "NoSuchBucket",
+            Message = "The specified bucket does not exist."
+        });
+
+        var document = XDocument.Parse(xml);
+        S3XmlTestHelper.AssertRoot(document, "Error");
+        Assert.Null(document.Root!.Element(XName.Get("HostId", ns)));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes the wire-format divergences enumerated in #163 so responses match the AWS S3 REST API more closely (strict clients/proxies care even where SDKs tolerate).

### Fixes
- **PutObject JSON success body → empty body.** The S3-compatible `PUT /{bucket}/{key}` now returns an empty body (the `ETag` continues to travel in the response header), matching AWS. The native `/buckets/{bucket}/objects/{key}` convenience API is unchanged and still returns the JSON `ObjectInfo` DTO — a new `s3CompatibleResponse` flag on the shared `PutObjectAsync` distinguishes the two surfaces, so existing native-API tests keep passing.
- **CreateBucket `Location` header.** The S3-compatible path-style `CreateBucket` now emits `Location: /{bucket}`.
- **Stray `ETag` response header removed on CopyObject and CompleteMultipartUpload.** AWS returns the ETag only inside the `<CopyObjectResult>` / `<CompleteMultipartUploadResult>` body (the header is deliberately absent because the body may carry a delayed error). Both handlers now strip the top-level `ETag` header while keeping it in the XML body and preserving other headers (version-id, checksums, SSE, etc.).
- **Error XML `<HostId>`.** `S3ErrorResponse` gained a `HostId` field; `WriteError` emits `<HostId>`; all three error-construction sites populate it from `httpContext.TraceIdentifier` (the same value already used for the `x-amz-id-2` header), so the body now mirrors the header.

### Already correct (no code change)
- CompleteMultipartUpload already emitted `<Location>` in its result body. A regression test now guards it.

### Tests
Added HTTP-level regression tests (fails-before/passes-after, verified by temporarily reverting each fix):
- PutObject S3-compatible path returns empty body + ETag header, not JSON.
- CopyObject and CompleteMultipartUpload emit no `ETag` response header, ETag present in the XML body.
- CompleteMultipartUpload body includes `<Location>`.
- Error body `<HostId>` present and equal to the `x-amz-id-2` header.

Plus `WriteError` unit tests for `<HostId>` present/omitted.

Full suite: **1129 passed, 0 failed**; solution builds clean (0 warnings, 0 errors).

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)