### PR TITLE
Serialize concurrent same-part-number UploadPart so returned ETag/checksum describes this call's bytes (#124)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -2620,6 +2620,15 @@ internal sealed class DiskStorageService(
 
         var partPath = GetMultipartPartPath(uploadDirectoryPath, request.PartNumber);
         var tempPartPath = $"{partPath}.{Guid.NewGuid():N}.tmp";
+        // The returned ETag/checksum/length MUST describe the bytes THIS call wrote. The finalized
+        // part path is shared per (uploadId, partNumber), so two concurrent UploadPart calls for the
+        // same part number race on partPath: re-reading partPath after File.Move could observe the
+        // other caller's bytes. Capture the metadata from this call's exclusively-owned temp file
+        // BEFORE the atomic File.Move so the response always matches what this call persisted. The
+        // File.Move rename is atomic, so the persisted part is never torn (last writer wins).
+        long partLength;
+        DateTime partLastWriteTimeUtc;
+        IReadOnlyDictionary<string, string> actualChecksums;
         if (HasCopySource(request)) {
             if (!string.IsNullOrWhiteSpace(request.ChecksumAlgorithm)
                 || request.Checksums is { Count: > 0 }) {
@@ -2684,7 +2693,19 @@ internal sealed class DiskStorageService(
                     await FlushToStableStorageAsync(tempStream, cancellationToken);
                 }
 
-                File.Move(tempPartPath, partPath, overwrite: true);
+                // Capture this call's metadata from the temp file before publishing it, so the
+                // response describes the bytes this call wrote even if a concurrent same-part
+                // upload overwrites partPath immediately after the move.
+                var tempInfo = new FileInfo(tempPartPath);
+                partLength = tempInfo.Length;
+                partLastWriteTimeUtc = tempInfo.LastWriteTimeUtc;
+                actualChecksums = await ComputeChecksumsAsync(tempPartPath, cancellationToken);
+
+                // Serialize the publish for this (uploadId, partNumber). Concurrent overwrite moves
+                // into the same destination fail with UnauthorizedAccessException on Windows.
+                using (await AcquireMultipartPartMutationLockAsync(uploadDirectoryPath, request.PartNumber, cancellationToken)) {
+                    File.Move(tempPartPath, partPath, overwrite: true);
+                }
             }
             finally {
                 if (File.Exists(tempPartPath)) {
@@ -2709,7 +2730,19 @@ internal sealed class DiskStorageService(
                     await FlushToStableStorageAsync(tempStream, cancellationToken);
                 }
 
-                File.Move(tempPartPath, partPath, overwrite: true);
+                // Capture this call's metadata from the temp file before publishing it, so the
+                // response describes the bytes this call wrote even if a concurrent same-part
+                // upload overwrites partPath immediately after the move.
+                var tempInfo = new FileInfo(tempPartPath);
+                partLength = tempInfo.Length;
+                partLastWriteTimeUtc = tempInfo.LastWriteTimeUtc;
+                actualChecksums = await ComputeChecksumsAsync(tempPartPath, cancellationToken);
+
+                // Serialize the publish for this (uploadId, partNumber). Concurrent overwrite moves
+                // into the same destination fail with UnauthorizedAccessException on Windows.
+                using (await AcquireMultipartPartMutationLockAsync(uploadDirectoryPath, request.PartNumber, cancellationToken)) {
+                    File.Move(tempPartPath, partPath, overwrite: true);
+                }
             }
             finally {
                 if (File.Exists(tempPartPath)) {
@@ -2718,8 +2751,6 @@ internal sealed class DiskStorageService(
             }
         }
 
-        var partInfo = new FileInfo(partPath);
-        var actualChecksums = await ComputeChecksumsAsync(partPath, cancellationToken);
         var checksumValidationError = ValidateRequestedChecksums(request.Checksums, actualChecksums, request.BucketName, request.Key);
         if (checksumValidationError is not null) {
             return StorageResult<MultipartUploadPart>.Failure(checksumValidationError);
@@ -2729,8 +2760,8 @@ internal sealed class DiskStorageService(
         {
             PartNumber = request.PartNumber,
             ETag = BuildPartETag(actualChecksums),
-            ContentLength = partInfo.Length,
-            LastModifiedUtc = partInfo.LastWriteTimeUtc,
+            ContentLength = partLength,
+            LastModifiedUtc = partLastWriteTimeUtc,
             Checksums = CreateMultipartPartResponseChecksums(
                 actualChecksums,
                 uploadChecksumAlgorithm,
@@ -2825,6 +2856,13 @@ internal sealed class DiskStorageService(
 
         var partPath = GetMultipartPartPath(uploadDirectoryPath, request.PartNumber);
         var tempPartPath = $"{partPath}.{Guid.NewGuid():N}.tmp";
+        // Capture the metadata from this call's exclusively-owned temp file before the atomic
+        // publish and serialize the publish, so the response always describes the bytes this call
+        // wrote and a concurrent same-part publish cannot fail the overwrite move on Windows. See
+        // the matching handling in UploadMultipartPartAsync.
+        long partLength;
+        DateTime partLastWriteTimeUtc;
+        IReadOnlyDictionary<string, string> actualChecksums;
         try {
             // The copy source is opened lock-free, so a concurrent delete/overwrite of the
             // source key can race this open. Translate a lost TOCTOU race to NoSuchKey (404)
@@ -2847,7 +2885,14 @@ internal sealed class DiskStorageService(
                 await FlushToStableStorageAsync(tempStream, cancellationToken);
             }
 
-            File.Move(tempPartPath, partPath, overwrite: true);
+            var tempInfo = new FileInfo(tempPartPath);
+            partLength = tempInfo.Length;
+            partLastWriteTimeUtc = tempInfo.LastWriteTimeUtc;
+            actualChecksums = await ComputeChecksumsAsync(tempPartPath, cancellationToken);
+
+            using (await AcquireMultipartPartMutationLockAsync(uploadDirectoryPath, request.PartNumber, cancellationToken)) {
+                File.Move(tempPartPath, partPath, overwrite: true);
+            }
         }
         finally {
             if (File.Exists(tempPartPath)) {
@@ -2855,8 +2900,6 @@ internal sealed class DiskStorageService(
             }
         }
 
-        var partInfo = new FileInfo(partPath);
-        var actualChecksums = await ComputeChecksumsAsync(partPath, cancellationToken);
         var checksumValidationError = ValidateRequestedChecksums(request.Checksums, actualChecksums, request.BucketName, request.Key);
         if (checksumValidationError is not null) {
             return StorageResult<MultipartUploadPart>.Failure(checksumValidationError);
@@ -2866,8 +2909,8 @@ internal sealed class DiskStorageService(
         {
             PartNumber = request.PartNumber,
             ETag = BuildPartETag(actualChecksums),
-            ContentLength = partInfo.Length,
-            LastModifiedUtc = partInfo.LastWriteTimeUtc,
+            ContentLength = partLength,
+            LastModifiedUtc = partLastWriteTimeUtc,
             Checksums = CreateMultipartPartResponseChecksums(
                 actualChecksums,
                 uploadChecksumAlgorithm,
@@ -6626,6 +6669,21 @@ internal sealed class DiskStorageService(
     private ValueTask<MutationLockReleaser> AcquireObjectMutationLockAsync(string bucketName, string key, CancellationToken cancellationToken)
     {
         return AcquireMutationLockAsync(GetBucketPath(bucketName), NormalizeKey(key), cancellationToken);
+    }
+
+    /// <summary>
+    /// Serializes finalization of a single multipart part identified by its upload directory and
+    /// part number. Two concurrent UploadPart calls for the same <c>(uploadId, partNumber)</c>
+    /// publish into the same shared part path, so without this lock their
+    /// <see cref="File.Move(string, string, bool)"/> overwrites can race (a concurrent overwrite of
+    /// the same destination fails with <c>UnauthorizedAccessException</c> on Windows) and their
+    /// returned ETag/checksum could describe the other caller's bytes. Locks are striped, so
+    /// unrelated parts may occasionally share a stripe, which only adds contention and never
+    /// changes correctness.
+    /// </summary>
+    private ValueTask<MutationLockReleaser> AcquireMultipartPartMutationLockAsync(string uploadDirectoryPath, int partNumber, CancellationToken cancellationToken)
+    {
+        return AcquireMutationLockAsync(uploadDirectoryPath, partNumber.ToString(System.Globalization.CultureInfo.InvariantCulture), cancellationToken);
     }
 
     private async ValueTask<MutationLockReleaser> AcquireMutationLockAsync(string bucketPath, string? key, CancellationToken cancellationToken)

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -5750,4 +5750,143 @@ public sealed class DiskStorageServiceTests
         Assert.True(headResult.IsSuccess);
         Assert.Equal(expectedETag, headResult.Value!.ETag);
     }
+
+    [Fact]
+    public async Task DiskStorage_ConcurrentSamePartNumberUploads_EachETagMatchesOwnBytesAndPersistedPartIsWhole()
+    {
+        // Regression for #124: two concurrent UploadPart calls for the same (uploadId, partNumber)
+        // with different payloads race on the shared, part-number-keyed final path. Previously the
+        // response ETag/checksum/length was derived by re-reading that shared path AFTER File.Move,
+        // so one caller could return metadata describing the OTHER caller's bytes (or a torn mix).
+        // The fix captures each call's metadata from its own exclusively-owned temp file before the
+        // atomic publish, so each response always describes the bytes that call wrote, and the
+        // persisted part is always exactly one caller's complete bytes (never torn).
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "same-part-race" });
+
+        // Many iterations to reliably hit the interleaving window between the two publishes and the
+        // (previously) shared-path re-reads.
+        for (var iteration = 0; iteration < 80; iteration++)
+        {
+            var key = $"docs/race-{iteration}.txt";
+            var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+            {
+                BucketName = "same-part-race",
+                Key = key,
+                ChecksumAlgorithm = "SHA256"
+            });
+            Assert.True(initiateResult.IsSuccess);
+            var uploadId = initiateResult.Value!.UploadId;
+
+            // Two distinct payloads of different lengths, so a torn/other-caller read is detectable
+            // via ETag, sha256, AND ContentLength.
+            var payloadA = $"AAAA-payload-alpha-{iteration}-{new string('a', 37)}";
+            var payloadB = $"BB-payload-beta-{iteration}";
+            var bytesA = Encoding.UTF8.GetBytes(payloadA);
+            var bytesB = Encoding.UTF8.GetBytes(payloadB);
+            var checksumA = ComputeSha256Base64(payloadA);
+            var checksumB = ComputeSha256Base64(payloadB);
+            var expectedEtagA = Convert.ToHexStringLower(System.Security.Cryptography.MD5.HashData(bytesA));
+            var expectedEtagB = Convert.ToHexStringLower(System.Security.Cryptography.MD5.HashData(bytesB));
+
+            var uploadA = Task.Run(async () =>
+            {
+                await using var stream = new MemoryStream(bytesA);
+                return await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+                {
+                    BucketName = "same-part-race",
+                    Key = key,
+                    UploadId = uploadId,
+                    PartNumber = 1,
+                    Content = stream,
+                    ChecksumAlgorithm = "SHA256",
+                    Checksums = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["sha256"] = checksumA
+                    }
+                });
+            });
+
+            var uploadB = Task.Run(async () =>
+            {
+                await using var stream = new MemoryStream(bytesB);
+                return await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+                {
+                    BucketName = "same-part-race",
+                    Key = key,
+                    UploadId = uploadId,
+                    PartNumber = 1,
+                    Content = stream,
+                    ChecksumAlgorithm = "SHA256",
+                    Checksums = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+                    {
+                        ["sha256"] = checksumB
+                    }
+                });
+            });
+
+            var resultA = await uploadA;
+            var resultB = await uploadB;
+
+            Assert.True(resultA.IsSuccess, $"Upload A failed: {resultA.Error?.Code}");
+            Assert.True(resultB.IsSuccess, $"Upload B failed: {resultB.Error?.Code}");
+
+            // Core invariant: each response describes THIS call's own bytes — ETag, checksum, and
+            // length — regardless of who published last. On the pre-fix code, a lost race makes one
+            // of these assertions observe the other caller's bytes.
+            Assert.Equal(expectedEtagA, resultA.Value!.ETag);
+            Assert.Equal(bytesA.Length, resultA.Value.ContentLength);
+            Assert.Equal(ComputeSha256Base64(payloadA), resultA.Value.Checksums!["sha256"]);
+
+            Assert.Equal(expectedEtagB, resultB.Value!.ETag);
+            Assert.Equal(bytesB.Length, resultB.Value.ContentLength);
+            Assert.Equal(ComputeSha256Base64(payloadB), resultB.Value.Checksums!["sha256"]);
+
+            // The persisted part is exactly one caller's whole bytes (atomic rename => never torn).
+            // Completing with the winning caller's returned part must succeed and reproduce that
+            // caller's exact payload; the losing caller's ETag no longer matches the persisted part.
+            var completeWithA = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+            {
+                BucketName = "same-part-race",
+                Key = key,
+                UploadId = uploadId,
+                Parts = [resultA.Value]
+            });
+
+            string winnerPayload;
+            if (completeWithA.IsSuccess)
+            {
+                winnerPayload = payloadA;
+            }
+            else
+            {
+                // A lost: its ETag must not match the persisted part; B won and must complete cleanly.
+                Assert.Equal(StorageErrorCode.InvalidPart, completeWithA.Error!.Code);
+                var completeWithB = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+                {
+                    BucketName = "same-part-race",
+                    Key = key,
+                    UploadId = uploadId,
+                    Parts = [resultB.Value]
+                });
+                Assert.True(completeWithB.IsSuccess, $"Complete with B failed: {completeWithB.Error?.Code}");
+                winnerPayload = payloadB;
+            }
+
+            var getResult = await storageService.GetObjectAsync(new GetObjectRequest
+            {
+                BucketName = "same-part-race",
+                Key = key
+            });
+            Assert.True(getResult.IsSuccess);
+            await using (var response = getResult.Value!)
+            {
+                using var reader = new StreamReader(response.Content, Encoding.UTF8, leaveOpen: false);
+                var content = await reader.ReadToEndAsync();
+                // Persisted object is exactly one caller's whole payload — never a torn mix.
+                Assert.Equal(winnerPayload, content);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

`DiskStorageService.UploadMultipartPartAsync` finalized a part with a non-atomic "move-then-read-shared-path" sequence and held **no** per-part lock. Two concurrent `UploadPart` calls for the same `(uploadId, partNumber)` with different payloads raced on the deterministic, part-number-keyed part path:

- The response `ETag`/`Checksums`/`ContentLength` were derived by re-reading the **shared** `partPath` **after** `File.Move`, so one caller could return metadata describing the **other** caller's bytes (or a torn mix). This caused spurious `MultipartConflict` on completion, stored-content/returned-checksum divergence, and — when `request.Checksums` was supplied — a spurious `InvalidChecksum` failure (the caller's declared checksum was compared against the other caller's bytes).
- Additionally, on Windows two concurrent `File.Move(temp, partPath, overwrite: true)` into the same destination could fail one with `UnauthorizedAccessException` (surfaced while writing the regression test).

## Fix

- Capture `length`/`last-write-time`/`checksums` from **this call's** exclusively-owned temp file **before** the atomic publish, so the response always describes the bytes this call wrote.
- Serialize the publish per `(uploadId, partNumber)` via a new striped `AcquireMultipartPartMutationLockAsync`, so the concurrent overwrite move cannot race. `File.Move` is an atomic rename, so the persisted part is always exactly one caller's whole bytes (last writer wins), never torn.
- Apply the identical handling to the standalone `UploadPartCopyAsync`, which publishes into the same part path and had the same race.

## Test

Adds `DiskStorage_ConcurrentSamePartNumberUploads_EachETagMatchesOwnBytesAndPersistedPartIsWhole`: 80 iterations, each launching two concurrent same-part uploads with distinct payloads. Asserts each response's `ETag`/`sha256`/`ContentLength` matches **its own** bytes, and that completing with the winning part reproduces exactly one caller's whole payload (never a torn mix).

- **Fails before** this change: `Upload B failed: InvalidChecksum` (B's declared checksum validated against A's re-read bytes).
- **Passes after.**

Full solution builds clean; all 1175 tests in `IntegratedS3.Tests` pass.

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)