### PR TITLE
fix: derive object & multipart-part ETags from content instead of size+mtime (#105)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -1881,7 +1881,7 @@ internal sealed class DiskStorageService(
             yield return new MultipartUploadPart
             {
                 PartNumber = partNumber,
-                ETag = BuildETag(partInfo),
+                ETag = BuildPartETag(actualChecksums),
                 ContentLength = partInfo.Length,
                 LastModifiedUtc = partInfo.LastWriteTimeUtc,
                 Checksums = CreateMultipartPartResponseChecksums(
@@ -2728,7 +2728,7 @@ internal sealed class DiskStorageService(
         return StorageResult<MultipartUploadPart>.Success(new MultipartUploadPart
         {
             PartNumber = request.PartNumber,
-            ETag = BuildETag(partInfo),
+            ETag = BuildPartETag(actualChecksums),
             ContentLength = partInfo.Length,
             LastModifiedUtc = partInfo.LastWriteTimeUtc,
             Checksums = CreateMultipartPartResponseChecksums(
@@ -2865,7 +2865,7 @@ internal sealed class DiskStorageService(
         return StorageResult<MultipartUploadPart>.Success(new MultipartUploadPart
         {
             PartNumber = request.PartNumber,
-            ETag = BuildETag(partInfo),
+            ETag = BuildPartETag(actualChecksums),
             ContentLength = partInfo.Length,
             LastModifiedUtc = partInfo.LastWriteTimeUtc,
             Checksums = CreateMultipartPartResponseChecksums(
@@ -2953,6 +2953,10 @@ internal sealed class DiskStorageService(
             ? new List<string>(request.Parts.Count)
             : null;
 
+        // Base64 MD5 of each part's bytes, in part order. Used to synthesize the S3 multipart object
+        // ETag "<hex(MD5(concat(partMd5Bytes)))>-<partCount>" independently of the checksum algorithm.
+        var partMd5Checksums = new List<string>(request.Parts.Count);
+
         // Validate the client-supplied part list before consuming it. AWS requires parts to be
         // listed in strictly ascending part-number order with no duplicates, and each part number
         // must fall within the 1..10000 range. These checks must run against the caller's original
@@ -3011,7 +3015,10 @@ internal sealed class DiskStorageService(
                         }
                     }
 
-                    var actualETag = BuildETag(new FileInfo(partPath));
+                    // Derive both the part ETag and the per-part MD5 (for the composite object ETag)
+                    // from the part's content, so completion no longer depends on filesystem mtime.
+                    var actualPartChecksums = await ComputeChecksumsAsync(partPath, cancellationToken);
+                    var actualETag = BuildPartETag(actualPartChecksums);
                     if (!string.Equals(NormalizeETag(requestedPart.ETag), NormalizeETag(actualETag), StringComparison.Ordinal)) {
                         return StorageResult<ObjectInfo>.Failure(InvalidPart(
                             $"The ETag supplied for part '{requestedPart.PartNumber}' does not match the ETag of the uploaded part.",
@@ -3019,11 +3026,7 @@ internal sealed class DiskStorageService(
                             request.Key));
                     }
 
-                    IReadOnlyDictionary<string, string>? actualPartChecksums = null;
-                    if (compositePartChecksums is not null
-                        || (requestedPart.Checksums is not null && requestedPart.Checksums.Count > 0)) {
-                        actualPartChecksums = await ComputeChecksumsAsync(partPath, cancellationToken);
-                    }
+                    partMd5Checksums.Add(actualPartChecksums[Md5ChecksumAlgorithm]);
 
                     var partChecksumValidationError = ValidateRequestedChecksums(requestedPart.Checksums, actualPartChecksums, request.BucketName, request.Key);
                     if (partChecksumValidationError is not null) {
@@ -3061,6 +3064,9 @@ internal sealed class DiskStorageService(
                     [uploadChecksumAlgorithm!] = BuildCompositeChecksum(uploadChecksumAlgorithm!, compositePartChecksums)
                 }
                 : await ComputeChecksumsAsync(objectPath, cancellationToken);
+            // A completed multipart object always exposes the composite S3 ETag
+            // "<hex(MD5(concat(partMd5Bytes)))>-<partCount>", regardless of any checksum algorithm.
+            var multipartETag = BuildMultipartETag(partMd5Checksums);
             var versionId = CreateVersionId();
             await WriteStoredObjectStateAsync(
                 request.BucketName,
@@ -3079,7 +3085,8 @@ internal sealed class DiskStorageService(
                 contentDisposition: uploadState.State.ContentDisposition,
                 contentEncoding: uploadState.State.ContentEncoding,
                 contentLanguage: uploadState.State.ContentLanguage,
-                expiresUtc: uploadState.State.ExpiresUtc);
+                expiresUtc: uploadState.State.ExpiresUtc,
+                etag: multipartETag);
 
             await DeleteStoredMultipartStateAsync(request.BucketName, request.Key, request.UploadId, uploadState.UploadDirectoryPath, cancellationToken);
             Directory.Delete(uploadState.UploadDirectoryPath, recursive: true);
@@ -3803,7 +3810,7 @@ internal sealed class DiskStorageService(
             ContentEncoding = metadata.IsDeleteMarker ? null : metadata.ContentEncoding,
             ContentLanguage = metadata.IsDeleteMarker ? null : metadata.ContentLanguage,
             ExpiresUtc = metadata.IsDeleteMarker ? null : metadata.ExpiresUtc,
-            ETag = metadata.IsDeleteMarker ? null : fileInfo is null ? null : BuildETag(fileInfo),
+            ETag = ResolveObjectETag(metadata, fileInfo),
             LastModifiedUtc = lastModifiedUtc,
             Metadata = metadata.Metadata,
             Tags = metadata.Tags,
@@ -3959,14 +3966,24 @@ internal sealed class DiskStorageService(
         string? contentDisposition = null,
         string? contentEncoding = null,
         string? contentLanguage = null,
-        DateTimeOffset? expiresUtc = null)
+        DateTimeOffset? expiresUtc = null,
+        string? etag = null)
     {
+        // Persist the S3 content ETag so it never depends on filesystem mtime. Multipart callers
+        // pass the composite "<md5>-<partCount>" form explicitly; every other write path stores a
+        // single object and derives the single-part hex-MD5 ETag here (reusing the MD5 already
+        // computed into the checksum dictionary when present, hashing the content otherwise).
+        var resolvedETag = isDeleteMarker
+            ? null
+            : etag ?? await ComputeSinglePartETagAsync(objectPath, checksums, cancellationToken);
+
         if (_objectStateStore is null) {
             await WriteMetadataAsync(objectPath, new DiskObjectMetadata
             {
                 VersionId = versionId,
                 IsLatest = isLatest,
                 IsDeleteMarker = isDeleteMarker,
+                ETag = resolvedETag,
                 LastModifiedUtc = lastModifiedUtc,
                 ContentType = contentType,
                 CacheControl = isDeleteMarker ? null : cacheControl,
@@ -4000,7 +4017,7 @@ internal sealed class DiskStorageService(
             ContentEncoding = isDeleteMarker ? null : contentEncoding,
             ContentLanguage = isDeleteMarker ? null : contentLanguage,
             ExpiresUtc = isDeleteMarker ? null : expiresUtc,
-            ETag = isDeleteMarker ? null : fileInfo is null ? null : BuildETag(fileInfo),
+            ETag = resolvedETag,
             LastModifiedUtc = lastModifiedUtc ?? fileInfo?.LastWriteTimeUtc ?? DateTimeOffset.UtcNow,
             Metadata = metadata is null ? null : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
             Tags = tags is null ? null : new Dictionary<string, string>(tags, StringComparer.Ordinal),
@@ -4649,6 +4666,7 @@ internal sealed class DiskStorageService(
                 VersionId = objectInfo.VersionId,
                 IsLatest = objectInfo.IsLatest,
                 IsDeleteMarker = objectInfo.IsDeleteMarker,
+                ETag = objectInfo.ETag,
                 LastModifiedUtc = objectInfo.LastModifiedUtc,
                 ContentType = objectInfo.ContentType,
                 CacheControl = objectInfo.CacheControl,
@@ -5491,9 +5509,95 @@ internal sealed class DiskStorageService(
         }
     }
 
-    private static string BuildETag(FileInfo fileInfo)
+    /// <summary>
+    /// Resolves the S3 ETag returned to clients for a stored object. Prefers the ETag persisted at
+    /// write time (single-part hex-MD5 or the multipart composite form), then falls back to deriving
+    /// the single-part hex-MD5 from the stored MD5 checksum for legacy metadata written before the
+    /// ETag was persisted. Returns null for delete markers, missing content, or content with no
+    /// recoverable MD5 (never the old size+mtime string, which is not a valid S3 ETag).
+    /// </summary>
+    private static string? ResolveObjectETag(DiskObjectMetadata metadata, FileInfo? fileInfo)
     {
-        return $"{fileInfo.Length:x}-{fileInfo.LastWriteTimeUtc.Ticks:x}";
+        if (metadata.IsDeleteMarker || fileInfo is null) {
+            return null;
+        }
+
+        if (!string.IsNullOrEmpty(metadata.ETag)) {
+            return metadata.ETag;
+        }
+
+        if (TryGetChecksumValue(metadata.Checksums, Md5ChecksumAlgorithm, out var md5Base64)) {
+            try {
+                return Convert.ToHexStringLower(Convert.FromBase64String(md5Base64));
+            }
+            catch (FormatException) {
+                return null;
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Computes the S3 single-part ETag for the content at <paramref name="contentPath"/>: the
+    /// lowercase-hex MD5 of the object bytes. Prefers the MD5 already present in
+    /// <paramref name="checksums"/> (stored base64 by <see cref="ComputeChecksumsAsync"/>) to avoid
+    /// re-reading the file, and falls back to hashing the content when MD5 is absent (e.g. a
+    /// PutObject that persisted only a caller-requested non-MD5 checksum).
+    /// </summary>
+    private static async Task<string?> ComputeSinglePartETagAsync(string contentPath, IReadOnlyDictionary<string, string>? checksums, CancellationToken cancellationToken)
+    {
+        if (TryGetChecksumValue(checksums, Md5ChecksumAlgorithm, out var md5Base64)) {
+            try {
+                return Convert.ToHexStringLower(Convert.FromBase64String(md5Base64));
+            }
+            catch (FormatException) {
+                // Fall through to recomputing from content on a malformed stored value.
+            }
+        }
+
+        if (!File.Exists(contentPath)) {
+            return null;
+        }
+
+        await using var stream = new FileStream(contentPath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        using var md5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+        var buffer = new byte[81920];
+        while (true) {
+            var read = await stream.ReadAsync(buffer.AsMemory(0, buffer.Length), cancellationToken);
+            if (read == 0) {
+                break;
+            }
+
+            md5.AppendData(buffer, 0, read);
+        }
+
+        return Convert.ToHexStringLower(md5.GetHashAndReset());
+    }
+
+    /// <summary>
+    /// Builds the S3 multipart object ETag: <c>&lt;hex(MD5(concat(partMd5Bytes)))&gt;-&lt;partCount&gt;</c>.
+    /// Each element of <paramref name="partMd5Base64"/> is the base64 MD5 of one part's bytes.
+    /// </summary>
+    private static string BuildMultipartETag(IReadOnlyList<string> partMd5Base64)
+    {
+        using var md5 = IncrementalHash.CreateHash(HashAlgorithmName.MD5);
+        foreach (var partMd5 in partMd5Base64) {
+            md5.AppendData(Convert.FromBase64String(partMd5));
+        }
+
+        return $"{Convert.ToHexStringLower(md5.GetHashAndReset())}-{partMd5Base64.Count}";
+    }
+
+    /// <summary>
+    /// Computes the S3 ETag of a single uploaded multipart part: the lowercase-hex MD5 of the part's
+    /// bytes, taken from the MD5 already computed by <see cref="ComputeChecksumsAsync"/>.
+    /// </summary>
+    private static string BuildPartETag(IReadOnlyDictionary<string, string> partChecksums)
+    {
+        return TryGetChecksumValue(partChecksums, Md5ChecksumAlgorithm, out var md5Base64)
+            ? Convert.ToHexStringLower(Convert.FromBase64String(md5Base64))
+            : throw new InvalidOperationException("Multipart part MD5 checksum is required to derive the part ETag.");
     }
 
     private static string CreateVersionId()

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskObjectMetadata.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskObjectMetadata.cs
@@ -8,6 +8,15 @@ internal sealed class DiskObjectMetadata
 
     public bool IsDeleteMarker { get; init; }
 
+    /// <summary>
+    /// The S3 content ETag persisted at write time so it is independent of filesystem mtime.
+    /// Single-part objects store the lowercase-hex MD5 of the content; multipart objects store the
+    /// composite form <c>&lt;hex(MD5(concat(partMd5Bytes)))&gt;-&lt;partCount&gt;</c>. Null for delete
+    /// markers and for legacy metadata written before this field existed (callers fall back to
+    /// deriving the ETag from the stored checksums).
+    /// </summary>
+    public string? ETag { get; init; }
+
     public DateTimeOffset? LastModifiedUtc { get; init; }
 
     public string? ContentType { get; init; }

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -5376,4 +5376,205 @@ public sealed class DiskStorageServiceTests
         using var reader = new StreamReader(response.Content, Encoding.UTF8, leaveOpen: false);
         Assert.Equal("still readable", await reader.ReadToEndAsync());
     }
+
+    private static string ComputeContentMd5Hex(byte[] content)
+    {
+        return Convert.ToHexStringLower(System.Security.Cryptography.MD5.HashData(content));
+    }
+
+    private static string ComputeContentMd5Hex(string content)
+    {
+        return ComputeContentMd5Hex(Encoding.UTF8.GetBytes(content));
+    }
+
+    [Fact]
+    public async Task DiskStorage_PutObject_ETagIsContentMd5Hex()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "etag-md5" });
+
+        const string payload = "hello integrated s3";
+        await using var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        var putResult = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "etag-md5",
+            Key = "docs/hello.txt",
+            Content = uploadStream,
+            ContentType = "text/plain"
+        });
+
+        Assert.True(putResult.IsSuccess);
+
+        // The single-part ETag must be the lowercase-hex MD5 of the content (S3 contract), not the
+        // old "<length:x>-<mtimeTicks:x>" string. This is a known-content -> known-MD5 assertion.
+        var expectedETag = ComputeContentMd5Hex(payload);
+        Assert.Equal(expectedETag, putResult.Value!.ETag);
+
+        // HeadObject must return the same persisted content ETag.
+        var headResult = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = "etag-md5",
+            Key = "docs/hello.txt"
+        });
+        Assert.True(headResult.IsSuccess);
+        Assert.Equal(expectedETag, headResult.Value!.ETag);
+    }
+
+    [Fact]
+    public async Task DiskStorage_ObjectETag_IsStableAcrossFilesystemMtimeChange()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "etag-mtime" });
+
+        const string payload = "content that must keep its etag";
+        await using (var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes(payload))) {
+            var putResult = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = "etag-mtime",
+                Key = "docs/stable.txt",
+                Content = uploadStream,
+                ContentType = "text/plain"
+            });
+            Assert.True(putResult.IsSuccess);
+        }
+
+        var expectedETag = ComputeContentMd5Hex(payload);
+
+        // Simulate any external process (backup, AV, replication/copy) resetting the content file's
+        // last-write time. With a content-derived ETag the value must not move; the old size+mtime
+        // ETag would change here and break conditional requests and integrity checks.
+        var contentPath = FindObjectContentPath(fixture.RootPath, "etag-mtime");
+        File.SetLastWriteTimeUtc(contentPath, new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        var headResult = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = "etag-mtime",
+            Key = "docs/stable.txt"
+        });
+
+        Assert.True(headResult.IsSuccess);
+        Assert.Equal(expectedETag, headResult.Value!.ETag);
+    }
+
+    [Fact]
+    public async Task DiskStorage_UploadPart_ETagIsPartContentMd5Hex()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "part-etag" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "part-etag",
+            Key = "docs/assembled.bin",
+            ContentType = "application/octet-stream"
+        });
+        Assert.True(initiateResult.IsSuccess);
+
+        var partBytes = new byte[5 * 1024 * 1024];
+        for (var i = 0; i < partBytes.Length; i++) {
+            partBytes[i] = (byte)(i % 251);
+        }
+
+        await using var partStream = new MemoryStream(partBytes);
+        var part = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "part-etag",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 1,
+            Content = partStream
+        });
+
+        Assert.True(part.IsSuccess);
+        Assert.Equal(ComputeContentMd5Hex(partBytes), part.Value!.ETag);
+    }
+
+    [Fact]
+    public async Task DiskStorage_CompleteMultipart_ETagIsCompositeMd5WithPartCount()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "composite-etag" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "composite-etag",
+            Key = "docs/assembled.bin",
+            ContentType = "application/octet-stream"
+        });
+        Assert.True(initiateResult.IsSuccess);
+
+        // Two parts: the first must meet the 5 MiB S3 minimum, the last may be small.
+        var part1Bytes = new byte[5 * 1024 * 1024];
+        for (var i = 0; i < part1Bytes.Length; i++) {
+            part1Bytes[i] = (byte)(i % 97);
+        }
+
+        var part2Bytes = Encoding.UTF8.GetBytes("final tiny part");
+
+        await using var part1Stream = new MemoryStream(part1Bytes);
+        var part1 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "composite-etag",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 1,
+            Content = part1Stream
+        });
+
+        await using var part2Stream = new MemoryStream(part2Bytes);
+        var part2 = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "composite-etag",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 2,
+            Content = part2Stream
+        });
+
+        Assert.True(part1.IsSuccess);
+        Assert.True(part2.IsSuccess);
+
+        // Touch a part file's mtime before completion: with content-derived part ETags this must not
+        // produce a spurious InvalidPart, because part validation no longer depends on mtime.
+        var partsDirectory = Directory
+            .EnumerateDirectories(Path.Combine(fixture.RootPath, ".integrateds3-multipart"), "parts", SearchOption.AllDirectories)
+            .FirstOrDefault();
+        if (partsDirectory is not null) {
+            foreach (var partFile in Directory.EnumerateFiles(partsDirectory, "*.part")) {
+                File.SetLastWriteTimeUtc(partFile, new DateTime(2001, 2, 3, 4, 5, 6, DateTimeKind.Utc));
+            }
+        }
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "composite-etag",
+            Key = "docs/assembled.bin",
+            UploadId = initiateResult.Value!.UploadId,
+            Parts = [part1.Value!, part2.Value!]
+        });
+
+        Assert.True(completeResult.IsSuccess);
+
+        // Expected composite ETag: hex(MD5(concat(part MD5 bytes)))-<partCount>.
+        var concatenatedPartMd5 = System.Security.Cryptography.MD5.HashData(part1Bytes)
+            .Concat(System.Security.Cryptography.MD5.HashData(part2Bytes))
+            .ToArray();
+        var expectedETag = $"{Convert.ToHexStringLower(System.Security.Cryptography.MD5.HashData(concatenatedPartMd5))}-2";
+
+        Assert.Equal(expectedETag, completeResult.Value!.ETag);
+        Assert.Matches(@"^[0-9a-f]{32}-\d+$", completeResult.Value.ETag!);
+
+        // The persisted composite ETag must survive a re-read via HeadObject.
+        var headResult = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = "composite-etag",
+            Key = "docs/assembled.bin"
+        });
+        Assert.True(headResult.IsSuccess);
+        Assert.Equal(expectedETag, headResult.Value!.ETag);
+    }
 }


