### PR TITLE
fix: generic 409 conflicts no longer mislabeled as BucketAlreadyExists (#139)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ErrorTranslator.cs
@@ -68,6 +68,10 @@ internal static class S3ErrorTranslator
                 (StorageErrorCode.BucketNotEmpty,
                  $"Bucket '{bucketName}' is not empty and cannot be deleted."),
 
+            "OperationAborted" =>
+                (StorageErrorCode.VersionConflict,
+                 $"A conflicting operation prevented the request on bucket '{bucketName}' from completing: {ex.Message}"),
+
             "PreconditionFailed" =>
                 (StorageErrorCode.PreconditionFailed,
                  !string.IsNullOrEmpty(objectKey)
@@ -134,9 +138,14 @@ internal static class S3ErrorTranslator
                 (StorageErrorCode.MultipartConflict,
                  $"A conflicting operation prevented the request for object '{objectKey}' in bucket '{bucketName}' from completing: {ex.Message}"),
 
+            // A bare 409 with no recognized S3 error code is a generic conflict — most commonly an
+            // aborted/conflicting operation on the bucket. It is NOT a bucket-name collision (those
+            // arrive as the named "BucketAlreadyExists"/"BucketAlreadyOwnedByYou" arms above), so it
+            // must not be relabeled as one. Route it to a neutral conflict code (surfaced on the wire
+            // as "OperationAborted") to keep the S3 code, message, and metrics accurate.
             _ when (int)ex.StatusCode == 409 =>
-                (StorageErrorCode.BucketAlreadyExists,
-                 $"Bucket '{bucketName}' already exists."),
+                (StorageErrorCode.VersionConflict,
+                 $"A conflicting operation prevented the request on bucket '{bucketName}' from completing: {ex.Message}"),
 
             _ when (int)ex.StatusCode == 503 =>
                 (StorageErrorCode.ProviderUnavailable,

--- a/src/IntegratedS3/IntegratedS3.Tests/S3ErrorTranslatorTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3ErrorTranslatorTests.cs
@@ -120,6 +120,68 @@ public sealed class S3ErrorTranslatorTests
         Assert.Equal(StorageErrorCode.InvalidTag, error.Code);
     }
 
+    // --- Generic 409 conflict translation (issue #139) ---
+
+    [Fact]
+    public void OperationAborted_MapsTo_VersionConflict_NotBucketAlreadyExists()
+    {
+        // S3 returns 409 OperationAborted when a conflicting/aborted operation is in progress on a
+        // bucket. It must not be relabeled as a bucket-name collision.
+        var ex = MakeException("OperationAborted", HttpStatusCode.Conflict);
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket");
+
+        Assert.Equal(StorageErrorCode.VersionConflict, error.Code);
+        Assert.NotEqual(StorageErrorCode.BucketAlreadyExists, error.Code);
+        Assert.Contains("my-bucket", error.Message);
+        Assert.DoesNotContain("already exists", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Generic409_WithoutObjectKey_MapsTo_VersionConflict_NotBucketAlreadyExists()
+    {
+        // A bare 409 with an unrecognized error code and no object key (e.g. a bucket-config write)
+        // is a generic conflict, not a bucket-name collision.
+        var ex = MakeException("SomeUnrecognizedConflict", HttpStatusCode.Conflict);
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket", objectKey: null);
+
+        Assert.Equal(StorageErrorCode.VersionConflict, error.Code);
+        Assert.NotEqual(StorageErrorCode.BucketAlreadyExists, error.Code);
+        Assert.DoesNotContain("already exists", error.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Generic409_WithObjectKey_MapsTo_MultipartConflict()
+    {
+        var ex = MakeException("SomeUnrecognizedConflict", HttpStatusCode.Conflict);
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket", "my-object.txt");
+
+        Assert.Equal(StorageErrorCode.MultipartConflict, error.Code);
+    }
+
+    [Fact]
+    public void BucketAlreadyExists_StillMapsTo_BucketAlreadyExists()
+    {
+        // A genuine bucket-name collision must still surface as BucketAlreadyExists.
+        var ex = MakeException("BucketAlreadyExists", HttpStatusCode.Conflict);
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket");
+
+        Assert.Equal(StorageErrorCode.BucketAlreadyExists, error.Code);
+    }
+
+    [Fact]
+    public void BucketAlreadyOwnedByYou_StillMapsTo_BucketAlreadyOwnedByYou()
+    {
+        var ex = MakeException("BucketAlreadyOwnedByYou", HttpStatusCode.Conflict);
+
+        var error = S3ErrorTranslator.Translate(ex, "test-provider", "my-bucket");
+
+        Assert.Equal(StorageErrorCode.BucketAlreadyOwnedByYou, error.Code);
+    }
+
     // --- Transport / service-level failure translation (issue #129) ---
 
     [Fact]


### PR DESCRIPTION
## Problem

`S3ErrorTranslator.Translate`'s catch-all `_ when (int)ex.StatusCode == 409` fallback (no object key) mapped **any** upstream HTTP 409 to `StorageErrorCode.BucketAlreadyExists` with the message `"Bucket '{bucketName}' already exists."`. That is only correct for a bucket-name collision.

Other legitimate 409s — most notably `OperationAborted`, returned when a conflicting config/conditional operation is in progress on a bucket (e.g. `PUT ?versioning` and the ~30 other bucket-config writes) — were silently relabeled as a name collision. The HTTP status stayed 409, but the emitted S3 `<Code>`, the message, and the `StorageErrorCode` used for metrics were all wrong. Callers could not distinguish a real (permanent) name collision from a transient, retryable conflict, and dashboards keyed on `StorageErrorCode` over-counted `BucketAlreadyExists`.

## Fix

Genuine name collisions already arrive via the named `"BucketAlreadyExists"` / `"BucketAlreadyOwnedByYou"` error-code arms. The bare-409 fallback now routes to `StorageErrorCode.VersionConflict`, which already exists and is already mapped to **HTTP 409 + wire code `"OperationAborted"`** — so the status is unchanged while the code and message become accurate. An explicit `"OperationAborted"` named arm is added for clarity.

## Tests

Regression tests in `S3ErrorTranslatorTests` assert:
- `OperationAborted` and a generic (unrecognized) 409 without an object key → `VersionConflict`, **not** `BucketAlreadyExists`, and no "already exists" message.
- A genuine `BucketAlreadyExists` / `BucketAlreadyOwnedByYou` still maps correctly.
- A generic 409 **with** an object key still maps to `MultipartConflict` (unchanged).

Verified fails-before / passes-after (new tests fail with `Expected VersionConflict / Actual BucketAlreadyExists` on the old code). Full suite green: **1169 passed, 0 failed**.

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)