### PR TITLE
fix: emit Content-Range on 416 and honor Range on HEAD (#162)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageError.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageError.cs
@@ -51,6 +51,13 @@ public sealed class StorageError
     public int? SuggestedHttpStatusCode { get; init; }
 
     /// <summary>
+    /// Gets the total size, in bytes, of the resource involved in the error, if known. Used to emit
+    /// the AWS-required <c>Content-Range: bytes */&lt;size&gt;</c> header on an unsatisfiable range
+    /// (<see cref="StorageErrorCode.InvalidRange"/>) response.
+    /// </summary>
+    public long? ResourceSize { get; init; }
+
+    /// <summary>
     /// Creates a <see cref="StorageError"/> with <see cref="StorageErrorCode.UnsupportedCapability"/>
     /// and an HTTP 501 suggested status code.
     /// </summary>

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -1584,8 +1584,47 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return TypedResults.StatusCode(StatusCodes.Status304NotModified);
                 }
 
-                httpContext.Response.ContentLength = objectInfo.ContentLength;
                 httpContext.Response.ContentType = objectInfo.ContentType ?? "application/octet-stream";
+
+                // AWS honors the Range header on HEAD, mirroring GET: a satisfiable range yields 206
+                // with Content-Range and the ranged Content-Length (no body); an unsatisfiable range
+                // yields 416 with Content-Range: bytes */<size>. A malformed or multi-range header is
+                // ignored (the full 200 response is returned), matching S3.
+                var rawRange = httpContext.Request.Headers.Range.ToString();
+                if (!string.IsNullOrWhiteSpace(rawRange)) {
+                    ObjectRange[] parsedRanges;
+                    try {
+                        parsedRanges = ParseMultipleRangeHeaders(rawRange);
+                    }
+                    catch (FormatException) {
+                        parsedRanges = [];
+                    }
+
+                    if (parsedRanges.Length == 1) {
+                        var normalizedRange = NormalizeRangeForResponse(parsedRanges[0], objectInfo.ContentLength, out var unsatisfiable);
+                        if (unsatisfiable) {
+                            // HEAD carries no body, so return a header-only 416 (mirroring AWS) rather
+                            // than the XML error document ToErrorResult would emit for GET.
+                            httpContext.Response.Headers["x-amz-request-id"] = httpContext.TraceIdentifier;
+                            httpContext.Response.Headers["x-amz-id-2"] = httpContext.TraceIdentifier;
+                            httpContext.Response.Headers[ErrorCodeHeaderName] = "InvalidRange";
+                            httpContext.Response.Headers[ErrorMessageHeaderName] = "The requested range is not satisfiable.";
+                            httpContext.Response.Headers.ContentRange = $"bytes */{objectInfo.ContentLength}";
+                            httpContext.Response.ContentLength = 0;
+                            return TypedResults.StatusCode(StatusCodes.Status416RangeNotSatisfiable);
+                        }
+
+                        if (normalizedRange is not null) {
+                            httpContext.Response.Headers.ContentRange =
+                                $"bytes {normalizedRange.Start}-{normalizedRange.End}/{objectInfo.ContentLength}";
+                            httpContext.Response.ContentLength =
+                                normalizedRange.End!.Value - normalizedRange.Start!.Value + 1;
+                            return TypedResults.StatusCode(StatusCodes.Status206PartialContent);
+                        }
+                    }
+                }
+
+                httpContext.Response.ContentLength = objectInfo.ContentLength;
 
                 return TypedResults.Ok();
             }, cancellationToken);
@@ -6808,6 +6847,55 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         };
     }
 
