### PR TITLE
fix: align bucket/quota/object-lock error codes with AWS (#164)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
@@ -41,8 +41,14 @@ public enum StorageErrorCode
     /// <summary>A concurrent modification was detected on the same object version.</summary>
     VersionConflict,
 
-    /// <summary>A bucket with the specified name already exists.</summary>
+    /// <summary>A bucket with the specified name already exists and is owned by another account.</summary>
     BucketAlreadyExists,
+
+    /// <summary>A bucket with the specified name already exists and is owned by the requesting account (idempotent re-create).</summary>
+    BucketAlreadyOwnedByYou,
+
+    /// <summary>The bucket is in a state that does not permit the requested operation (e.g., enabling Object Lock without versioning).</summary>
+    InvalidBucketState,
 
     /// <summary>The bucket cannot be deleted because it still contains objects.</summary>
     BucketNotEmpty,

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -4186,6 +4186,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.MethodNotAllowed => StatusCodes.Status405MethodNotAllowed,
             StorageErrorCode.VersionConflict => StatusCodes.Status409Conflict,
             StorageErrorCode.BucketAlreadyExists => StatusCodes.Status409Conflict,
+            StorageErrorCode.BucketAlreadyOwnedByYou => StatusCodes.Status409Conflict,
+            StorageErrorCode.InvalidBucketState => StatusCodes.Status409Conflict,
             StorageErrorCode.BucketNotEmpty => StatusCodes.Status409Conflict,
             StorageErrorCode.MultipartConflict => StatusCodes.Status409Conflict,
             StorageErrorCode.NoSuchUpload => StatusCodes.Status404NotFound,
@@ -4195,7 +4197,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.Throttled => StatusCodes.Status429TooManyRequests,
             StorageErrorCode.ProviderUnavailable => StatusCodes.Status503ServiceUnavailable,
             StorageErrorCode.UnsupportedCapability => StatusCodes.Status501NotImplemented,
-            StorageErrorCode.QuotaExceeded => StatusCodes.Status413PayloadTooLarge,
+            StorageErrorCode.QuotaExceeded => StatusCodes.Status400BadRequest,
             StorageErrorCode.ObjectLocked => StatusCodes.Status403Forbidden,
             _ => StatusCodes.Status500InternalServerError
         };
@@ -4227,6 +4229,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.MethodNotAllowed => "MethodNotAllowed",
             StorageErrorCode.VersionConflict => "OperationAborted",
             StorageErrorCode.BucketAlreadyExists => "BucketAlreadyExists",
+            StorageErrorCode.BucketAlreadyOwnedByYou => "BucketAlreadyOwnedByYou",
+            StorageErrorCode.InvalidBucketState => "InvalidBucketState",
             StorageErrorCode.BucketNotEmpty => "BucketNotEmpty",
             StorageErrorCode.MultipartConflict => "InvalidRequest",
             StorageErrorCode.NoSuchUpload => "NoSuchUpload",

