### PR TITLE
fix: translate lock-free read/copy-source TOCTOU races to 404 and use FileShare.Delete (#120)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -1974,7 +1974,17 @@ internal sealed class DiskStorageService(
             return StorageResult<GetObjectResponse>.Failure(rangeError);
         }
 
-        var stream = new FileStream(storedObject.ContentPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        // The content file is opened without holding the per-object mutation lock (reads are
+        // intentionally lock-free). A concurrent DeleteObject/overwrite can therefore land between
+        // ResolveStoredObjectAsync above and this open, causing FileNotFoundException/
+        // DirectoryNotFoundException. Translate that lost TOCTOU race to the S3-correct
+        // NoSuchKey (404) instead of surfacing an InternalError (500). The stream is opened with
+        // FileShare.Delete so a concurrent rename/delete of the file cannot fail a writer's
+        // File.Move on Windows while a reader keeps its handle.
+        var stream = TryOpenObjectReadStream(storedObject.ContentPath);
+        if (stream is null) {
+            return StorageResult<GetObjectResponse>.Failure(ObjectNotFound(request.BucketName, request.Key, request.VersionId));
+        }
 
         Stream responseStream = stream;
         ObjectInfo responseObject = objectInfo;
@@ -2164,7 +2174,17 @@ internal sealed class DiskStorageService(
 
         var tempDestinationPath = $"{destinationPath}.{Guid.NewGuid():N}.tmp";
         try {
-            await using (var sourceStream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            // The source content file is opened while holding only the destination mutation lock,
+            // never the source lock, so a concurrent delete/overwrite of the source key can race
+            // this open. Translate a lost TOCTOU race (FileNotFound/DirectoryNotFound) to the
+            // S3-correct NoSuchKey (404) instead of an InternalError (500), and open with
+            // FileShare.Delete so a concurrent rename/delete of the source cannot fail on Windows.
+            var sourceStream = TryOpenObjectReadStream(sourcePath);
+            if (sourceStream is null) {
+                return StorageResult<ObjectInfo>.Failure(ObjectNotFound(request.SourceBucketName, request.SourceKey, request.SourceVersionId));
+            }
+
+            await using (sourceStream)
             await using (var destinationStream = new FileStream(tempDestinationPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 await sourceStream.CopyToAsync(destinationStream, cancellationToken);
                 await FlushToStableStorageAsync(destinationStream, cancellationToken);
@@ -2637,7 +2657,15 @@ internal sealed class DiskStorageService(
             }
 
             try {
-                await using (var sourceStream = new FileStream(sourceObject.ContentPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
+                // The copy source is opened lock-free, so a concurrent delete/overwrite of the
+                // source key can race this open. Translate a lost TOCTOU race to NoSuchKey (404)
+                // and open with FileShare.Delete so a concurrent rename/delete cannot fail on Windows.
+                var sourceStream = TryOpenObjectReadStream(sourceObject.ContentPath);
+                if (sourceStream is null) {
+                    return StorageResult<MultipartUploadPart>.Failure(ObjectNotFound(request.CopySourceBucketName!, request.CopySourceKey!, request.CopySourceVersionId));
+                }
+
+                await using (sourceStream)
                 await using (var tempStream = new FileStream(tempPartPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                     if (normalizedRange is { Start: long start, End: long end }) {
                         sourceStream.Seek(start, SeekOrigin.Begin);
@@ -2792,7 +2820,15 @@ internal sealed class DiskStorageService(
         var partPath = GetMultipartPartPath(uploadDirectoryPath, request.PartNumber);
         var tempPartPath = $"{partPath}.{Guid.NewGuid():N}.tmp";
         try {
-            await using (var sourceStream = new FileStream(sourceObject.ContentPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan))
+            // The copy source is opened lock-free, so a concurrent delete/overwrite of the
+            // source key can race this open. Translate a lost TOCTOU race to NoSuchKey (404)
+            // and open with FileShare.Delete so a concurrent rename/delete cannot fail on Windows.
+            var sourceStream = TryOpenObjectReadStream(sourceObject.ContentPath);
+            if (sourceStream is null) {
+                return StorageResult<MultipartUploadPart>.Failure(ObjectNotFound(request.SourceBucketName, request.SourceKey, request.SourceVersionId));
+            }
+
+            await using (sourceStream)
             await using (var tempStream = new FileStream(tempPartPath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
                 if (normalizedRange is { Start: { } start, End: { } end }) {
                     sourceStream.Seek(start, SeekOrigin.Begin);
@@ -5457,6 +5493,35 @@ internal sealed class DiskStorageService(
     private static string CreateVersionId()
     {
         return Guid.CreateVersion7().ToString("N");
+    }
+
+    /// <summary>
+    /// Opens an object content file for a lock-free read/copy-source stream. The file is opened
+    /// with <see cref="FileShare.Read"/> | <see cref="FileShare.Delete"/> so a concurrent
+    /// delete/rename of the underlying file (e.g. a writer publishing an overwrite via
+    /// <see cref="File.Move(string, string, bool)"/> on Windows) cannot fail the open or the
+    /// ongoing read while this reader keeps its handle. Returns <see langword="null"/> when the
+    /// file has already been removed by a concurrent delete (a lost TOCTOU race), so the caller
+    /// can translate it into an S3 <c>NoSuchKey</c> (404) rather than surfacing an
+    /// <see cref="IOException"/> as an <c>InternalError</c> (500).
+    /// </summary>
+    private static FileStream? TryOpenObjectReadStream(string contentPath)
+    {
+        try {
+            return new FileStream(
+                contentPath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.Read | FileShare.Delete,
+                81920,
+                FileOptions.Asynchronous | FileOptions.SequentialScan);
+        }
+        catch (FileNotFoundException) {
+            return null;
+        }
+        catch (DirectoryNotFoundException) {
+            return null;
+        }
     }
 
     private static async Task<IReadOnlyDictionary<string, string>> ComputeChecksumsAsync(string objectPath, CancellationToken cancellationToken)

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -5223,4 +5223,134 @@ public sealed class DiskStorageServiceTests
         Assert.Equal(StorageErrorCode.NoSuchUpload, completeResult.Error!.Code);
         Assert.Equal(404, completeResult.Error.SuggestedHttpStatusCode);
     }
+
+    // ---- Regression tests for issue #120: TOCTOU delete/overwrite races on lock-free reads ----
+
+    // Locates the on-disk content file for a freshly-Put object by finding the sibling of the
+    // metadata sidecar (content path == sidecar path minus the metadata suffix). This lets the
+    // test reproduce the exact TOCTOU window the provider races: metadata still present, but the
+    // content file deleted out from under the lock-free read/copy-source open.
+    private static string FindObjectContentPath(string rootPath, string bucketName)
+    {
+        var bucketPath = Path.Combine(rootPath, bucketName);
+        const string metadataSuffix = ".integrateds3.json";
+        var sidecar = Directory
+            .EnumerateFiles(bucketPath, "*" + metadataSuffix, SearchOption.AllDirectories)
+            .First(path => !Path.GetFileName(path).StartsWith(".integrateds3.", StringComparison.Ordinal));
+        return sidecar[..^metadataSuffix.Length];
+    }
+
+    [Fact]
+    public async Task DiskStorage_GetObject_ContentFileDeletedAfterResolve_ReturnsNoSuchKeyNot500()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "toctou-get" });
+
+        await using (var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes("racy content"))) {
+            var put = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = "toctou-get",
+                Key = "race.txt",
+                Content = uploadStream,
+                ContentType = "text/plain"
+            });
+            Assert.True(put.IsSuccess);
+        }
+
+        // Simulate a concurrent DeleteObject landing between ResolveStoredObjectAsync and the
+        // lock-free content-file open: remove only the content file, leaving metadata intact so
+        // the object still resolves. Before the fix the open threw FileNotFoundException, which
+        // surfaced as an InternalError (500); after the fix it must translate to NoSuchKey (404).
+        var contentPath = FindObjectContentPath(fixture.RootPath, "toctou-get");
+        File.Delete(contentPath);
+
+        var getResult = await storageService.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = "toctou-get",
+            Key = "race.txt"
+        });
+
+        Assert.False(getResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.ObjectNotFound, getResult.Error!.Code);
+        Assert.Equal(404, getResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_CopyObject_SourceContentFileDeletedAfterResolve_ReturnsNoSuchKeyNot500()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "toctou-copy" });
+
+        await using (var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes("copy source"))) {
+            var put = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = "toctou-copy",
+                Key = "src.txt",
+                Content = uploadStream,
+                ContentType = "text/plain"
+            });
+            Assert.True(put.IsSuccess);
+        }
+
+        // CopyObject opens the source content file while holding only the destination lock, never
+        // the source lock. Deleting the source content file (metadata intact) reproduces that race;
+        // the losing copy must return NoSuchKey (404) rather than an InternalError (500).
+        var sourceContentPath = FindObjectContentPath(fixture.RootPath, "toctou-copy");
+        File.Delete(sourceContentPath);
+
+        var copyResult = await storageService.CopyObjectAsync(new CopyObjectRequest
+        {
+            SourceBucketName = "toctou-copy",
+            SourceKey = "src.txt",
+            DestinationBucketName = "toctou-copy",
+            DestinationKey = "dst.txt"
+        });
+
+        Assert.False(copyResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.ObjectNotFound, copyResult.Error!.Code);
+        Assert.Equal(404, copyResult.Error.SuggestedHttpStatusCode);
+    }
+
+    [Fact]
+    public async Task DiskStorage_GetObject_ReaderSharesDeleteSoUnderlyingFileCanBeRemovedWhileOpen()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "fileshare-delete" });
+
+        await using (var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes("still readable"))) {
+            var put = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = "fileshare-delete",
+                Key = "open.txt",
+                Content = uploadStream,
+                ContentType = "text/plain"
+            });
+            Assert.True(put.IsSuccess);
+        }
+
+        var getResult = await storageService.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = "fileshare-delete",
+            Key = "open.txt"
+        });
+        Assert.True(getResult.IsSuccess);
+
+        var contentPath = FindObjectContentPath(fixture.RootPath, "fileshare-delete");
+
+        await using var response = getResult.Value!;
+
+        // The read stream must have been opened with FileShare.Delete: on Windows, deleting (or a
+        // writer's File.Move overwrite of) the underlying file while a reader holds the handle only
+        // succeeds when the reader shares Delete. Without it this File.Delete throws IOException.
+        var exception = Record.Exception(() => File.Delete(contentPath));
+        Assert.Null(exception);
+
+        // The already-open reader keeps its handle and can still stream the full content even after
+        // the directory entry is unlinked.
+        using var reader = new StreamReader(response.Content, Encoding.UTF8, leaveOpen: false);
+        Assert.Equal("still readable", await reader.ReadToEndAsync());
+    }
 }