+    /// <summary>
+    /// Resolves a requested byte range against a known object size using the same semantics as the
+    /// storage providers. Returns the normalized (inclusive start/end) range on success, or
+    /// <see langword="null"/> with <paramref name="unsatisfiable"/> set when the range cannot be
+    /// satisfied. Mirrors <c>DiskStorageService.NormalizeRange</c> so HEAD range handling matches GET.
+    /// </summary>
+    private static ObjectRange? NormalizeRangeForResponse(ObjectRange requestedRange, long contentLength, out bool unsatisfiable)
+    {
+        unsatisfiable = false;
+
+        if (contentLength <= 0) {
+            unsatisfiable = true;
+            return null;
+        }
+
+        long start;
+        long end;
+
+        if (requestedRange.Start is null) {
+            var suffixLength = requestedRange.End;
+            if (suffixLength is null || suffixLength <= 0) {
+                unsatisfiable = true;
+                return null;
+            }
+
+            var effectiveLength = Math.Min(suffixLength.Value, contentLength);
+            start = contentLength - effectiveLength;
+            end = contentLength - 1;
+        }
+        else {
+            start = requestedRange.Start.Value;
+            end = requestedRange.End ?? contentLength - 1;
+
+            if (start < 0 || end < start) {
+                unsatisfiable = true;
+                return null;
+            }
+
+            if (start >= contentLength) {
+                unsatisfiable = true;
+                return null;
+            }
+
+            end = Math.Min(end, contentLength - 1);
+        }
+
+        return new ObjectRange { Start = start, End = end };
+    }
+
     private static ObjectRange? ParseCopySourceRangeHeader(string? rangeHeader)
     {
         var range = ParseRangeHeader(rangeHeader);
@@ -8609,6 +8697,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
         if (error.IsDeleteMarker) {
             httpResponse.Headers[DeleteMarkerHeaderName] = "true";
+        }
+
+        // AWS requires an unsatisfiable range (416) to advertise the resource's total size via
+        // Content-Range: bytes */<size> so clients can retry with a valid range.
+        if (error.Code == StorageErrorCode.InvalidRange && error.ResourceSize is { } resourceSize && resourceSize >= 0) {
+            httpResponse.Headers.ContentRange = $"bytes */{resourceSize}";
         }
     }
 

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -6051,7 +6051,7 @@ internal sealed class DiskStorageService(
         }
 
         if (contentLength <= 0) {
-            error = InvalidRange("Cannot satisfy a range request for an empty object.", bucketName, objectKey);
+            error = InvalidRange("Cannot satisfy a range request for an empty object.", bucketName, objectKey, contentLength);
             return null;
         }
 
