### PR TITLE
fix: honor GET/HEAD response-content-* override query params (#148)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -147,6 +147,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string IntelligentTieringQueryParameterName = "intelligent-tiering";
     private const string IdQueryParameterName = "id";
     private const string RestoreQueryParameterName = "restore";
+    private const string ResponseContentTypeQueryParameterName = "response-content-type";
+    private const string ResponseContentLanguageQueryParameterName = "response-content-language";
+    private const string ResponseExpiresQueryParameterName = "response-expires";
+    private const string ResponseCacheControlQueryParameterName = "response-cache-control";
+    private const string ResponseContentDispositionQueryParameterName = "response-content-disposition";
+    private const string ResponseContentEncodingQueryParameterName = "response-content-encoding";
     private const string SelectQueryParameterName = "select";
     private const string SelectTypeQueryParameterName = "select-type";
     private const string OriginHeaderName = "Origin";
@@ -204,11 +210,18 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static readonly HashSet<string> ObjectAttributesQueryParameters = CreateQueryParameterSet(AttributesQueryParameterName, VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectRestoreQueryParameters = CreateQueryParameterSet(RestoreQueryParameterName, VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectSelectQueryParameters = CreateQueryParameterSet(SelectQueryParameterName, SelectTypeQueryParameterName);
+    private static readonly HashSet<string> ResponseHeaderOverrideQueryParameters = CreateQueryParameterSet(
+        ResponseContentTypeQueryParameterName,
+        ResponseContentLanguageQueryParameterName,
+        ResponseExpiresQueryParameterName,
+        ResponseCacheControlQueryParameterName,
+        ResponseContentDispositionQueryParameterName,
+        ResponseContentEncodingQueryParameterName);
     private static readonly HashSet<string> ObjectMultipartInitiateQueryParameters = CreateQueryParameterSet(UploadsQueryParameterName);
     private static readonly HashSet<string> ObjectMultipartPartQueryParameters = CreateQueryParameterSet(UploadIdQueryParameterName, PartNumberQueryParameterName);
     private static readonly HashSet<string> ObjectMultipartUploadQueryParameters = CreateQueryParameterSet(UploadIdQueryParameterName);
     private static readonly HashSet<string> ObjectMultipartListPartsQueryParameters = CreateQueryParameterSet(UploadIdQueryParameterName, PartNumberMarkerQueryParameterName, MaxPartsQueryParameterName, EncodingTypeQueryParameterName);
-    private static readonly HashSet<string> KnownObjectQueryParameters = CreateQueryParameterSet(AclQueryParameterName, TaggingQueryParameterName, RetentionQueryParameterName, LegalHoldQueryParameterName, AttributesQueryParameterName, VersionIdQueryParameterName, RestoreQueryParameterName, SelectQueryParameterName, SelectTypeQueryParameterName, UploadsQueryParameterName, UploadIdQueryParameterName, PartNumberQueryParameterName, PartNumberMarkerQueryParameterName, MaxPartsQueryParameterName, EncodingTypeQueryParameterName);
+    private static readonly HashSet<string> KnownObjectQueryParameters = CreateQueryParameterSet(AclQueryParameterName, TaggingQueryParameterName, RetentionQueryParameterName, LegalHoldQueryParameterName, AttributesQueryParameterName, VersionIdQueryParameterName, RestoreQueryParameterName, SelectQueryParameterName, SelectTypeQueryParameterName, UploadsQueryParameterName, UploadIdQueryParameterName, PartNumberQueryParameterName, PartNumberMarkerQueryParameterName, MaxPartsQueryParameterName, EncodingTypeQueryParameterName, ResponseContentTypeQueryParameterName, ResponseContentLanguageQueryParameterName, ResponseExpiresQueryParameterName, ResponseCacheControlQueryParameterName, ResponseContentDispositionQueryParameterName, ResponseContentEncodingQueryParameterName);
     private static readonly HashSet<string> SupportedManagedServerSideEncryptionRequestHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
         ServerSideEncryptionHeaderName,
@@ -1475,6 +1488,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return customerEncryptionError;
                 }
 
+                var responseOverrides = ResponseHeaderOverrides.FromRequest(request);
+
                 var rawRange = request.Headers.Range.ToString();
                 var multipleRanges = ParseMultipleRangeHeaders(rawRange);
 
@@ -1486,7 +1501,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         headers.IfModifiedSince,
                         headers.IfUnmodifiedSince,
                         customerEncryption,
-                        multipleRanges);
+                        multipleRanges,
+                        responseOverrides);
                 }
 
                 var result = await storageService.GetObjectAsync(new GetObjectRequest
@@ -1506,7 +1522,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, key), explicitVersionId: versionId);
                 }
 