### PR DESCRIPTION
## Summary

Fixes two related concurrency defects in the disk storage provider's lock-free object read and copy-source open paths (issue #120).

The read-side `FileStream` opens for `GetObject`, `CopyObject`, and `UploadPartCopy` are performed **without** holding the per-object mutation lock (reads are intentionally lock-free), and readers previously opened with `FileShare.Read` only:

1. **TOCTOU delete → wrong HTTP status.** A concurrent `DeleteObject` landing between `ResolveStoredObjectAsync` and the content-file open threw `FileNotFoundException`/`DirectoryNotFoundException`, which was not translated and surfaced as **500 InternalError** where S3 requires **404 NoSuchKey**.
2. **Windows overwrite failure.** Because readers opened with `FileShare.Read` only (no `FileShare.Delete`), a concurrent `PutObject`/`CopyObject` publishing via `File.Move(temp, objectPath, overwrite: true)` over a file a reader was still streaming could fail with `IOException`, turning a legitimate overwrite into a 500 for the **writer**.

## Fix

Added a shared `TryOpenObjectReadStream(contentPath)` helper that:
- Opens with `FileShare.Read | FileShare.Delete` so a concurrent delete/rename cannot fail the open or an ongoing read, and cannot fail a writer's `File.Move` overwrite on Windows.
- Returns `null` when the file has already been removed (`FileNotFoundException`/`DirectoryNotFoundException`), letting each caller translate the lost TOCTOU race into `ObjectNotFound` (404).

Applied at all four lock-free read/copy-source open sites:
- `GetObjectCoreAsync` (read stream returned to the caller)
- `CopyObjectCoreAsync` source open (held only the destination lock)
- both `UploadPartCopy` source opens (`UploadMultipartPartAsync` copy branch and `UploadPartCopyAsync`)

The internal multipart part reads and checksum reads run on write paths under the mutation lock and are out of scope.

## Tests

Added three regression tests in `DiskStorageServiceTests`:
- `DiskStorage_GetObject_ContentFileDeletedAfterResolve_ReturnsNoSuchKeyNot500` — deleting only the content file (metadata intact) reproduces the exact TOCTOU state; GET now returns `NoSuchKey`/404 instead of throwing.
- `DiskStorage_CopyObject_SourceContentFileDeletedAfterResolve_ReturnsNoSuchKeyNot500` — same for the copy-source path.
- `DiskStorage_GetObject_ReaderSharesDeleteSoUnderlyingFileCanBeRemovedWhileOpen` — asserts the reader shares Delete (the underlying file can be deleted while the reader keeps streaming; on Windows this only succeeds with `FileShare.Delete`).

Build clean (0 warnings), full test project green: **1138 passed**.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)
