### PR TITLE
fix: reject signed-streaming requests when no signing context is present (#114)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -8291,8 +8291,19 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
 
         if (!AwsChunkedTrailerSigningContextStore.TryGet(request.HttpContext, out var signingContext)) {
-            errorResult = null;
-            return true;
+            // The request declares a signed-trailer streaming payload hash and carries an
+            // 'x-amz-trailer-signature' trailer, but no signing context was established (the
+            // built-in SigV4/SigV4a authenticator did not run and succeed). Without a signing
+            // context there is no authenticated secret key to verify the trailer signature
+            // against, so the signature cannot be validated. Reject rather than fail open:
+            // accepting here would silently skip trailer-signature verification.
+            errorResult = ToErrorResult(
+                request.HttpContext,
+                StatusCodes.Status403Forbidden,
+                "AccessDenied",
+                $"The request declares a signed streaming payload hash and includes an '{AwsTrailerSignatureHeaderName}' trailer, but the trailer signature cannot be validated because the request was not authenticated with AWS Signature Version 4.",
+                resource: null);
+            return false;
         }
 
         var finalChunkSignature = preparedBody.FinalChunkSignature;

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -912,6 +912,51 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         Assert.Contains("x-amz-trailer-signature", GetRequiredElementValue(document, "Message"), StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task PutObject_WithTrailerBackedPayloadHashAndTrailerSignatureButNoSigningContext_ReturnsAccessDenied()
+    {
+        // Regression for #114: a request that declares a signed-trailer streaming payload hash
+        // (STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER) and supplies an 'x-amz-trailer-signature'
+        // trailer, but is not authenticated with SigV4 (the default test host does not enable
+        // AWS Signature V4 authentication), previously failed open: the trailer signature was
+        // never checked and the object was accepted. It must now be rejected because there is
+        // no signing context to verify the trailer signature against.
+        using var client = await _factory.CreateClientAsync();
+
+        const string bucketName = "aws-chunked-trailer-signature-no-context-bucket";
+        const string objectKey = "docs/trailer-signature-no-context.txt";
+        const string payload = "hello from signed aws chunked trailer without signing context";
+        var checksum = ComputeSha256Base64(payload);
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var putRequest = CreateAwsChunkedPutObjectRequest(
+            $"/integrated-s3/{bucketName}/{objectKey}",
+            payload,
+            sdkChecksumAlgorithm: "SHA256",
+            declaredTrailerHeaderNames: ["x-amz-checksum-sha256"],
+            trailerHeaderEntries:
+            [
+                new KeyValuePair<string, string>("x-amz-checksum-sha256", checksum),
+                // An arbitrary, unverifiable trailer signature. There is no authenticated secret
+                // key to validate it against, so the request must be rejected rather than accepted.
+                new KeyValuePair<string, string>("x-amz-trailer-signature", new string('0', 64))
+            ]);
+        putRequest.Headers.TryAddWithoutValidation("x-amz-content-sha256", "STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER");
+
+        var response = await client.SendAsync(putRequest);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("AccessDenied", GetRequiredElementValue(document, "Code"));
+
+        // The object must not have been written by the fail-open path.
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.NotFound, getResponse.StatusCode);
+    }
+
     [Theory]
     [InlineData("SHA1", "x-amz-checksum-sha1", "aws-chunked-signed-trailer-sha1-valid-bucket", "docs/signed-trailer-sha1.txt", "hello from signed aws chunked sha1 trailer")]
     [InlineData("CRC32", "x-amz-checksum-crc32", "aws-chunked-signed-trailer-crc32-valid-bucket", "docs/signed-trailer-crc32.txt", "hello from signed aws chunked crc32 trailer")]


### PR DESCRIPTION
## Summary

`TryValidateAwsChunkedTrailerSignature` was the only server-side check tying `aws-chunked` trailing headers back to the request signature, and it **failed open**. When a request declared a signed-trailer streaming payload hash (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` / SigV4a variant) **and** supplied an `x-amz-trailer-signature` trailer, but no signing context was stored, the method returned `true` and skipped trailer-signature verification entirely.

The signing context is stored only inside `AwsSignatureV4RequestAuthenticator` on a successful SigV4/SigV4a authentication. It is therefore absent whenever the built-in SigV4 authenticator did not run and succeed — reachable in production (`EnableAwsSignatureV4Authentication = false` with `RequireAuthenticatedRequests = false`, `AllowAnonymousRequests = true`, or when a different scheme already authenticated the request). In those configs a signed-trailer PUT with an arbitrary trailer signature was silently accepted, nullifying the signed-trailer integrity control with zero test signal.

## Fix

`src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs` — replace the fail-open `return true` in the no-signing-context branch of `TryValidateAwsChunkedTrailerSignature` with a `403 AccessDenied` rejection. At that point the request has already been confirmed to declare a signed streaming payload hash and to carry a non-empty trailer signature; with no signing context there is no authenticated secret key to verify it against, so the request cannot be validated and must be rejected.

Requests that are *not* signed-trailer streaming (`return true` at the top of the method) and unsigned-trailer streaming (`STREAMING-UNSIGNED-PAYLOAD-TRAILER`) are unaffected. Authenticated SigV4/SigV4a signed-trailer requests still store a context and follow the existing verification path.

## Test

Added `PutObject_WithTrailerBackedPayloadHashAndTrailerSignatureButNoSigningContext_ReturnsAccessDenied` (`IntegratedS3HttpEndpointsTests.cs`): drives a signed-streaming PUT with an `x-amz-trailer-signature` trailer through the full pipeline with SigV4 auth disabled (default test host) and asserts `403 AccessDenied` and that the object is **not** written.

- **Before the fix:** request returned `200 OK` (object accepted, fail-open) — test fails.
- **After the fix:** `403 AccessDenied` — test passes.

Full suite green: **1165 passed, 0 failed**.

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)