### PR DESCRIPTION
## Summary

The disk provider derived every object and multipart-part ETag from the file's byte length and filesystem last-write time (`<length:x>-<mtimeTicks:x>` in `BuildETag`), which is **not** a valid S3 ETag. This broke SDK content-integrity checks (a single-part ETag must be the content MD5 hex), made multipart completion fragile against any external process that touched a part file's mtime, and made conditional `If-Match`/`If-None-Match` requests unstable and collision-prone.

## Changes

ETags are now derived from **content** and persisted independently of filesystem mtime:

- **Single-part** objects (`PutObject`, `CopyObject`, `RestoreObject`, compose): lowercase-hex MD5 of the stored bytes, reusing the MD5 already computed by `ComputeChecksumsAsync` (hashing the content only when a caller-requested non-MD5 checksum displaced it from the persisted dictionary).
- **Each uploaded multipart part** (`UploadPart`, `UploadPartCopy`, `ListParts`): lowercase-hex MD5 of the part bytes.
- **Completed multipart object**: the S3 composite form `<hex(MD5(concat(partMd5Bytes)))>-<partCount>`, always, regardless of any per-part checksum algorithm.
- **Multipart completion** now validates each requested part ETag against the part's content MD5 rather than a live `FileInfo`, so touching a part file's mtime between `UploadPart` and `Complete` no longer produces a spurious `InvalidPart`.

The ETag is persisted in a new `DiskObjectMetadata.ETag` field (and in the `ObjectInfo` stored via an external object-state store, plumbed through `ToDiskObjectMetadata`). Reads prefer the persisted ETag and fall back to deriving hex-MD5 from the stored MD5 checksum for legacy metadata, so the old size+mtime string is never returned again. The dead `BuildETag` size+mtime helper is removed.

## Tests

Adds 4 regression tests to `DiskStorageServiceTests`:
- `DiskStorage_PutObject_ETagIsContentMd5Hex` — known content → known hex MD5 (Put + Head).
- `DiskStorage_ObjectETag_IsStableAcrossFilesystemMtimeChange` — ETag unchanged after touching the content file's mtime.
- `DiskStorage_UploadPart_ETagIsPartContentMd5Hex` — part ETag = hex MD5 of the part bytes.
- `DiskStorage_CompleteMultipart_ETagIsCompositeMd5WithPartCount` — composite `-N` object ETag format, and no spurious conflict after touching part mtimes.

Full suite: **1146 passed, 0 failed**. Build: 0 warnings.

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)