### PR TITLE
Serialize AbortMultipartUpload against Complete under the object lock and make cleanup idempotent

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -3089,7 +3089,7 @@ internal sealed class DiskStorageService(
                 etag: multipartETag);
 
             await DeleteStoredMultipartStateAsync(request.BucketName, request.Key, request.UploadId, uploadState.UploadDirectoryPath, cancellationToken);
-            Directory.Delete(uploadState.UploadDirectoryPath, recursive: true);
+            DeleteDirectoryIfExists(uploadState.UploadDirectoryPath);
         }
         finally {
             if (File.Exists(tempObjectPath)) {
@@ -3109,14 +3109,23 @@ internal sealed class DiskStorageService(
             return StorageResult.Failure(BucketNotFound(request.BucketName));
         }
 
+        // Serialize against CompleteMultipartUpload on the same striped object mutation lock so an
+        // Abort concurrent with a Complete cannot interleave and delete the upload directory out from
+        // under an in-flight assemble/cleanup (which would surface as an unhandled 500 instead of a
+        // deterministic S3 error). Re-read the multipart state *after* acquiring the lock: a Complete
+        // (or a second Abort) that ran first may already have removed it, in which case we return a
+        // clean NoSuchUpload rather than throwing.
+        using var objectMutationLock = await AcquireObjectMutationLockAsync(request.BucketName, request.Key, cancellationToken);
+
         var uploadStateResult = await ReadMultipartStateAsync(request.BucketName, request.Key, request.UploadId, cancellationToken);
         if (!uploadStateResult.IsSuccess) {
             return StorageResult.Failure(uploadStateResult.Error!);
         }
 
-        Directory.Delete(uploadStateResult.Value!.UploadDirectoryPath, recursive: true);
-        await DeleteStoredMultipartStateAsync(request.BucketName, request.Key, request.UploadId, uploadStateResult.Value.UploadDirectoryPath, cancellationToken);
-        DeleteEmptyParentDirectories(Path.GetDirectoryName(uploadStateResult.Value.UploadDirectoryPath), GetMultipartRootPath());
+        var uploadDirectoryPath = uploadStateResult.Value!.UploadDirectoryPath;
+        DeleteDirectoryIfExists(uploadDirectoryPath);
+        await DeleteStoredMultipartStateAsync(request.BucketName, request.Key, request.UploadId, uploadDirectoryPath, cancellationToken);
+        DeleteEmptyParentDirectories(Path.GetDirectoryName(uploadDirectoryPath), GetMultipartRootPath());
         return StorageResult.Success();
     }
 
@@ -4649,12 +4658,25 @@ internal sealed class DiskStorageService(
 
     private static async ValueTask<DiskMultipartUploadState?> ReadDiskMultipartUploadStateAsync(string statePath, CancellationToken cancellationToken)
     {
-        if (!File.Exists(statePath)) {
+        // The multipart state sidecar is read without holding the object mutation lock (Complete and
+        // Abort both read it before acquiring the lock). A concurrent Abort/Complete may delete the
+        // upload directory containing this file while it is open. Share FileShare.Delete so a
+        // concurrent directory delete cannot fault this reader with a sharing violation; translate a
+        // lost race (file removed out from under us) to a null "no such upload" result.
+        FileStream stream;
+        try {
+            stream = new FileStream(statePath, FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        }
+        catch (FileNotFoundException) {
+            return null;
+        }
+        catch (DirectoryNotFoundException) {
             return null;
         }
 
-        await using var stream = new FileStream(statePath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, FileOptions.Asynchronous | FileOptions.SequentialScan);
-        return await JsonSerializer.DeserializeAsync(stream, DiskStorageJsonSerializerContext.Default.DiskMultipartUploadState, cancellationToken);
+        await using (stream) {
+            return await JsonSerializer.DeserializeAsync(stream, DiskStorageJsonSerializerContext.Default.DiskMultipartUploadState, cancellationToken);
+        }
     }
 
     private static DiskObjectMetadata ToDiskObjectMetadata(ObjectInfo? objectInfo)
@@ -6417,6 +6439,27 @@ internal sealed class DiskStorageService(
     {
         var utcValue = value.ToUniversalTime();
         return utcValue.AddTicks(-(utcValue.Ticks % TimeSpan.TicksPerSecond));
+    }
+
+    /// <summary>
+    /// Recursively deletes <paramref name="directoryPath"/> if it still exists, treating an
+    /// already-removed directory as a benign no-op. Unlike <see cref="File.Delete(string)"/>,
+    /// <see cref="Directory.Delete(string, bool)"/> throws <see cref="DirectoryNotFoundException"/>
+    /// when the path is missing; this makes multipart cleanup idempotent so a concurrent
+    /// Abort/Complete (or a repeated Abort) cannot turn into an unhandled exception.
+    /// </summary>
+    private static void DeleteDirectoryIfExists(string directoryPath)
+    {
+        if (string.IsNullOrWhiteSpace(directoryPath)) {
+            return;
+        }
+
+        try {
+            Directory.Delete(directoryPath, recursive: true);
+        }
+        catch (DirectoryNotFoundException) {
+            // Another Abort/Complete on the same upload already removed the directory. No-op.
+        }
     }
 
     private static void DeleteEmptyParentDirectories(string? currentDirectoryPath, string stopAtDirectoryPath)

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -3372,6 +3372,179 @@ public sealed class DiskStorageServiceTests
     }
 
     [Fact]
+    public async Task DiskStorage_MultipartUpload_AbortTwice_IsIdempotent()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "multipart-abort-twice" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "multipart-abort-twice",
+            Key = "docs/aborted.txt"
+        });
+        Assert.True(initiateResult.IsSuccess);
+
+        await using var partStream = new MemoryStream(Encoding.UTF8.GetBytes("temporary"));
+        var uploadPartResult = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "multipart-abort-twice",
+            Key = "docs/aborted.txt",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 1,
+            Content = partStream
+        });
+        Assert.True(uploadPartResult.IsSuccess);
+
+        var firstAbort = await storageService.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+        {
+            BucketName = "multipart-abort-twice",
+            Key = "docs/aborted.txt",
+            UploadId = initiateResult.Value.UploadId
+        });
+        Assert.True(firstAbort.IsSuccess);
+
+        // A repeated Abort on an upload whose directory was already removed must not throw a
+        // DirectoryNotFoundException; it should return a deterministic NoSuchUpload failure.
+        var secondAbort = await storageService.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+        {
+            BucketName = "multipart-abort-twice",
+            Key = "docs/aborted.txt",
+            UploadId = initiateResult.Value.UploadId
+        });
+
+        Assert.False(secondAbort.IsSuccess);
+        Assert.Equal(IntegratedS3.Abstractions.Errors.StorageErrorCode.NoSuchUpload, secondAbort.Error!.Code);
+    }
+
+    [Fact]
+    public async Task DiskStorage_MultipartUpload_AbortAfterComplete_IsIdempotent()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "multipart-abort-after-complete" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "multipart-abort-after-complete",
+            Key = "docs/assembled.txt"
+        });
+        Assert.True(initiateResult.IsSuccess);
+
+        await using var partStream = new MemoryStream(Encoding.UTF8.GetBytes("completed"));
+        var uploadPartResult = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+        {
+            BucketName = "multipart-abort-after-complete",
+            Key = "docs/assembled.txt",
+            UploadId = initiateResult.Value!.UploadId,
+            PartNumber = 1,
+            Content = partStream
+        });
+        Assert.True(uploadPartResult.IsSuccess);
+
+        var completeResult = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "multipart-abort-after-complete",
+            Key = "docs/assembled.txt",
+            UploadId = initiateResult.Value.UploadId,
+            Parts = [uploadPartResult.Value!]
+        });
+        Assert.True(completeResult.IsSuccess);
+
+        // Complete already cleaned up the upload directory. A follow-up Abort (e.g. a client retry)
+        // must be a benign no-op returning NoSuchUpload rather than throwing on the missing directory.
+        var abortResult = await storageService.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+        {
+            BucketName = "multipart-abort-after-complete",
+            Key = "docs/assembled.txt",
+            UploadId = initiateResult.Value.UploadId
+        });
+
+        Assert.False(abortResult.IsSuccess);
+        Assert.Equal(IntegratedS3.Abstractions.Errors.StorageErrorCode.NoSuchUpload, abortResult.Error!.Code);
+    }
+
+    [Fact]
+    public async Task DiskStorage_MultipartUpload_ConcurrentAbortAndComplete_NeverThrowsAndStaysConsistent()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "multipart-abort-race" });
+
+        // Many iterations to shake out interleavings between a lock-holding Complete and a
+        // concurrent Abort on the same bucket/key/uploadId. Each iteration must terminate with a
+        // clean StorageResult on both operations — never a thrown DirectoryNotFoundException/500.
+        for (var iteration = 0; iteration < 60; iteration++)
+        {
+            var key = $"docs/race-{iteration}.txt";
+
+            var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+            {
+                BucketName = "multipart-abort-race",
+                Key = key
+            });
+            Assert.True(initiateResult.IsSuccess);
+            var uploadId = initiateResult.Value!.UploadId;
+
+            await using (var partStream = new MemoryStream(Encoding.UTF8.GetBytes($"payload-{iteration}")))
+            {
+                var uploadPartResult = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+                {
+                    BucketName = "multipart-abort-race",
+                    Key = key,
+                    UploadId = uploadId,
+                    PartNumber = 1,
+                    Content = partStream
+                });
+                Assert.True(uploadPartResult.IsSuccess);
+
+                var completeTask = Task.Run(async () => await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+                {
+                    BucketName = "multipart-abort-race",
+                    Key = key,
+                    UploadId = uploadId,
+                    Parts = [uploadPartResult.Value!]
+                }));
+
+                var abortTask = Task.Run(async () => await storageService.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+                {
+                    BucketName = "multipart-abort-race",
+                    Key = key,
+                    UploadId = uploadId
+                }));
+
+                // Neither operation may throw; both must resolve to a StorageResult. If either threw,
+                // Task.WhenAll rethrows here and the test fails, which is precisely the bug we guard.
+                var completeResult = await completeTask;
+                var abortResult = await abortTask;
+
+                // Every outcome must be either a clean success or a clean, well-defined failure.
+                Assert.True(
+                    completeResult.IsSuccess
+                        || completeResult.Error!.Code is IntegratedS3.Abstractions.Errors.StorageErrorCode.NoSuchUpload
+                            or IntegratedS3.Abstractions.Errors.StorageErrorCode.MultipartConflict
+                            or IntegratedS3.Abstractions.Errors.StorageErrorCode.InvalidPart,
+                    $"Unexpected Complete outcome: {completeResult.Error?.Code}");
+                Assert.True(
+                    abortResult.IsSuccess
+                        || abortResult.Error!.Code == IntegratedS3.Abstractions.Errors.StorageErrorCode.NoSuchUpload,
+                    $"Unexpected Abort outcome: {abortResult.Error?.Code}");
+            }
+
+            // A follow-up Abort of the same upload id must always be a clean no-op (NoSuchUpload),
+            // proving no orphaned upload directory/state survived the race.
+            var trailingAbort = await storageService.AbortMultipartUploadAsync(new AbortMultipartUploadRequest
+            {
+                BucketName = "multipart-abort-race",
+                Key = key,
+                UploadId = uploadId
+            });
+            Assert.False(trailingAbort.IsSuccess);
+            Assert.Equal(IntegratedS3.Abstractions.Errors.StorageErrorCode.NoSuchUpload, trailingAbort.Error!.Code);
+        }
+    }
+
+    [Fact]
     public async Task DiskStorage_MultipartUpload_ListMultipartUploads_AppliesPrefixMarkersAndPageSize()
     {
         await using var fixture = new DiskStorageFixture();


### PR DESCRIPTION
## Summary

`DiskStorageService.AbortMultipartUploadAsync` deleted the multipart upload directory **without acquiring the per-object mutation lock** that `CompleteMultipartUploadCoreAsync` holds. A concurrent Abort + Complete (or Abort + Abort) on the same `bucket/key/uploadId` — a plausible client double-submit / retry — could interleave and surface as an unhandled **500** instead of a deterministic S3 error.

## Root cause

Two distinct races, both fixed here:

1. **No serialization.** Abort took no lock, so its `Directory.Delete` could run while a lock-holding Complete was assembling parts, tripping `DirectoryNotFoundException` at Complete's part-open or final cleanup delete.
2. **Lock-free state read.** Even after adding the lock, both Complete and Abort read the `upload.json` sidecar **before** acquiring the lock. That read opened the file with `FileShare.Read` (no `Delete`), so a concurrent Abort deleting the directory faulted the reader with a sharing-violation `IOException` (`upload.json ... used by another process`). This was surfaced by the new concurrency test and is the load-bearing part of the fix.

## Changes

- `AbortMultipartUploadAsync` now acquires `AcquireObjectMutationLockAsync` (the same striped lock Complete uses) and **re-reads** the multipart state under the lock; when the state is already gone it returns a clean `NoSuchUpload`.
- New idempotent `DeleteDirectoryIfExists` helper (swallows `DirectoryNotFoundException`) used by both Complete and Abort cleanup, closing the bare-`Directory.Delete` TOCTOU window.
- `ReadDiskMultipartUploadStateAsync` opens the sidecar with `FileShare.Read | FileShare.Delete` and tolerates `File/DirectoryNotFoundException`, so the pre-lock state read can't fault when a concurrent Abort deletes the directory.

## Tests

- `DiskStorage_MultipartUpload_ConcurrentAbortAndComplete_NeverThrowsAndStaysConsistent` — 60 iterations of `Task.WhenAll(Complete, Abort)`; asserts neither throws and every outcome is a clean `StorageResult`. **Fails before this fix** (`IOException`), passes after; verified stable across repeated runs.
- `DiskStorage_MultipartUpload_AbortTwice_IsIdempotent` and `DiskStorage_MultipartUpload_AbortAfterComplete_IsIdempotent` — repeated / post-Complete Abort returns `NoSuchUpload`, never throws.

Full suite green: **1167 passed, 0 failed**.

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)