### PR TITLE
fix: route ?intelligent-tiering bucket requests to their handlers (#153)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -198,10 +198,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static readonly HashSet<string> BucketAnalyticsQueryParameters = CreateQueryParameterSet(AnalyticsQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketMetricsQueryParameters = CreateQueryParameterSet(MetricsQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketInventoryQueryParameters = CreateQueryParameterSet(InventoryQueryParameterName, IdQueryParameterName);
+    private static readonly HashSet<string> BucketIntelligentTieringQueryParameters = CreateQueryParameterSet(IntelligentTieringQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketVersionListingQueryParameters = CreateQueryParameterSet(VersionsQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MaxKeysQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, EncodingTypeQueryParameterName);
     private static readonly HashSet<string> BucketMultipartUploadsQueryParameters = CreateQueryParameterSet(UploadsQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MaxUploadsQueryParameterName, KeyMarkerQueryParameterName, UploadIdMarkerQueryParameterName, EncodingTypeQueryParameterName);
     private static readonly HashSet<string> BucketDeleteQueryParameters = CreateQueryParameterSet(DeleteQueryParameterName);
-    private static readonly HashSet<string> KnownBucketQueryParameters = CreateQueryParameterSet(ListTypeQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MarkerQueryParameterName, StartAfterQueryParameterName, MaxKeysQueryParameterName, MaxUploadsQueryParameterName, ContinuationTokenQueryParameterName, EncodingTypeQueryParameterName, FetchOwnerQueryParameterName, LocationQueryParameterName, AclQueryParameterName, CorsQueryParameterName, PolicyQueryParameterName, VersioningQueryParameterName, EncryptionQueryParameterName, TaggingQueryParameterName, LoggingQueryParameterName, WebsiteQueryParameterName, RequestPaymentQueryParameterName, AccelerateQueryParameterName, LifecycleQueryParameterName, ReplicationQueryParameterName, NotificationQueryParameterName, ObjectLockQueryParameterName, AnalyticsQueryParameterName, MetricsQueryParameterName, InventoryQueryParameterName, IdQueryParameterName, VersionsQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, UploadIdMarkerQueryParameterName, UploadsQueryParameterName, DeleteQueryParameterName);
+    private static readonly HashSet<string> KnownBucketQueryParameters = CreateQueryParameterSet(ListTypeQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MarkerQueryParameterName, StartAfterQueryParameterName, MaxKeysQueryParameterName, MaxUploadsQueryParameterName, ContinuationTokenQueryParameterName, EncodingTypeQueryParameterName, FetchOwnerQueryParameterName, LocationQueryParameterName, AclQueryParameterName, CorsQueryParameterName, PolicyQueryParameterName, VersioningQueryParameterName, EncryptionQueryParameterName, TaggingQueryParameterName, LoggingQueryParameterName, WebsiteQueryParameterName, RequestPaymentQueryParameterName, AccelerateQueryParameterName, LifecycleQueryParameterName, ReplicationQueryParameterName, NotificationQueryParameterName, ObjectLockQueryParameterName, AnalyticsQueryParameterName, MetricsQueryParameterName, InventoryQueryParameterName, IntelligentTieringQueryParameterName, IdQueryParameterName, VersionsQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, UploadIdMarkerQueryParameterName, UploadsQueryParameterName, DeleteQueryParameterName);
     private static readonly HashSet<string> ObjectVersionQueryParameters = CreateQueryParameterSet(VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectAclQueryParameters = CreateQueryParameterSet(AclQueryParameterName);
     private static readonly HashSet<string> ObjectTaggingQueryParameters = CreateQueryParameterSet(TaggingQueryParameterName, VersionIdQueryParameterName);
@@ -4940,6 +4941,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         var isBucketAnalyticsRequest = queryKeys.Contains(AnalyticsQueryParameterName) && queryKeys.IsSubsetOf(BucketAnalyticsQueryParameters);
         var isBucketMetricsRequest = queryKeys.Contains(MetricsQueryParameterName) && queryKeys.IsSubsetOf(BucketMetricsQueryParameters);
         var isBucketInventoryRequest = queryKeys.Contains(InventoryQueryParameterName) && queryKeys.IsSubsetOf(BucketInventoryQueryParameters);
+        var isBucketIntelligentTieringRequest = queryKeys.Contains(IntelligentTieringQueryParameterName) && queryKeys.IsSubsetOf(BucketIntelligentTieringQueryParameters);
         var isListObjectVersionsRequest = queryKeys.Contains(VersionsQueryParameterName) && queryKeys.IsSubsetOf(BucketVersionListingQueryParameters);
         var isListMultipartUploadsRequest = queryKeys.Contains(UploadsQueryParameterName) && queryKeys.IsSubsetOf(BucketMultipartUploadsQueryParameters);
         var isDeleteObjectsRequest = queryKeys.SetEquals(BucketDeleteQueryParameters);
@@ -4980,6 +4982,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketAnalyticsRequest
                     || isBucketMetricsRequest
                     || isBucketInventoryRequest
+                    || isBucketIntelligentTieringRequest
                     || isListObjectVersionsRequest
                     || isListMultipartUploadsRequest) {
                     break;
@@ -5022,7 +5025,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketObjectLockRequest
                     || isBucketAnalyticsRequest
                     || isBucketMetricsRequest
-                    || isBucketInventoryRequest) {
+                    || isBucketInventoryRequest
+                    || isBucketIntelligentTieringRequest) {
                     break;
                 }
 
@@ -5039,7 +5043,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketReplicationRequest
                     || isBucketAnalyticsRequest
                     || isBucketMetricsRequest
-                    || isBucketInventoryRequest) {
+                    || isBucketInventoryRequest
+                    || isBucketIntelligentTieringRequest) {
                     break;
                 }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -1460,6 +1460,9 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     [InlineData("?analytics&id=report", "NoSuchConfiguration")]
     [InlineData("?metrics&id=report", "NoSuchConfiguration")]
     [InlineData("?inventory&id=report", "NoSuchConfiguration")]
+    // Regression for #153: ?intelligent-tiering was rejected by the request validator before dispatch,
+    // so the (existing) handler was unreachable. It must now route through and surface the mapped 404.
+    [InlineData("?intelligent-tiering&id=report", "NoSuchConfiguration")]
     public async Task S3CompatibleBucketSubresource_WhenConfigAbsent_ReturnsNoSuchCodeWithNotFoundStatus(string query, string expectedCode)
     {
         // Regression test for #152: absent bucket subresource configs must surface the specific
@@ -10163,6 +10166,7 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
             => ValueTask.FromResult(StorageResult<BucketInventoryConfiguration>.Failure(NotFound(StorageErrorCode.InventoryConfigurationNotFound, bucketName)));
 
         public IAsyncEnumerable<BucketInfo> ListBucketsAsync(CancellationToken cancellationToken = default) => throw Boom();
+        // Overridden below with a proper NotFound result so #153's intelligent-tiering routing regression can assert the mapped 404.
         public ValueTask<StorageResult<BucketInfo>> CreateBucketAsync(CreateBucketRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult<BucketLocationInfo>> GetBucketLocationAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult<BucketVersioningInfo>> GetBucketVersioningAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
@@ -10221,7 +10225,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         public ValueTask<StorageResult<BucketInventoryConfiguration>> PutBucketInventoryConfigurationAsync(PutBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult> DeleteBucketInventoryConfigurationAsync(DeleteBucketInventoryConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult<IReadOnlyList<BucketInventoryConfiguration>>> ListBucketInventoryConfigurationsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
-        public ValueTask<StorageResult<BucketIntelligentTieringConfiguration>> GetBucketIntelligentTieringConfigurationAsync(string bucketName, string id, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<BucketIntelligentTieringConfiguration>> GetBucketIntelligentTieringConfigurationAsync(string bucketName, string id, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(StorageResult<BucketIntelligentTieringConfiguration>.Failure(NotFound(StorageErrorCode.IntelligentTieringConfigurationNotFound, bucketName)));
         public ValueTask<StorageResult<BucketIntelligentTieringConfiguration>> PutBucketIntelligentTieringConfigurationAsync(PutBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult> DeleteBucketIntelligentTieringConfigurationAsync(DeleteBucketIntelligentTieringConfigurationRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult<IReadOnlyList<BucketIntelligentTieringConfiguration>>> ListBucketIntelligentTieringConfigurationsAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();


### PR DESCRIPTION
## Summary
The `?intelligent-tiering` bucket subresource handlers (`List`/`Get`/`Put`/`Delete`) existed and were already wired into the dispatch switch, but they were **unreachable dead code**: `TryValidateBucketRequestSubresources` runs *before* dispatch and `intelligent-tiering` was missing from `KnownBucketQueryParameters`. Every `?intelligent-tiering` request was rejected as an unsupported subresource and returned `501 NotImplemented`.

## Fix
Mirrors exactly how the sibling `id=`-scoped subresources (`analytics`/`metrics`/`inventory`) are accepted:

- Add `IntelligentTieringQueryParameterName` to `KnownBucketQueryParameters`.
- Add `BucketIntelligentTieringQueryParameters` = `{ intelligent-tiering, id }`.
- Add `isBucketIntelligentTieringRequest` and accept it in the `GET`/`PUT`/`DELETE` validator branches.

No handler or dispatch changes were needed — those were already correct; only the validator gate was closed.

## Regression test
Extended the existing absent-subresource theory (`S3CompatibleBucketSubresource_WhenConfigAbsent_ReturnsNoSuchCodeWithNotFoundStatus`) with `?intelligent-tiering&id=report`. The request now routes through to the handler and returns `404 NoSuchConfiguration` instead of `501 NotImplemented`.

Verified **fails-before** (returned `501 NotImplemented`) / **passes-after**. Full suite: **1165 passed, 0 failed**; build clean, 0 warnings.

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)
