### PR TITLE
fix: reject duplicate Authorization-header params with 400 (#118)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Protocol/S3SigV4RequestParser.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3SigV4RequestParser.cs
@@ -87,14 +87,11 @@ public static class S3SigV4RequestParser
         }
 
         var parameterSection = trimmed[AlgorithmName.Length..].TrimStart();
-        var parameters = parameterSection.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(static part => part.Split('=', 2, StringSplitOptions.TrimEntries))
-            .ToDictionary(
-                static parts => parts[0],
-                static parts => parts.Length > 1 ? parts[1] : string.Empty,
-                StringComparer.Ordinal);
+        if (!TryBuildAuthorizationParameters(parameterSection, out var parameters, out error)) {
+            return true;
+        }
 
-        if (!parameters.TryGetValue("Credential", out var credential)
+        if (!parameters!.TryGetValue("Credential", out var credential)
             || !TryParseCredentialScope(credential, out var credentialScope, out error)) {
             error ??= "The authorization header must include a valid Credential component.";
             return true;
@@ -224,6 +221,26 @@ public static class S3SigV4RequestParser
         return true;
     }
 
+    private static bool TryBuildAuthorizationParameters(string parameterSection, out Dictionary<string, string>? parameters, out string? error)
+    {
+        parameters = new Dictionary<string, string>(StringComparer.Ordinal);
+        error = null;
+
+        foreach (var part in parameterSection.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)) {
+            var pair = part.Split('=', 2, StringSplitOptions.TrimEntries);
+            var key = pair[0];
+            var value = pair.Length > 1 ? pair[1] : string.Empty;
+
+            if (!parameters.TryAdd(key, value)) {
+                parameters = null;
+                error = "The authorization header contains duplicate parameters.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static bool TryParseCredentialScope(string? value, out S3SigV4CredentialScope? credentialScope, out string? error)
     {
         credentialScope = null;
@@ -286,14 +303,11 @@ public static class S3SigV4RequestParser
         error = null;
 
         var parameterSection = trimmed[SigV4aAlgorithmName.Length..].TrimStart();
-        var parameters = parameterSection.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-            .Select(static part => part.Split('=', 2, StringSplitOptions.TrimEntries))
-            .ToDictionary(
-                static parts => parts[0],
-                static parts => parts.Length > 1 ? parts[1] : string.Empty,
-                StringComparer.Ordinal);
+        if (!TryBuildAuthorizationParameters(parameterSection, out var parameters, out error)) {
+            return true;
+        }
 
-        if (!parameters.TryGetValue("Credential", out var credential)
+        if (!parameters!.TryGetValue("Credential", out var credential)
             || !TryParseSigV4aCredentialScope(credential, out var credentialScope, out error)) {
             error ??= "The authorization header must include a valid Credential component.";
             return true;

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ProtocolTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ProtocolTests.cs
@@ -160,6 +160,39 @@ public sealed class IntegratedS3SigV4ProtocolTests
     }
 
     [Fact]
+    public void AuthorizationHeaderParser_RejectsDuplicateParametersWithoutThrowing()
+    {
+        // A crafted header with two Credential parameters must be reported through the
+        // error out-parameter (yielding a 400), not surface as an unhandled ArgumentException (500).
+        // Regression for issue #118.
+        const string header = "AWS4-HMAC-SHA256 " +
+            "Credential=AKID/20240101/us-east-1/s3/aws4_request, " +
+            "Credential=OTHER/20240101/us-east-1/s3/aws4_request, " +
+            "SignedHeaders=host, Signature=abc";
+
+        var recognized = S3SigV4RequestParser.TryParseAuthorizationHeader(header, out var authorization, out var error);
+
+        Assert.True(recognized);
+        Assert.Null(authorization);
+        Assert.Equal("The authorization header contains duplicate parameters.", error);
+    }
+
+    [Fact]
+    public void SigV4aAuthorizationHeaderParser_RejectsDuplicateParametersWithoutThrowing()
+    {
+        // The SigV4a header path shares the same duplicate-key defect. Regression for issue #118.
+        const string header = "AWS4-ECDSA-P256-SHA256 " +
+            "Credential=AKID/20240101/s3/aws4_request, " +
+            "Signature=abc, Signature=def, SignedHeaders=host";
+
+        var recognized = S3SigV4RequestParser.TryParseAuthorizationHeader(header, out var authorization, out var error);
+
+        Assert.True(recognized);
+        Assert.Null(authorization);
+        Assert.Equal("The authorization header contains duplicate parameters.", error);
+    }
+
+    [Fact]
     public void Presigner_BuildsExpectedQueryParametersAndExpiry()
     {
         var signedAtUtc = new DateTimeOffset(2026, 3, 11, 18, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
## Summary

`S3SigV4RequestParser` built its Authorization-header parameter dictionary with `Enumerable.ToDictionary` using a plain key selector, which throws `System.ArgumentException` when two entries produce the same key. A crafted header with a duplicated parameter (e.g. two `Signature=` or two `Credential=`) therefore escaped the `Try*` contract as an unhandled exception, propagated through the endpoint filter (which logs and re-throws), and surfaced as **HTTP 500** instead of the intended **400 `AuthorizationHeaderMalformed`**.

This is a low-effort, unauthenticated way to force server errors — the reason it was labeled `security`.

## Fix

- Added a shared `TryBuildAuthorizationParameters` helper that builds the dictionary with `Dictionary.TryAdd`. On a duplicate key it reports the problem through the `error` out-parameter (still returning `true`) instead of throwing.
- Applied to **both** the SigV4 (`AWS4-HMAC-SHA256`) and SigV4a (`AWS4-ECDSA-P256-SHA256`) header parsers.
- The authenticator already maps a non-null `error` with a null authorization to a clean `400 AuthorizationHeaderMalformed` (`AwsSignatureV4RequestAuthenticator.ValidateHeaderAuthorizationAsync`), so no changes were needed there.

## Tests

Added two regression tests in `IntegratedS3SigV4ProtocolTests`:
- Duplicated `Credential` on the SigV4 path → `error` set, no exception.
- Duplicated `Signature` on the SigV4a path → `error` set, no exception.

Verified **fails-before** (both threw `System.ArgumentException`) and **passes-after**. Full suite green: **1144 passed, 0 failed**.

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)