### PR TITLE
fix: enforce presigned URL expiry as absolute bound, not expiry+skew (#132)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsSignatureV4RequestAuthenticator.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsSignatureV4RequestAuthenticator.cs
@@ -201,7 +201,10 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             return IntegratedS3RequestAuthenticationResult.Failure("RequestTimeTooSkewed", "The presigned request time is too far in the future.");
         }
 
-        if (nowUtc - presignedRequest.SignedAtUtc > TimeSpan.FromSeconds(presignedRequest.ExpiresSeconds) + TimeSpan.FromMinutes(settings.AllowedSignatureClockSkewMinutes)) {
+        // The presigned expiry boundary is an absolute bound at SignedAtUtc + X-Amz-Expires.
+        // Clock-skew tolerance applies only to the future-dated SignedAtUtc check above,
+        // not to lengthening the URL's stated lifetime (see issue #132).
+        if (nowUtc - presignedRequest.SignedAtUtc > TimeSpan.FromSeconds(presignedRequest.ExpiresSeconds)) {
             return IntegratedS3RequestAuthenticationResult.Failure("AccessDenied", "The presigned request has expired.");
         }
 
@@ -446,7 +449,10 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             return IntegratedS3RequestAuthenticationResult.Failure("RequestTimeTooSkewed", "The presigned request time is too far in the future.");
         }
 
-        if (nowUtc - presignedRequest.SignedAtUtc > TimeSpan.FromSeconds(presignedRequest.ExpiresSeconds) + TimeSpan.FromMinutes(settings.AllowedSignatureClockSkewMinutes)) {
+        // The presigned expiry boundary is an absolute bound at SignedAtUtc + X-Amz-Expires.
+        // Clock-skew tolerance applies only to the future-dated SignedAtUtc check above,
+        // not to lengthening the URL's stated lifetime (see issue #132).
+        if (nowUtc - presignedRequest.SignedAtUtc > TimeSpan.FromSeconds(presignedRequest.ExpiresSeconds)) {
             return IntegratedS3RequestAuthenticationResult.Failure("AccessDenied", "The presigned request has expired.");
         }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
@@ -1673,6 +1673,36 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
     }
 
     [Fact]
+    public async Task SigV4PresignedQueryAuthentication_ExpiredWithinClockSkewGrace_ReturnsXmlError()
+    {
+        // Regression for #132: the presigned expiry boundary is an absolute bound at
+        // SignedAtUtc + X-Amz-Expires. The clock-skew allowance must NOT extend it. With the
+        // default AllowedSignatureClockSkewMinutes = 5, a URL signed 1 minute ago with
+        // expiresSeconds: 1 is well past its stated lifetime, yet used to be accepted because
+        // the skew allowance was (incorrectly) added to the expiry window.
+        const string accessKeyId = "sigv4-skew-expiry-access";
+        const string secretAccessKey = "sigv4-skew-expiry-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var expiredRequest = CreateSigV4PresignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/buckets/skew-expiry-bucket/objects/docs/skew.txt",
+            accessKeyId,
+            secretAccessKey,
+            expiresSeconds: 1,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-1));
+        var response = await client.SendAsync(expiredRequest);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("AccessDenied", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("expired", GetRequiredElementValue(errorDocument, "Message"), StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
     public async Task SigV4PresignedQueryAuthentication_ZeroExpiry_ReturnsXmlError()
     {
         const string accessKeyId = "sigv4-zero-expiry-access";


### PR DESCRIPTION
## Summary

Presigned-request expiry was extended by `AllowedSignatureClockSkewMinutes` (default **5 min**) beyond the URL's stated `X-Amz-Expires`, so every presigned URL was honored for up to 5 minutes past its declared expiry. AWS enforces presigned expiry as an absolute bound at `X-Amz-Date + X-Amz-Expires`; clock-skew tolerance applies only to the future-dated (`RequestTimeTooSkewed`) check, not to lengthening a URL's lifetime.

## Change

Removed the `+ TimeSpan.FromMinutes(settings.AllowedSignatureClockSkewMinutes)` term from the expiry comparison in **both** presigned paths (SigV4 and SigV4a) in `AwsSignatureV4RequestAuthenticator`. `SignedAtUtc + ExpiresSeconds` is now treated as an absolute upper bound. The future-dated skew check is unchanged.

## Test

Added `SigV4PresignedQueryAuthentication_ExpiredWithinClockSkewGrace_ReturnsXmlError`: a URL signed 1 minute ago with `X-Amz-Expires=1` under the default 5-minute skew is now rejected as expired.
- Verified **fails-before** (buggy code accepted it → 404 NotFound past auth) / **passes-after** (403 AccessDenied, "expired").
- Full suite green: **1136 passed, 0 failed**.

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)