@@ -6061,7 +6061,7 @@ internal sealed class DiskStorageService(
         if (requestedRange.Start is null) {
             var suffixLength = requestedRange.End;
             if (suffixLength is null || suffixLength <= 0) {
-                error = InvalidRange("The requested suffix range is invalid.", bucketName, objectKey);
+                error = InvalidRange("The requested suffix range is invalid.", bucketName, objectKey, contentLength);
                 return null;
             }
 
@@ -6074,12 +6074,12 @@ internal sealed class DiskStorageService(
             end = requestedRange.End ?? contentLength - 1;
 
             if (start < 0 || end < start) {
-                error = InvalidRange("The requested byte range is invalid.", bucketName, objectKey);
+                error = InvalidRange("The requested byte range is invalid.", bucketName, objectKey, contentLength);
                 return null;
             }
 
             if (start >= contentLength) {
-                error = InvalidRange("The requested range starts beyond the end of the object.", bucketName, objectKey);
+                error = InvalidRange("The requested range starts beyond the end of the object.", bucketName, objectKey, contentLength);
                 return null;
             }
 
@@ -6093,7 +6093,7 @@ internal sealed class DiskStorageService(
         };
     }
 
-    private static StorageError InvalidRange(string message, string bucketName, string objectKey)
+    private static StorageError InvalidRange(string message, string bucketName, string objectKey, long resourceSize)
     {
         return new StorageError
         {
@@ -6101,7 +6101,8 @@ internal sealed class DiskStorageService(
             Message = message,
             BucketName = bucketName,
             ObjectKey = objectKey,
-            SuggestedHttpStatusCode = 416
+            SuggestedHttpStatusCode = 416,
+            ResourceSize = resourceSize
         };
     }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -2661,6 +2661,66 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task GetObject_WithUnsatisfiableRange_Returns416WithContentRange()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/range-416-bucket", content: null);
+        await client.PutAsync(
+            "/integrated-s3/buckets/range-416-bucket/objects/docs/range.txt",
+            new StringContent("hello integrated s3", Encoding.UTF8, "text/plain")); // 19 bytes
+
+        using var request = new HttpRequestMessage(HttpMethod.Get, "/integrated-s3/buckets/range-416-bucket/objects/docs/range.txt");
+        request.Headers.TryAddWithoutValidation("Range", "bytes=100-200");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.RequestedRangeNotSatisfiable, response.StatusCode);
+        Assert.Equal("bytes */19", response.Content.Headers.ContentRange?.ToString());
+    }
+
+    [Fact]
+    public async Task HeadObject_WithUnsatisfiableRange_Returns416WithContentRange()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/head-range-416-bucket", content: null);
+        await client.PutAsync(
+            "/integrated-s3/buckets/head-range-416-bucket/objects/docs/range.txt",
+            new StringContent("hello integrated s3", Encoding.UTF8, "text/plain")); // 19 bytes
+
+        using var request = new HttpRequestMessage(HttpMethod.Head, "/integrated-s3/buckets/head-range-416-bucket/objects/docs/range.txt");
+        request.Headers.TryAddWithoutValidation("Range", "bytes=100-200");
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.RequestedRangeNotSatisfiable, response.StatusCode);
+        Assert.Equal("bytes */19", response.Content.Headers.ContentRange?.ToString());
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
+    public async Task HeadObject_WithSatisfiableRange_Returns206WithContentRangeAndRangedLengthAndEmptyBody()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/head-range-206-bucket", content: null);
+        await client.PutAsync(
+            "/integrated-s3/buckets/head-range-206-bucket/objects/docs/range.txt",
+            new StringContent("hello integrated s3", Encoding.UTF8, "text/plain")); // 19 bytes
+
+        using var request = new HttpRequestMessage(HttpMethod.Head, "/integrated-s3/buckets/head-range-206-bucket/objects/docs/range.txt");
+        request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(6, 15);
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.PartialContent, response.StatusCode);
+        Assert.Equal("bytes 6-15/19", response.Content.Headers.ContentRange?.ToString());
+        Assert.Equal(10, response.Content.Headers.ContentLength);
+        Assert.Empty(await response.Content.ReadAsByteArrayAsync());
+    }
+
+    [Fact]
     public async Task GetObject_WithIfNoneMatchHeader_ReturnsNotModified()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary
Closes #162. Fixes two AWS S3 range-handling compliance gaps in the S3-compatible server.

### 1. 416 responses now emit `Content-Range: bytes */<size>`
An unsatisfiable range correctly returned `416 InvalidRange` but omitted the AWS-required `Content-Range: bytes */<total-length>` header. Fixed by:
- Adding a nullable `ResourceSize` to `StorageError` (the object's total size).
- Populating it from the Disk provider's `NormalizeRange`/`InvalidRange` paths.
- Emitting `Content-Range: bytes */<size>` from `ApplyStorageErrorHeaders` on every `InvalidRange` (416), which covers both the GET and HEAD error paths.

### 2. HEAD now honors the `Range` header
`HeadObjectAsync` previously ignored `Range`, returning `200` + full `Content-Length` where AWS mirrors GET. Now:
- A satisfiable single range → `206 PartialContent` with `Content-Range: bytes start-end/total` and the ranged `Content-Length` (no body).
- An unsatisfiable range → header-only `416` with `Content-Range: bytes */<size>` (no body, as HEAD carries none).
- A malformed or multi-range header is ignored (full `200`), matching S3.

## Tests
Added regression tests to `IntegratedS3HttpEndpointsTests` (verified fail-before / pass-after):
- `GetObject_WithUnsatisfiableRange_Returns416WithContentRange`
- `HeadObject_WithUnsatisfiableRange_Returns416WithContentRange`
- `HeadObject_WithSatisfiableRange_Returns206WithContentRangeAndRangedLengthAndEmptyBody`

Full suite: 1145 passed, 0 failed. Build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)