-                return new StreamObjectResult(result.Value!);
+                return new StreamObjectResult(result.Value!, responseOverrides);
             }, cancellationToken);
         }
         catch (EndpointStorageAuthorizationException exception) {
@@ -1560,9 +1576,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 }
 
                 var objectInfo = result.Value!;
+                var responseOverrides = ResponseHeaderOverrides.FromRequest(httpContext.Request);
                 ApplyObjectHeaders(httpContext.Response, objectInfo);
                 ApplyObjectTaggingCountHeader(httpContext.Response, objectInfo);
                 httpContext.Response.Headers.AcceptRanges = "bytes";
+                responseOverrides.Apply(httpContext.Response);
 
                 if (!MatchesIfMatch(httpContext.Request.Headers.IfMatch.ToString(), objectInfo.ETag)) {
                     return TypedResults.StatusCode(StatusCodes.Status412PreconditionFailed);
@@ -1584,7 +1602,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return TypedResults.StatusCode(StatusCodes.Status304NotModified);
                 }
 
-                httpContext.Response.ContentType = objectInfo.ContentType ?? "application/octet-stream";
+                httpContext.Response.ContentType = responseOverrides.ContentType ?? objectInfo.ContentType ?? "application/octet-stream";
 
                 // AWS honors the Range header on HEAD, mirroring GET: a satisfiable range yields 206
                 // with Content-Range and the ranged Content-Length (no body); an unsatisfiable range
@@ -5041,6 +5059,16 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static bool TryValidateObjectRequestSubresources(HttpRequest request, out string? errorCode, out string? errorMessage, out int statusCode)
     {
         var queryKeys = GetValidatedQueryKeys(request);
+
+        // GET/HEAD object retrieval accepts the S3 response-header override parameters
+        // (response-content-type, response-content-disposition, etc.) alongside a plain
+        // or versioned object request. They do not designate a subresource, so strip them
+        // before matching the object/versioned-object shapes. Other methods reject them.
+        if ((request.Method == "GET" || request.Method == "HEAD") && queryKeys.Overlaps(ResponseHeaderOverrideQueryParameters)) {
+            queryKeys = queryKeys.Where(static queryKey => !ResponseHeaderOverrideQueryParameters.Contains(queryKey))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        }
+
         var isCurrentObjectRequest = queryKeys.SetEquals(EmptyQueryParameters);
         var isVersionedObjectRequest = queryKeys.SetEquals(ObjectVersionQueryParameters);
         var isAclRequest = queryKeys.SetEquals(ObjectAclQueryParameters);
@@ -8761,6 +8789,76 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
     }
 
+    /// <summary>
+    /// The S3 <c>response-*</c> GET/HEAD query parameters that override representation headers on
+    /// the response. All fields are the raw provided values (verbatim); AWS does not validate them.
+    /// </summary>
+    private readonly record struct ResponseHeaderOverrides(
+        string? ContentType,
+        string? ContentLanguage,
+        string? Expires,
+        string? CacheControl,
+        string? ContentDisposition,
+        string? ContentEncoding)
+    {
+        public bool HasAny =>
+            ContentType is not null
+            || ContentLanguage is not null
+            || Expires is not null
+            || CacheControl is not null
+            || ContentDisposition is not null
+            || ContentEncoding is not null;
+
+        public static ResponseHeaderOverrides FromRequest(HttpRequest request)
+        {
+            ArgumentNullException.ThrowIfNull(request);
+
+            return new ResponseHeaderOverrides(
+                ReadOverride(request, ResponseContentTypeQueryParameterName),
+                ReadOverride(request, ResponseContentLanguageQueryParameterName),
+                ReadOverride(request, ResponseExpiresQueryParameterName),
+                ReadOverride(request, ResponseCacheControlQueryParameterName),
+                ReadOverride(request, ResponseContentDispositionQueryParameterName),
+                ReadOverride(request, ResponseContentEncodingQueryParameterName));
+        }
+
+        // Applies the overrides after the object's own representation headers, replacing them.
+        // Content-Type is set via HttpResponse.ContentType so the framework keeps it in sync.
+        public void Apply(HttpResponse httpResponse)
+        {
+            ArgumentNullException.ThrowIfNull(httpResponse);
+
+            if (ContentType is not null) {
+                httpResponse.ContentType = ContentType;
+            }
+
+            if (ContentLanguage is not null) {
+                httpResponse.Headers[HeaderNames.ContentLanguage] = ContentLanguage;
+            }
+
+            if (Expires is not null) {
+                httpResponse.Headers[HeaderNames.Expires] = Expires;
+            }
+
+            if (CacheControl is not null) {
+                httpResponse.Headers.CacheControl = CacheControl;
+            }
+
+            if (ContentDisposition is not null) {
+                httpResponse.Headers[HeaderNames.ContentDisposition] = ContentDisposition;
+            }
+
+            if (ContentEncoding is not null) {
+                httpResponse.Headers[HeaderNames.ContentEncoding] = ContentEncoding;
+            }
+        }
+
+        private static string? ReadOverride(HttpRequest request, string queryKey)
+        {
+            return request.Query.TryGetValue(queryKey, out var value) ? value.ToString() : null;
+        }
+    }
+
     private static void ApplyObjectHeaders(HttpResponse httpResponse, ObjectInfo objectInfo)
     {
         ApplyObjectResultHeaders(httpResponse, objectInfo);
@@ -9242,7 +9340,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
     }
 