--- a/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
@@ -2003,7 +2003,9 @@ internal sealed class OrchestratedStorageService(
         var replicaResult = await replicaBackend.CreateBucketAsync(request, cancellationToken);
         ObserveResult(replicaBackend, replicaResult);
         if (!replicaResult.IsSuccess) {
-            if (replicaResult.Error?.Code != StorageErrorCode.BucketAlreadyExists) {
+            // A replica bucket that already exists (regardless of ownership-specific code) is not a
+            // failure for replication — it is the idempotent case; fall through to refresh/versioning.
+            if (replicaResult.Error?.Code is not (StorageErrorCode.BucketAlreadyExists or StorageErrorCode.BucketAlreadyOwnedByYou)) {
                 return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket create did not succeed.");
             }
 

--- a/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
@@ -84,7 +84,9 @@ internal sealed class StorageReplicaRepairService(
         var replicaResult = await replicaBackend.CreateBucketAsync(request, cancellationToken);
         ObserveResult(replicaBackend, replicaResult);
         if (!replicaResult.IsSuccess) {
-            if (replicaResult.Error?.Code != StorageErrorCode.BucketAlreadyExists) {
+            // A replica bucket that already exists (regardless of ownership-specific code) is not a
+            // failure for repair — it is the idempotent case; fall through to refresh/versioning.
+            if (replicaResult.Error?.Code is not (StorageErrorCode.BucketAlreadyExists or StorageErrorCode.BucketAlreadyOwnedByYou)) {
                 return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket create did not succeed.");
             }
 

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -165,10 +165,14 @@ internal sealed class DiskStorageService(
 
         var bucketPath = GetBucketPath(request.BucketName);
         if (Directory.Exists(bucketPath)) {
+            // The disk backend is single-tenant: an existing bucket directory is always owned by
+            // the requesting account, so this is an idempotent re-create. AWS reports this as
+            // BucketAlreadyOwnedByYou (409 outside us-east-1); BucketAlreadyExists is reserved for
+            // names owned by a *different* account, which cannot occur here.
             return StorageResult<BucketInfo>.Failure(new StorageError
             {
-                Code = StorageErrorCode.BucketAlreadyExists,
-                Message = $"Bucket '{request.BucketName}' already exists.",
+                Code = StorageErrorCode.BucketAlreadyOwnedByYou,
+                Message = $"Your previous request to create the named bucket '{request.BucketName}' succeeded and you already own it.",
                 BucketName = request.BucketName,
                 ProviderName = options.ProviderName
             });
@@ -1057,9 +1061,11 @@ internal sealed class DiskStorageService(
         using var bucketMutationLock = await AcquireBucketMutationLockAsync(bucketPath, cancellationToken);
         var existingMetadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
         if (existingMetadata.VersioningStatus != BucketVersioningStatus.Enabled) {
+            // AWS surfaces this precondition as InvalidBucketState (409), not OperationAborted: the
+            // bucket must have versioning enabled before Object Lock can be configured.
             return StorageResult<ObjectLockConfiguration>.Failure(new StorageError
             {
-                Code = StorageErrorCode.VersionConflict,
+                Code = StorageErrorCode.InvalidBucketState,
                 Message = $"Object Lock configuration requires versioning to be enabled on bucket '{request.BucketName}'.",
                 BucketName = request.BucketName,
                 ProviderName = options.ProviderName,

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
@@ -45,8 +45,8 @@ internal static class S3ErrorTranslator
                  $"Bucket '{bucketName}' already exists (owned by another account)."),
 
             "BucketAlreadyOwnedByYou" =>
-                (StorageErrorCode.BucketAlreadyExists,
-                 $"Bucket '{bucketName}' already exists and is owned by you."),
+                (StorageErrorCode.BucketAlreadyOwnedByYou,
+                 $"Your previous request to create the named bucket '{bucketName}' succeeded and you already own it."),
 
             "BadDigest" =>
                 (StorageErrorCode.InvalidChecksum,

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -819,6 +819,28 @@ public sealed class DiskStorageServiceTests
     }
 
     [Fact]
+    public async Task DiskStorage_CreateBucket_WhenAlreadyExists_ReturnsBucketAlreadyOwnedByYou()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        const string bucketName = "owned-by-you";
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = bucketName
+        })).IsSuccess);
+
+        var secondCreate = await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = bucketName
+        });
+
+        Assert.False(secondCreate.IsSuccess);
+        // Single-tenant disk backend: an owner re-create is BucketAlreadyOwnedByYou, not BucketAlreadyExists.
+        Assert.Equal(StorageErrorCode.BucketAlreadyOwnedByYou, secondCreate.Error!.Code);
+    }
+
+    [Fact]
     public async Task DiskStorage_BucketMetadataDeleteOperations_PreserveOtherConfigurationsUntilEmpty()
     {
         await using var fixture = new DiskStorageFixture();
@@ -4777,7 +4799,8 @@ public sealed class DiskStorageServiceTests
         });
 
         Assert.False(putObjectLock.IsSuccess);
-        Assert.Equal(StorageErrorCode.VersionConflict, putObjectLock.Error!.Code);
+        // AWS surfaces this precondition as InvalidBucketState (not OperationAborted / VersionConflict).
+        Assert.Equal(StorageErrorCode.InvalidBucketState, putObjectLock.Error!.Code);
         Assert.Equal(409, putObjectLock.Error.SuggestedHttpStatusCode);
         Assert.Contains("versioning", putObjectLock.Error.Message, StringComparison.OrdinalIgnoreCase);
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -2573,8 +2573,11 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         var errorDocument = XDocument.Parse(await secondResponse.Content.ReadAsStringAsync());
         S3XmlTestHelper.AssertRoot(errorDocument, "Error");
-        Assert.Equal("BucketAlreadyExists", GetRequiredElementValue(errorDocument, "Code"));
-        Assert.Contains("already exists", GetRequiredElementValue(errorDocument, "Message"), StringComparison.OrdinalIgnoreCase);
+        // The disk backend is single-tenant, so re-creating an existing bucket is an idempotent
+        // owner re-create. AWS reports this as BucketAlreadyOwnedByYou, not BucketAlreadyExists
+        // (which is reserved for names owned by a different account).
+        Assert.Equal("BucketAlreadyOwnedByYou", GetRequiredElementValue(errorDocument, "Code"));
+        Assert.Contains("you already own it", GetRequiredElementValue(errorDocument, "Message"), StringComparison.OrdinalIgnoreCase);
         Assert.Equal("/conflict-bucket", GetRequiredElementValue(errorDocument, "Resource"));
     }
 
@@ -5207,7 +5210,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 """, Encoding.UTF8, "application/xml")
         };
 
-        await AssertErrorResponseAsync(await client.SendAsync(putObjectLockRequest), HttpStatusCode.Conflict, "OperationAborted");
+        // AWS returns InvalidBucketState (409) for enabling Object Lock without versioning, not OperationAborted.
+        await AssertErrorResponseAsync(await client.SendAsync(putObjectLockRequest), HttpStatusCode.Conflict, "InvalidBucketState");
     }
 
     [Fact]
@@ -7358,6 +7362,38 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         Assert.Equal("InvalidRequest", GetRequiredElementValue(document, "Code"));
         Assert.Contains("x-amz-server-side-encryption-aws-kms-key-id", GetRequiredElementValue(document, "Message"));
         Assert.Null(storageService.LastPutObjectRequest);
+    }
+
+    [Fact]
+    public async Task S3CompatiblePutObject_WhenQuotaExceeded_ReturnsEntityTooLargeWith400()
+    {
+        var storageService = new RecordingStorageService
+        {
+            PutObjectFailure = new StorageError
+            {
+                Code = StorageErrorCode.QuotaExceeded,
+                Message = "A storage quota was exceeded.",
+                BucketName = "quota-bucket",
+                ObjectKey = "docs/over-quota.txt",
+                ProviderName = "recording"
+            }
+        };
+        await using var isolatedClient = await CreateStorageServiceIsolatedClientAsync(storageService);
+        using var client = isolatedClient.Client;
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/quota-bucket/docs/over-quota.txt")
+        {
+            Content = new StringContent("payload", Encoding.UTF8, "text/plain")
+        };
+
+        var response = await client.SendAsync(request);
+
+        // AWS EntityTooLarge is HTTP 400, not 413.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("EntityTooLarge", GetRequiredElementValue(document, "Code"));
     }
 
     [Fact]
@@ -10372,9 +10408,15 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
                     customerEncryption: ToCustomerEncryptionInfo(request.DestinationCustomerEncryption))));
         }
 
+        public StorageError? PutObjectFailure { get; set; }
+
         public ValueTask<StorageResult<ObjectInfo>> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = default)
         {
             LastPutObjectRequest = request;
+
+            if (PutObjectFailure is not null) {
+                return new ValueTask<StorageResult<ObjectInfo>>(StorageResult<ObjectInfo>.Failure(PutObjectFailure));
+            }
 
             return new ValueTask<StorageResult<ObjectInfo>>(StorageResult<ObjectInfo>.Success(
                 PutObjectResult ?? CreateObjectInfo(

--- a/src/IntegratedS3/IntegratedS3.Tests/S3StorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3StorageServiceTests.cs
@@ -292,6 +292,21 @@ public sealed class S3StorageServiceTests
         Assert.Equal(StorageErrorCode.BucketAlreadyExists, result.Error!.Code);
     }
 
+    [Fact]
+    public async Task CreateBucketAsync_TranslatesBucketAlreadyOwnedByYou_ToDistinctCode()
+    {
+        var fake = new FakeS3Client();
+        fake.CreateBucketException = new AmazonS3Exception(
+            "Bucket already owned by you.", ErrorType.Sender, "BucketAlreadyOwnedByYou", "req-1", HttpStatusCode.Conflict);
+
+        var svc = BuildService(fake);
+        var result = await svc.CreateBucketAsync(new CreateBucketRequest { BucketName = "my-bucket" });
+
+        Assert.False(result.IsSuccess);
+        // Must be distinguished from BucketAlreadyExists (a name owned by another account).
+        Assert.Equal(StorageErrorCode.BucketAlreadyOwnedByYou, result.Error!.Code);
+    }
+
     // --- HeadBucketAsync ---
 
     [Fact]

--- a/src/IntegratedS3/WebUi.BlazorWasm/BlazorWasmSampleDataSeeder.cs
+++ b/src/IntegratedS3/WebUi.BlazorWasm/BlazorWasmSampleDataSeeder.cs
@@ -24,7 +24,7 @@ internal sealed class BlazorWasmSampleDataSeeder(IStorageService storageService)
             BucketName = BlazorWasmSampleDefaults.BucketName
         }, cancellationToken);
 
-        if (!createBucketResult.IsSuccess && createBucketResult.Error?.Code != StorageErrorCode.BucketAlreadyExists) {
+        if (!createBucketResult.IsSuccess && createBucketResult.Error?.Code is not (StorageErrorCode.BucketAlreadyExists or StorageErrorCode.BucketAlreadyOwnedByYou)) {
             throw new InvalidOperationException($"Unable to seed bucket '{BlazorWasmSampleDefaults.BucketName}': {createBucketResult.Error?.Message}");
         }
 

--- a/src/IntegratedS3/WebUi.MvcRazor/MvcRazorSampleDataSeeder.cs
+++ b/src/IntegratedS3/WebUi.MvcRazor/MvcRazorSampleDataSeeder.cs
@@ -24,7 +24,7 @@ internal sealed class MvcRazorSampleDataSeeder(IStorageService storageService) :
             BucketName = MvcRazorSampleDefaults.BucketName
         }, cancellationToken);
 
-        if (!createBucketResult.IsSuccess && createBucketResult.Error?.Code != StorageErrorCode.BucketAlreadyExists) {
+        if (!createBucketResult.IsSuccess && createBucketResult.Error?.Code is not (StorageErrorCode.BucketAlreadyExists or StorageErrorCode.BucketAlreadyOwnedByYou)) {
             throw new InvalidOperationException($"Unable to seed bucket '{MvcRazorSampleDefaults.BucketName}': {createBucketResult.Error?.Message}");
         }
 


### PR DESCRIPTION
## Summary

Fixes the three error-code granularity divergences from AWS S3 described in #164:

1. **`BucketAlreadyOwnedByYou` now distinguished.** Added a dedicated `StorageErrorCode.BucketAlreadyOwnedByYou`. The single-tenant disk backend reports an idempotent owner re-create (`Directory.Exists`) as `BucketAlreadyOwnedByYou` (HTTP 409), and the S3 provider translator maps the SDK's `"BucketAlreadyOwnedByYou"` error to it. `BucketAlreadyExists` stays reserved for names owned by another account (still returned when the upstream reports `BucketAlreadyExists`). Endpoint status/code tables map the new code to `409` / `"BucketAlreadyOwnedByYou"`.
2. **`QuotaExceeded -> EntityTooLarge` is now HTTP 400** (was `413`). AWS `EntityTooLarge` is a `400`.
3. **Object-lock-requires-versioning now returns `InvalidBucketState` (409)** instead of `VersionConflict`/`OperationAborted`, matching AWS.

## Ripple fixes

The idempotent bucket-create guards that previously only accepted `BucketAlreadyExists` now also accept `BucketAlreadyOwnedByYou`, so warm-store re-creates on the disk backend keep working:
- `OrchestratedStorageService.WriteReplicaBucketCreateAsync`
- `StorageReplicaRepairService.WriteReplicaBucketCreateAsync`
- `MvcRazorSampleDataSeeder` / `BlazorWasmSampleDataSeeder`

## Tests

- Disk: owner re-create -> `BucketAlreadyOwnedByYou`; object-lock-without-versioning -> `InvalidBucketState` (updated existing assertion).
- S3 translator: `"BucketAlreadyOwnedByYou"` -> distinct code (new), alongside the existing `"BucketAlreadyExists"` case.
- HTTP endpoints: duplicate create -> `BucketAlreadyOwnedByYou`; object-lock-without-versioning -> `InvalidBucketState` (updated); `QuotaExceeded` -> `EntityTooLarge` with `400` (new).

Full suite green: **1138 passed, 0 failed**. Build clean (0 warnings).

Closes #164

🤖 Generated with [Claude Code](https://claude.com/claude-code)