### PR TITLE
fix: stop ReportFailure masking failing backends on non-transport errors (#127)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Core/Services/StorageBackendHealthMonitor.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/StorageBackendHealthMonitor.cs
@@ -81,15 +81,16 @@ internal sealed class StorageBackendHealthMonitor
     {
         ArgumentNullException.ThrowIfNull(backend);
 
-        var status = error?.Code is StorageErrorCode.ProviderUnavailable or StorageErrorCode.Throttled
-            ? StorageBackendHealthStatus.Unhealthy
-            : StorageBackendHealthStatus.Healthy;
-        var ttl = status == StorageBackendHealthStatus.Unhealthy
-            ? _options.Value.BackendHealth.UnhealthySnapshotTtl
-            : _options.Value.BackendHealth.HealthySnapshotTtl;
+        // A failed operation is never a positive success signal, so it must not stamp the backend
+        // Healthy. Only genuine transport-level failures demote the backend to Unhealthy; every
+        // other (per-request/semantic) error code leaves the existing snapshot untouched, so a
+        // failing operation can never re-mark a backend green or clobber a probe-set Unhealthy state.
+        if (error?.Code is not (StorageErrorCode.ProviderUnavailable or StorageErrorCode.Throttled)) {
+            return;
+        }
 
-        UpdateSnapshot(backend.Name, status, ttl);
-        TrackStatus(backend, status, "operation");
+        UpdateSnapshot(backend.Name, StorageBackendHealthStatus.Unhealthy, _options.Value.BackendHealth.UnhealthySnapshotTtl);
+        TrackStatus(backend, StorageBackendHealthStatus.Unhealthy, "operation");
     }
 
     private async ValueTask<StorageBackendHealthStatus> ProbeAsync(IStorageBackend backend, StorageBackendHealthOptions healthOptions, CancellationToken cancellationToken)

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
@@ -3735,6 +3735,51 @@ public sealed class IntegratedS3CoreOrchestrationTests
         }
     }
 
+    [Fact]
+    public async Task StorageBackendHealthMonitor_ReportFailureWithNonTransportError_DoesNotResetProbeSetUnhealthy()
+    {
+        // Regression for #127: a probe marks the backend Unhealthy; a subsequent operation that fails
+        // with a non-transport error code (e.g. Unknown) must NOT overwrite that snapshot with Healthy.
+        var backend = new InMemoryStorageBackend("failing-memory");
+        var evaluator = new ConfigurableStorageBackendHealthEvaluator(
+            new Dictionary<string, StorageBackendHealthStatus>(StringComparer.Ordinal));
+        var probe = new ConfigurableStorageBackendHealthProbe(
+            new Dictionary<string, StorageBackendHealthStatus>(StringComparer.Ordinal)
+            {
+                [backend.Name] = StorageBackendHealthStatus.Unhealthy
+            });
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2024, 1, 1, 0, 0, 0, TimeSpan.Zero));
+        var options = Microsoft.Extensions.Options.Options.Create(new IntegratedS3CoreOptions
+        {
+            BackendHealth =
+            {
+                EnableDynamicSnapshots = true,
+                EnableActiveProbing = true,
+                HealthySnapshotTtl = TimeSpan.FromMinutes(5),
+                UnhealthySnapshotTtl = TimeSpan.FromMinutes(5)
+            }
+        });
+
+        var monitor = new StorageBackendHealthMonitor(
+            evaluator,
+            probe,
+            options,
+            timeProvider,
+            Microsoft.Extensions.Logging.Abstractions.NullLogger<StorageBackendHealthMonitor>.Instance);
+
+        // Active probe stamps an Unhealthy snapshot.
+        Assert.Equal(StorageBackendHealthStatus.Unhealthy, await monitor.GetStatusAsync(backend));
+
+        // A failed operation with a non-transport error code must leave the Unhealthy snapshot intact.
+        monitor.ReportFailure(backend, new StorageError
+        {
+            Code = StorageErrorCode.Unknown,
+            Message = "degraded endpoint returned an unclassified error"
+        });
+
+        Assert.Equal(StorageBackendHealthStatus.Unhealthy, await monitor.GetStatusAsync(backend));
+    }
+
     private sealed class ConfigurableStorageBackendHealthEvaluator(IReadOnlyDictionary<string, StorageBackendHealthStatus> statuses) : IStorageBackendHealthEvaluator
     {
         public ValueTask<StorageBackendHealthStatus> GetStatusAsync(IStorageBackend backend, CancellationToken cancellationToken = default)


### PR DESCRIPTION
## Summary

`StorageBackendHealthMonitor.ReportFailure` previously stamped a fresh **Healthy** snapshot (30s TTL) for every error code except `ProviderUnavailable` and `Throttled`. Since `DefaultStorageBackendHealthEvaluator` returns `Healthy` and `CombineStatuses` ORs toward `Healthy`, a backend that kept failing with a non-transport code (`Unknown`, `QuotaExceeded`, `ObjectLocked`, ...) was continuously reported healthy. Worse, a failed operation could overwrite a probe-set `Unhealthy` snapshot and re-mark it green with a *longer* TTL (30s vs 10s), erasing a just-detected outage and defeating `PreferHealthyReplica` read routing, the strict write-through preflight, and the exported health gauge.

## Fix

`ReportFailure` now demotes to `Unhealthy` only on the genuine transport codes (`ProviderUnavailable`/`Throttled`); for any other code it returns without touching the snapshot, leaving the existing health state intact. A failing operation can therefore never reset a backend to `Healthy` or extend an `Unhealthy` state's lifetime. Only `ReportSuccess` or a successful probe establishes/refreshes a `Healthy` snapshot. Per-request semantic errors (`ObjectNotFound`, `AccessDenied`, `PreconditionFailed`, ...) still do not demote the whole backend.

## Test

Adds `StorageBackendHealthMonitor_ReportFailureWithNonTransportError_DoesNotResetProbeSetUnhealthy`: an active probe marks the backend `Unhealthy`, then `ReportFailure` with `StorageErrorCode.Unknown` is called; the backend must remain `Unhealthy`. Verified fails-before (`Expected: Unhealthy, Actual: Healthy`) / passes-after. Full suite green (1154 passed).

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)