-    private sealed class StreamObjectResult(GetObjectResponse objectResponse) : IResult, IAsyncDisposable
+    private sealed class StreamObjectResult(GetObjectResponse objectResponse, ResponseHeaderOverrides responseOverrides = default) : IResult, IAsyncDisposable
     {
         private GetObjectResponse? _objectResponse = objectResponse;
 
@@ -9264,11 +9362,13 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             httpContext.Response.Headers.AcceptRanges = "bytes";
 
             if (response.IsNotModified) {
+                responseOverrides.Apply(httpContext.Response);
                 httpContext.Response.StatusCode = StatusCodes.Status304NotModified;
                 return;
             }
 
             httpContext.Response.ContentType = response.Object.ContentType ?? "application/octet-stream";
+            responseOverrides.Apply(httpContext.Response);
             httpContext.Response.ContentLength = response.Object.ContentLength;
 
             if (response.Range is not null) {
@@ -9304,7 +9404,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         DateTimeOffset? ifModifiedSinceUtc,
         DateTimeOffset? ifUnmodifiedSinceUtc,
         ObjectCustomerEncryptionSettings? customerEncryption,
-        ObjectRange[] ranges) : IResult
+        ObjectRange[] ranges,
+        ResponseHeaderOverrides responseOverrides = default) : IResult
     {
         public async Task ExecuteAsync(HttpContext httpContext)
         {
@@ -9337,13 +9438,18 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             ApplyObjectTaggingCountHeader(httpContext.Response, firstResponse.Object);
             httpContext.Response.Headers.AcceptRanges = "bytes";
 
+            // Apply response-* overrides (Content-Disposition, Cache-Control, etc.) before the
+            // multipart container Content-Type is set below, so the transport type still wins for
+            // Content-Type while the other overrides survive.
+            responseOverrides.Apply(httpContext.Response);
+
             if (firstResponse.IsNotModified) {
                 httpContext.Response.StatusCode = StatusCodes.Status304NotModified;
                 return;
             }
 
             var totalLength = firstResponse.TotalContentLength;
-            var contentType = firstResponse.Object.ContentType ?? "application/octet-stream";
+            var contentType = responseOverrides.ContentType ?? firstResponse.Object.ContentType ?? "application/octet-stream";
 
             httpContext.Response.StatusCode = StatusCodes.Status206PartialContent;
             httpContext.Response.ContentType = $"multipart/byteranges; boundary={boundary}";

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -159,6 +159,113 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task GetObject_WithResponseHeaderOverrideQueryParams_OverridesResponseHeaders()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "response-override-get-bucket";
+        const string objectKey = "docs/override.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var uploadRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("response override payload", Encoding.UTF8, "text/plain")
+        };
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(uploadRequest)).StatusCode);
+
+        const string expiresValue = "Wed, 21 Oct 2026 07:28:00 GMT";
+        var query =
+            "?response-content-type=application%2Fpdf" +
+            "&response-content-language=de-AT" +
+            "&response-expires=" + Uri.EscapeDataString(expiresValue) +
+            "&response-cache-control=" + Uri.EscapeDataString("max-age=42, private") +
+            "&response-content-disposition=" + Uri.EscapeDataString("attachment; filename=\"renamed.pdf\"") +
+            "&response-content-encoding=gzip";
+
+        var downloadResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}{query}");
+
+        Assert.Equal(HttpStatusCode.OK, downloadResponse.StatusCode);
+        Assert.Equal("application/pdf", downloadResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("de-AT", downloadResponse.Content.Headers.ContentLanguage);
+        Assert.Equal(expiresValue, Assert.Single(downloadResponse.Content.Headers.GetValues("Expires")));
+        Assert.Equal("max-age=42, private", downloadResponse.Headers.CacheControl?.ToString());
+        Assert.Equal("attachment", downloadResponse.Content.Headers.ContentDisposition?.DispositionType);
+        Assert.Equal("renamed.pdf", downloadResponse.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+        Assert.Contains("gzip", downloadResponse.Content.Headers.ContentEncoding);
+        Assert.Equal("response override payload", await downloadResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task HeadObject_WithResponseHeaderOverrideQueryParams_OverridesResponseHeaders()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "response-override-head-bucket";
+        const string objectKey = "docs/override.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var uploadRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("response override payload", Encoding.UTF8, "text/plain")
+        };
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(uploadRequest)).StatusCode);
+
+        const string expiresValue = "Wed, 21 Oct 2026 07:28:00 GMT";
+        var query =
+            "?response-content-type=application%2Fpdf" +
+            "&response-content-language=de-AT" +
+            "&response-expires=" + Uri.EscapeDataString(expiresValue) +
+            "&response-cache-control=" + Uri.EscapeDataString("max-age=42, private") +
+            "&response-content-disposition=" + Uri.EscapeDataString("attachment; filename=\"renamed.pdf\"") +
+            "&response-content-encoding=gzip";
+
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}{query}");
+        var headResponse = await client.SendAsync(headRequest);
+
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.Equal("application/pdf", headResponse.Content.Headers.ContentType?.MediaType);
+        Assert.Contains("de-AT", headResponse.Content.Headers.ContentLanguage);
+        Assert.Equal(expiresValue, Assert.Single(headResponse.Content.Headers.GetValues("Expires")));
+        Assert.Equal("max-age=42, private", headResponse.Headers.CacheControl?.ToString());
+        Assert.Equal("attachment", headResponse.Content.Headers.ContentDisposition?.DispositionType);
+        Assert.Equal("renamed.pdf", headResponse.Content.Headers.ContentDisposition?.FileName?.Trim('"'));
+        Assert.Contains("gzip", headResponse.Content.Headers.ContentEncoding);
+    }
+
+    [Theory]
+    [InlineData("response-content-type=text%2Fcsv")]
+    [InlineData("response-content-language=fr-FR")]
+    [InlineData("response-expires=Wed%2C%2021%20Oct%202026%2007%3A28%3A00%20GMT")]
+    [InlineData("response-cache-control=no-cache")]
+    [InlineData("response-content-disposition=inline")]
+    [InlineData("response-content-encoding=identity")]
+    public async Task GetObject_WithSingleResponseOverrideParam_DoesNotReturn501(string overrideQuery)
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "response-override-single-bucket";
+        var objectKey = $"docs/{Guid.NewGuid():N}.txt";
+
+        // Theory cases share the bucket; the first creates it, later runs see it already exists.
+        var createBucketStatus = (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode;
+        Assert.True(createBucketStatus is HttpStatusCode.Created or HttpStatusCode.Conflict, $"Unexpected bucket create status: {createBucketStatus}");
+
+        using var uploadRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("single override payload", Encoding.UTF8, "text/plain")
+        };
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(uploadRequest)).StatusCode);
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}?{overrideQuery}");
+        Assert.NotEqual(HttpStatusCode.NotImplemented, getResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}?{overrideQuery}");
+        var headResponse = await client.SendAsync(headRequest);
+        Assert.NotEqual(HttpStatusCode.NotImplemented, headResponse.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+    }
+
+    [Fact]
     public async Task PutObject_WithChecksumHeaders_ValidatesPayloadAndEmitsCurrentVersionHeaders()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary
GET/HEAD object requests carrying any S3 `response-*` header-override query parameter were rejected with `501 NotImplemented`, because those keys did not match `EmptyQueryParameters` in the object-subresource validator. This broke the most common presigned-download pattern (aws-cli `presign`, the S3 console, browser download links, rclone/mc), which almost always embeds `response-content-disposition`.

## Fix
For `GET`/`HEAD` object retrieval, the six S3 response-override parameters are now honored instead of returning 501:

- `response-content-type` → `Content-Type`
- `response-content-language` → `Content-Language`
- `response-expires` → `Expires`
- `response-cache-control` → `Cache-Control`
- `response-content-disposition` → `Content-Disposition`
- `response-content-encoding` → `Content-Encoding`

Implementation:
- The keys are stripped before matching the plain/versioned object shapes in `TryValidateObjectRequestSubresources` (only for GET/HEAD; other methods still reject them) and added to `KnownObjectQueryParameters`.
- A `ResponseHeaderOverrides` value is parsed from the request and applied verbatim (AWS does not validate the values) to the response after the object's own representation headers, for single-range GET (`StreamObjectResult`), multi-range GET (`MultiRangeStreamObjectResult`, where the multipart container `Content-Type` is preserved), and HEAD.

## Tests
Adds regression tests in `IntegratedS3HttpEndpointsTests`:
- `GetObject_WithResponseHeaderOverrideQueryParams_OverridesResponseHeaders`
- `HeadObject_WithResponseHeaderOverrideQueryParams_OverridesResponseHeaders`
- `GetObject_WithSingleResponseOverrideParam_DoesNotReturn501` (theory over all six params, GET + HEAD)

Verified fails-before (all new tests hit 501 with the fix disabled) / passes-after. Full suite green: 1161 passed.

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
