### PR TITLE
Verify per-chunk SigV4/SigV4a signature chain for signed aws-chunked uploads

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/ChunkSignatureMismatchException.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/ChunkSignatureMismatchException.cs
@@ -1,0 +1,13 @@
+namespace IntegratedS3.AspNetCore.Endpoints;
+
+/// <summary>
+/// Thrown while decoding a signed <c>aws-chunked</c> streaming body when a chunk's
+/// per-chunk SigV4/SigV4a signature (the <c>;chunk-signature=</c> extension) does not match the
+/// signature recomputed by the server over the chunk bytes and the rolling signature chain.
+/// This is what cryptographically binds the uploaded body bytes to the authenticated request
+/// signature. Maps to the S3 <c>SignatureDoesNotMatch</c> error (HTTP 403).
+/// </summary>
+internal sealed class ChunkSignatureMismatchException()
+    : Exception("The request signature we calculated does not match the signature you provided.")
+{
+}

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -7144,10 +7144,15 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         var tempFilePath = Path.Combine(Path.GetTempPath(), $"integrateds3-aws-chunked-{Guid.NewGuid():N}.tmp");
         var trailerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var trailerHeaderEntries = new List<KeyValuePair<string, string>>();
+        // For signed streaming payload hashes (STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER and the
+        // SigV4a ECDSA variant) the per-chunk signature chain is what binds the body bytes to the
+        // authenticated request. Build a verifier from the signing context established by the
+        // authenticator so CopyAwsChunkedContentToAsync can recompute and check each chunk signature.
+        var chunkSignatureVerifier = TryCreateChunkSignatureVerifier(request);
         string? finalChunkSignature = null;
         try {
             await using (var tempWriteStream = new FileStream(tempFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
-                finalChunkSignature = await CopyAwsChunkedContentToAsync(request.Body, tempWriteStream, trailerHeaders, trailerHeaderEntries, cancellationToken);
+                finalChunkSignature = await CopyAwsChunkedContentToAsync(request.Body, tempWriteStream, trailerHeaders, trailerHeaderEntries, chunkSignatureVerifier, cancellationToken);
                 await tempWriteStream.FlushAsync(cancellationToken);
             }
 
@@ -7258,6 +7263,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         Stream destination,
         Dictionary<string, string> trailerHeaders,
         List<KeyValuePair<string, string>> trailerHeaderEntries,
+        AwsChunkedChunkSignatureVerifier? chunkSignatureVerifier,
         CancellationToken cancellationToken)
     {
         while (true) {
@@ -7270,13 +7276,55 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             }
 
             if (chunkLength == 0) {
+                // The zero-length terminating chunk carries the final chunk signature, which anchors
+                // the trailer signature. When verifying, recompute it over the empty chunk (chained
+                // from the last data chunk) so the returned value is the server-verified signature
+                // rather than the client-supplied one; this closes the trailer-signature gap too.
+                if (chunkSignatureVerifier is not null) {
+                    var verifiedFinalSignature = chunkSignatureVerifier.VerifyChunk(
+                        chunkHeader,
+                        S3SigV4Signer.ComputeSha256Hex(ReadOnlySpan<byte>.Empty));
+                    await ConsumeChunkTrailersAsync(source, trailerHeaders, trailerHeaderEntries, cancellationToken);
+                    return verifiedFinalSignature;
+                }
+
                 await ConsumeChunkTrailersAsync(source, trailerHeaders, trailerHeaderEntries, cancellationToken);
                 return TryGetAwsChunkSignature(chunkHeader);
             }
 
-            await CopyExactBytesAsync(source, destination, chunkLength, cancellationToken);
+            if (chunkSignatureVerifier is null) {
+                await CopyExactBytesAsync(source, destination, chunkLength, hasher: null, cancellationToken);
+                await ExpectCrLfAsync(source, cancellationToken);
+                continue;
+            }
+
+            using var chunkHasher = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+            await CopyExactBytesAsync(source, destination, chunkLength, chunkHasher, cancellationToken);
             await ExpectCrLfAsync(source, cancellationToken);
+            var chunkContentHashHex = Convert.ToHexStringLower(chunkHasher.GetCurrentHash());
+            chunkSignatureVerifier.VerifyChunk(chunkHeader, chunkContentHashHex);
         }
+    }
+
+    /// <summary>
+    /// Builds a per-chunk signature verifier for signed <c>aws-chunked</c> streaming uploads, or
+    /// <see langword="null"/> when the request does not use a signed streaming payload hash (in which
+    /// case the intermediate chunk signatures are advisory and not verified). Requires the signing
+    /// context established by the SigV4/SigV4a authenticator; if the request declares a signed
+    /// streaming payload hash but carries no signing context, the trailer-signature validation path
+    /// already rejects it (fail-closed), so returning <see langword="null"/> here is safe.
+    /// </summary>
+    private static AwsChunkedChunkSignatureVerifier? TryCreateChunkSignatureVerifier(HttpRequest request)
+    {
+        if (!IsSignedTrailerBackedStreamingPayloadHash(request.Headers[AwsContentSha256HeaderName].ToString())) {
+            return null;
+        }
+
+        if (!AwsChunkedTrailerSigningContextStore.TryGet(request.HttpContext, out var signingContext)) {
+            return null;
+        }
+
+        return new AwsChunkedChunkSignatureVerifier(signingContext);
     }
 
     private static async Task<string?> ReadLineAsync(Stream source, CancellationToken cancellationToken)
@@ -7373,7 +7421,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         return null;
     }
 
-    private static async Task CopyExactBytesAsync(Stream source, Stream destination, long byteCount, CancellationToken cancellationToken)
+    private static async Task CopyExactBytesAsync(Stream source, Stream destination, long byteCount, IncrementalHash? hasher, CancellationToken cancellationToken)
     {
         var remaining = byteCount;
         var buffer = new byte[81920];
@@ -7384,6 +7432,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 throw new FormatException("The aws-chunked request body ended unexpectedly while reading a chunk.");
             }
 
+            hasher?.AppendData(buffer.AsSpan(0, read));
             await destination.WriteAsync(buffer.AsMemory(0, read), cancellationToken);
             remaining -= read;
         }
@@ -9544,6 +9593,79 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static bool FixedTimeEqualsOrdinalIgnoreCase(string expected, string actual)
     {
         return FixedTimeEqualsOrdinal(expected.ToUpperInvariant(), actual.ToUpperInvariant());
+    }
+
+    /// <summary>
+    /// Verifies the per-chunk SigV4/SigV4a signature chain of a signed <c>aws-chunked</c> streaming
+    /// upload as chunks are decoded, binding the body bytes to the authenticated request signature.
+    /// <para>
+    /// Each data chunk's <c>chunk-signature</c> extension is recomputed by the server from the rolling
+    /// previous signature (seeded with the request's own signature) and the SHA-256 of the chunk bytes;
+    /// a mismatch throws <see cref="ChunkSignatureMismatchException"/> (→ 403 SignatureDoesNotMatch).
+    /// The zero-length terminating chunk is verified the same way, and its recomputed/verified signature
+    /// is returned so it — not a client-supplied value — anchors the trailer-signature validation.
+    /// </para>
+    /// </summary>
+    private sealed class AwsChunkedChunkSignatureVerifier
+    {
+        private readonly AwsChunkedTrailerSigningContext _context;
+        private string _previousSignature;
+
+        public AwsChunkedChunkSignatureVerifier(AwsChunkedTrailerSigningContext context)
+        {
+            _context = context;
+            _previousSignature = context.SeedSignature;
+        }
+
+        /// <summary>
+        /// Verifies a single chunk's <c>chunk-signature</c> against the recomputed signature and
+        /// advances the rolling previous signature. Returns the now-verified chunk signature.
+        /// </summary>
+        public string VerifyChunk(string chunkHeader, string chunkContentHashHex)
+        {
+            var providedSignature = TryGetAwsChunkSignature(chunkHeader);
+            if (string.IsNullOrWhiteSpace(providedSignature)) {
+                // A signed streaming upload must attach a chunk-signature to every chunk (including
+                // the zero-length terminator). Absence means the chain cannot be verified: reject.
+                throw new ChunkSignatureMismatchException();
+            }
+
+            if (_context.IsSigV4a) {
+                var credentialScopeString = S3SigV4aSigner.BuildCredentialScopeString(
+                    _context.CredentialScope.DateStamp,
+                    _context.CredentialScope.Service);
+                var stringToSign = S3SigV4aSigner.BuildStreamingPayloadStringToSign(
+                    _context.SignedAtUtc,
+                    credentialScopeString,
+                    _previousSignature,
+                    chunkContentHashHex);
+                using var ecdsaKey = S3SigV4aSigner.DeriveEcdsaKey(_context.SecretAccessKey, _context.AccessKeyId!);
+                if (!S3SigV4aSigner.VerifySignature(ecdsaKey, stringToSign, providedSignature)) {
+                    throw new ChunkSignatureMismatchException();
+                }
+
+                // SigV4a signatures are non-deterministic, so the chain advances using the client's
+                // (now cryptographically verified) signature text — the same value the client chained.
+                _previousSignature = providedSignature;
+                return providedSignature;
+            }
+
+            var hmacStringToSign = S3SigV4Signer.BuildStreamingPayloadStringToSign(
+                _context.SignedAtUtc,
+                _context.CredentialScope,
+                _previousSignature,
+                chunkContentHashHex);
+            var expectedSignature = S3SigV4Signer.ComputeSignature(
+                _context.SecretAccessKey,
+                _context.CredentialScope,
+                hmacStringToSign);
+            if (!FixedTimeEqualsOrdinalIgnoreCase(expectedSignature, providedSignature)) {
+                throw new ChunkSignatureMismatchException();
+            }
+
+            _previousSignature = expectedSignature;
+            return expectedSignature;
+        }
     }
 
     private sealed class PreparedRequestBody(

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3RequestAuthenticationEndpointFilter.cs
@@ -98,6 +98,13 @@ internal sealed class IntegratedS3RequestAuthenticationEndpointFilter(
                 "The provided 'x-amz-content-sha256' header does not match what was computed.");
         }
 
+        if (exception is ChunkSignatureMismatchException) {
+            return (
+                StatusCodes.Status403Forbidden,
+                "SignatureDoesNotMatch",
+                "The request signature we calculated does not match the signature you provided.");
+        }
+
         if (exception is BadHttpRequestException badRequest) {
             return badRequest.StatusCode switch
             {

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsChunkedTrailerSigningContext.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsChunkedTrailerSigningContext.cs
@@ -13,6 +13,13 @@ internal sealed class AwsChunkedTrailerSigningContext
     public required string SecretAccessKey { get; init; }
 
     /// <summary>
+    /// The request's seed signature: the SigV4/SigV4a signature computed over the canonical request.
+    /// It anchors the per-chunk signature chain — <c>chunk[0]</c> chains from this value — so that the
+    /// verified body bytes are cryptographically bound back to the authenticated request signature.
+    /// </summary>
+    public required string SeedSignature { get; init; }
+
+    /// <summary>
     /// When true the trailer signature must be verified with ECDSA (SigV4a) instead of HMAC (SigV4).
     /// </summary>
     public bool IsSigV4a { get; init; }

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsSignatureV4RequestAuthenticator.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsSignatureV4RequestAuthenticator.cs
@@ -170,7 +170,12 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             return IntegratedS3RequestAuthenticationResult.Failure("SignatureDoesNotMatch", "The request signature we calculated does not match the signature you provided.");
         }
 
-        StoreAwsChunkedTrailerSigningContext(httpContext, payloadHash!, credential, authorization.CredentialScope, requestTimestampUtc);
+        // Seed the per-chunk signature chain with the client's own (now cryptographically verified)
+        // request signature text, not the server-recomputed one: AWS clients derive chunk signatures
+        // from the exact hex string they placed in the Authorization header, and the header signature
+        // is compared case-insensitively — so a differently-cased-but-valid seed must chain from the
+        // client's text to reproduce the same HMAC chain.
+        StoreAwsChunkedTrailerSigningContext(httpContext, payloadHash!, credential, authorization.CredentialScope, requestTimestampUtc, authorization.Signature);
         return IntegratedS3RequestAuthenticationResult.Success(CreatePrincipal(credential));
     }
 
@@ -240,7 +245,7 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             return IntegratedS3RequestAuthenticationResult.Failure("SignatureDoesNotMatch", "The presigned request signature does not match the expected signature.");
         }
 
-        StoreAwsChunkedTrailerSigningContext(httpContext, payloadHash!, credential, presignedRequest.CredentialScope, presignedRequest.SignedAtUtc);
+        StoreAwsChunkedTrailerSigningContext(httpContext, payloadHash!, credential, presignedRequest.CredentialScope, presignedRequest.SignedAtUtc, presignedRequest.Signature);
         return IntegratedS3RequestAuthenticationResult.Success(CreatePrincipal(credential));
     }
 
@@ -423,7 +428,7 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             return IntegratedS3RequestAuthenticationResult.Failure("SignatureDoesNotMatch", "The request signature we calculated does not match the signature you provided.");
         }
 
-        StoreSigV4aChunkedTrailerSigningContext(httpContext, payloadHash!, credential, authorization.CredentialScope, requestTimestampUtc);
+        StoreSigV4aChunkedTrailerSigningContext(httpContext, payloadHash!, credential, authorization.CredentialScope, requestTimestampUtc, authorization.Signature);
         return IntegratedS3RequestAuthenticationResult.Success(CreateSigV4aPrincipal(credential));
     }
 
@@ -492,7 +497,7 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             return IntegratedS3RequestAuthenticationResult.Failure("SignatureDoesNotMatch", "The presigned request signature does not match the expected signature.");
         }
 
-        StoreSigV4aChunkedTrailerSigningContext(httpContext, payloadHash!, credential, presignedRequest.CredentialScope, presignedRequest.SignedAtUtc);
+        StoreSigV4aChunkedTrailerSigningContext(httpContext, payloadHash!, credential, presignedRequest.CredentialScope, presignedRequest.SignedAtUtc, presignedRequest.Signature);
         return IntegratedS3RequestAuthenticationResult.Success(CreateSigV4aPrincipal(credential));
     }
 
@@ -559,7 +564,8 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
         string payloadHash,
         IntegratedS3AccessKeyCredential credential,
         S3SigV4CredentialScope credentialScope,
-        DateTimeOffset requestTimestampUtc)
+        DateTimeOffset requestTimestampUtc,
+        string seedSignature)
     {
         if (!IsSignedTrailerBackedPayloadHash(payloadHash)) {
             return;
@@ -570,6 +576,7 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
             CredentialScope = credentialScope,
             SignedAtUtc = requestTimestampUtc,
             SecretAccessKey = credential.SecretAccessKey,
+            SeedSignature = seedSignature,
             IsSigV4a = true,
             AccessKeyId = credential.AccessKeyId
         });
@@ -752,7 +759,8 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
         string payloadHash,
         IntegratedS3AccessKeyCredential credential,
         S3SigV4CredentialScope credentialScope,
-        DateTimeOffset requestTimestampUtc)
+        DateTimeOffset requestTimestampUtc,
+        string seedSignature)
     {
         if (!IsSignedTrailerBackedPayloadHash(payloadHash)) {
             return;
@@ -762,7 +770,8 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
         {
             CredentialScope = credentialScope,
             SignedAtUtc = requestTimestampUtc,
-            SecretAccessKey = credential.SecretAccessKey
+            SecretAccessKey = credential.SecretAccessKey,
+            SeedSignature = seedSignature
         });
     }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
@@ -885,6 +885,93 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
     }
 
     [Fact]
+    public async Task SigV4HeaderAuthentication_TamperedAwsChunkedPayloadBytesWithValidChunkSignature_ReturnsSignatureDoesNotMatch()
+    {
+        // Regression for the per-chunk SigV4 signature-chain gap (issue #101): a signed streaming
+        // upload whose data-chunk bytes are flipped on the wire — but whose (originally valid)
+        // chunk-signature, final-chunk signature and trailer-signature are left untouched — must be
+        // rejected, because the server recomputes the chunk signature over the received bytes and it
+        // no longer matches. Before the fix the tampered body was accepted with all checks passing.
+        const string accessKeyId = "sigv4-chunked-payload-tamper-access";
+        const string secretAccessKey = "sigv4-chunked-payload-tamper-secret";
+        const string bucketName = "sigv4-chunked-payload-tamper-bucket";
+        const string objectKey = "docs/payload-tamper.txt";
+        const string payload = "hello from a signed aws chunked payload that will be tampered";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var createBucketRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Put, $"/integrated-s3/buckets/{bucketName}", accessKeyId, secretAccessKey);
+        Assert.Equal(HttpStatusCode.Created, (await client.SendAsync(createBucketRequest)).StatusCode);
+
+        var tamperedBytes = Encoding.UTF8.GetBytes(payload);
+        tamperedBytes[0] ^= 0xFF; // Flip a byte; same length keeps the chunk framing valid.
+
+        using var putObjectRequest = CreateSigV4AwsChunkedTrailerRequest(
+            $"/integrated-s3/buckets/{bucketName}/objects/{objectKey}",
+            accessKeyId,
+            secretAccessKey,
+            payload,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["x-amz-checksum-sha256"] = ComputeSha256Base64(payload)
+            },
+            includeTrailerSignature: true,
+            tamperedWirePayloadBytes: tamperedBytes);
+        var response = await client.SendAsync(putObjectRequest);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("SignatureDoesNotMatch", GetRequiredElementValue(errorDocument, "Code"));
+
+        // The tampered object must not have been stored.
+        using var getObjectRequest = CreateSigV4HeaderSignedRequest(
+            HttpMethod.Get,
+            $"/integrated-s3/buckets/{bucketName}/objects/{objectKey}",
+            accessKeyId,
+            secretAccessKey);
+        var getObjectResponse = await client.SendAsync(getObjectRequest);
+        Assert.Equal(HttpStatusCode.NotFound, getObjectResponse.StatusCode);
+    }
+
+    [Fact]
+    public async Task SigV4HeaderAuthentication_MutatedAwsChunkedDataChunkSignature_ReturnsSignatureDoesNotMatch()
+    {
+        // Regression for issue #101: mutating a data chunk's chunk-signature (bytes intact) must be
+        // rejected — the recomputed per-chunk signature no longer matches the supplied one.
+        const string accessKeyId = "sigv4-chunked-chunk-signature-mutated-access";
+        const string secretAccessKey = "sigv4-chunked-chunk-signature-mutated-secret";
+        const string bucketName = "sigv4-chunked-chunk-signature-mutated-bucket";
+        const string objectKey = "docs/chunk-signature-mutated.txt";
+        const string payload = "hello from a signed aws chunked chunk with a mutated chunk signature";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var createBucketRequest = CreateSigV4HeaderSignedRequest(HttpMethod.Put, $"/integrated-s3/buckets/{bucketName}", accessKeyId, secretAccessKey);
+        Assert.Equal(HttpStatusCode.Created, (await client.SendAsync(createBucketRequest)).StatusCode);
+
+        using var putObjectRequest = CreateSigV4AwsChunkedTrailerRequest(
+            $"/integrated-s3/buckets/{bucketName}/objects/{objectKey}",
+            accessKeyId,
+            secretAccessKey,
+            payload,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["x-amz-checksum-sha256"] = ComputeSha256Base64(payload)
+            },
+            includeTrailerSignature: true,
+            dataChunkSignatureOverride: new string('0', 64));
+        var response = await client.SendAsync(putObjectRequest);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("SignatureDoesNotMatch", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    [Fact]
     public async Task SigV4HeaderAuthentication_MissingAwsChunkedTrailerSignature_ReturnsInvalidRequest()
     {
         const string accessKeyId = "sigv4-chunked-trailer-signature-missing-access";
@@ -3064,7 +3151,9 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
         string? trailerSignatureOverride = null,
         string host = "localhost",
         DateTimeOffset? signedAtUtc = null,
-        string? securityToken = null)
+        string? securityToken = null,
+        byte[]? tamperedWirePayloadBytes = null,
+        string? dataChunkSignatureOverride = null)
     {
         var timestampUtc = signedAtUtc ?? DateTimeOffset.UtcNow;
         var payloadBytes = Encoding.UTF8.GetBytes(payload);
@@ -3105,7 +3194,9 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
                 payloadBytes,
                 trailerHeaders,
                 includeTrailerSignature,
-                trailerSignatureOverride);
+                trailerSignatureOverride,
+                tamperedWirePayloadBytes,
+                dataChunkSignatureOverride);
         request.Content = new ByteArrayContent(contentBytes);
         request.Content.Headers.TryAddWithoutValidation("Content-Type", "text/plain");
         request.Content.Headers.ContentEncoding.Add("aws-chunked");
@@ -3311,8 +3402,13 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
         byte[] payloadBytes,
         IReadOnlyDictionary<string, string> trailerHeaders,
         bool includeTrailerSignature,
-        string? trailerSignatureOverride)
+        string? trailerSignatureOverride,
+        byte[]? tamperedWirePayloadBytes = null,
+        string? dataChunkSignatureOverride = null)
     {
+        // The per-chunk signature is always computed over the ORIGINAL (signed) payload bytes.
+        // 'tamperedWirePayloadBytes' lets a test emit different bytes on the wire while keeping the
+        // otherwise-valid chunk-signature — modelling a MITM that flips body bytes without the key.
         var payloadChunkSignature = ComputeSigV4ChunkSignature(secretAccessKey, credentialScope, signedAtUtc, seedSignature, payloadBytes);
         var finalChunkSignature = ComputeSigV4ChunkSignature(secretAccessKey, credentialScope, signedAtUtc, payloadChunkSignature, Array.Empty<byte>());
         var trailerSignature = includeTrailerSignature || trailerSignatureOverride is not null
@@ -3320,9 +3416,12 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
                 ?? ComputeSigV4TrailerSignature(secretAccessKey, credentialScope, signedAtUtc, finalChunkSignature, trailerHeaders)
             : null;
 
+        var wirePayloadBytes = tamperedWirePayloadBytes ?? payloadBytes;
+        var emittedDataChunkSignature = dataChunkSignatureOverride ?? payloadChunkSignature;
+
         using var stream = new MemoryStream();
-        WriteAscii(stream, $"{payloadBytes.Length:x};chunk-signature={payloadChunkSignature}\r\n");
-        stream.Write(payloadBytes, 0, payloadBytes.Length);
+        WriteAscii(stream, $"{wirePayloadBytes.Length:x};chunk-signature={emittedDataChunkSignature}\r\n");
+        stream.Write(wirePayloadBytes, 0, wirePayloadBytes.Length);
         WriteAscii(stream, "\r\n");
         WriteAscii(stream, $"0;chunk-signature={finalChunkSignature}\r\n");
         foreach (var trailerHeader in trailerHeaders.OrderBy(static header => header.Key, StringComparer.Ordinal)) {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4aConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4aConformanceTests.cs
@@ -288,6 +288,59 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
         Assert.Equal(payload, await getObjectResponse.Content.ReadAsStringAsync());
     }
 
+    [Fact]
+    public async Task SigV4aHeaderAuthentication_TamperedAwsChunkedPayloadBytesWithValidChunkSignature_ReturnsSignatureDoesNotMatch()
+    {
+        // Regression for the per-chunk SigV4a (ECDSA) signature-chain gap (issue #101): flipping the
+        // data-chunk bytes on the wire while leaving the (originally valid) chunk-signatures untouched
+        // must be rejected, because the server re-derives the streaming-payload string-to-sign from the
+        // received bytes and the ECDSA verification of the client's chunk signature then fails.
+        const string accessKeyId = "sigv4a-chunked-payload-tamper-access";
+        const string secretAccessKey = "sigv4a-chunked-payload-tamper-secret";
+        const string bucketName = "sigv4a-chunked-payload-tamper-bucket";
+        const string objectKey = "docs/payload-tamper-sigv4a.txt";
+        const string payload = "hello from a signed sigv4a aws chunked payload that will be tampered";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var createBucketRequest = CreateSigV4aHeaderSignedRequest(
+            HttpMethod.Put,
+            $"/integrated-s3/buckets/{bucketName}",
+            accessKeyId,
+            secretAccessKey);
+        Assert.Equal(HttpStatusCode.Created, (await client.SendAsync(createBucketRequest)).StatusCode);
+
+        var tamperedBytes = Encoding.UTF8.GetBytes(payload);
+        tamperedBytes[0] ^= 0xFF; // Flip a byte; same length keeps the chunk framing valid.
+
+        using var putObjectRequest = CreateSigV4aAwsChunkedTrailerRequest(
+            $"/integrated-s3/buckets/{bucketName}/objects/{objectKey}",
+            accessKeyId,
+            secretAccessKey,
+            payload,
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["x-amz-checksum-sha256"] = ComputeSha256Base64(payload)
+            },
+            includeTrailerSignature: true,
+            tamperedWirePayloadBytes: tamperedBytes);
+        var response = await client.SendAsync(putObjectRequest);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("SignatureDoesNotMatch", GetRequiredElementValue(errorDocument, "Code"));
+
+        using var getObjectRequest = CreateSigV4aHeaderSignedRequest(
+            HttpMethod.Get,
+            $"/integrated-s3/buckets/{bucketName}/objects/{objectKey}",
+            accessKeyId,
+            secretAccessKey);
+        var getObjectResponse = await client.SendAsync(getObjectRequest);
+        Assert.Equal(HttpStatusCode.NotFound, getObjectResponse.StatusCode);
+    }
+
     // ── Helpers ─────────────────────────────────────────────────────────────
 
     private Task<WebUiApplicationFactory.IsolatedWebUiClient> CreateAuthenticatedClientAsync(
@@ -491,7 +544,8 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
         string payloadHashOverride = StreamingSigV4aPayloadTrailer,
         bool includeTrailerSignature = false,
         string host = "localhost",
-        DateTimeOffset? signedAtUtc = null)
+        DateTimeOffset? signedAtUtc = null,
+        byte[]? tamperedWirePayloadBytes = null)
     {
         var timestampUtc = signedAtUtc ?? DateTimeOffset.UtcNow;
         var payloadBytes = Encoding.UTF8.GetBytes(payload);
@@ -535,7 +589,8 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
                 seedSignature,
                 payloadBytes,
                 trailerHeaders,
-                includeTrailerSignature);
+                includeTrailerSignature,
+                tamperedWirePayloadBytes);
         }
 
         request.Content = new ByteArrayContent(contentBytes);
@@ -552,12 +607,16 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
         string seedSignature,
         byte[] payloadBytes,
         IReadOnlyDictionary<string, string> trailerHeaders,
-        bool includeTrailerSignature)
+        bool includeTrailerSignature,
+        byte[]? tamperedWirePayloadBytes = null)
     {
         var credentialScopeString = S3SigV4aSigner.BuildCredentialScopeString(
             signedAtUtc.ToString("yyyyMMdd"),
             "s3");
 
+        // The per-chunk signature is always computed over the ORIGINAL (signed) payload bytes;
+        // 'tamperedWirePayloadBytes' emits different bytes on the wire while keeping the otherwise-
+        // valid chunk-signature, modelling a MITM that flips body bytes without the secret key.
         var payloadChunkSignature = ComputeSigV4aChunkSignature(secretAccessKey, accessKeyId, credentialScopeString, signedAtUtc, seedSignature, payloadBytes);
         var finalChunkSignature = ComputeSigV4aChunkSignature(secretAccessKey, accessKeyId, credentialScopeString, signedAtUtc, payloadChunkSignature, Array.Empty<byte>());
 
@@ -566,9 +625,11 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
             trailerSignature = ComputeSigV4aTrailerSignature(secretAccessKey, accessKeyId, credentialScopeString, signedAtUtc, finalChunkSignature, trailerHeaders);
         }
 
+        var wirePayloadBytes = tamperedWirePayloadBytes ?? payloadBytes;
+
         using var stream = new MemoryStream();
-        WriteAscii(stream, $"{payloadBytes.Length:x};chunk-signature={payloadChunkSignature}\r\n");
-        stream.Write(payloadBytes, 0, payloadBytes.Length);
+        WriteAscii(stream, $"{wirePayloadBytes.Length:x};chunk-signature={payloadChunkSignature}\r\n");
+        stream.Write(wirePayloadBytes, 0, wirePayloadBytes.Length);
         WriteAscii(stream, "\r\n");
         WriteAscii(stream, $"0;chunk-signature={finalChunkSignature}\r\n");
         foreach (var trailerHeader in trailerHeaders.OrderBy(static header => header.Key, StringComparer.Ordinal)) {


### PR DESCRIPTION
## Summary

Closes #101.

Signed `aws-chunked` streaming uploads (`STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER` and the SigV4a `STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD-TRAILER` variant) parsed each chunk's `;chunk-signature=` extension but **never verified it**. The seed signature is computed over the sentinel payload-hash (so it binds identity/headers, not the body), and `TryValidateAwsChunkedTrailerSignature` chained from a **client-supplied, unverified** final-chunk signature. The uploaded body bytes entered no verified computation — a replay/MITM attacker without the secret key could substitute arbitrary object contents for `PutObject`/`UploadPart` while every signature check still passed.

## Fix

- **Thread the seed signature into the reader.** `AwsChunkedTrailerSigningContext` now carries the request's `SeedSignature`; the SigV4/SigV4a authenticator populates it (verified request signature) at all four store sites (header + presigned, SigV4 + SigV4a).
- **Verify each chunk during body copy.** `CopyAwsChunkedContentToAsync` incrementally SHA-256s each data chunk and, for signed streaming, recomputes the per-chunk string-to-sign (`AWS4-HMAC-SHA256-PAYLOAD` / `AWS4-ECDSA-P256-SHA256-PAYLOAD`) chained from the rolling previous signature. It compares (fixed-time HMAC for SigV4, ECDSA verify for SigV4a) against the value on the wire, rejecting any mismatch.
- **Bind the final chunk + trailer.** The zero-length terminating chunk is verified the same way; its recomputed/verified signature — not the client's verbatim value — now anchors the existing trailer-signature validation, closing that gap too.
- **Reject with `SignatureDoesNotMatch` (HTTP 403).** A new `ChunkSignatureMismatchException` maps to 403 in the auth endpoint filter (same mechanism as `ContentSha256MismatchException`). Applies to both `PutObject` and `UploadPart`, which both flow through `PrepareRequestBodyAsync`.
- Unsigned streaming (`STREAMING-UNSIGNED-PAYLOAD-TRAILER`) is unaffected — it has no chunk signatures and none are required.

## Tests

Regression tests that exercise a **real** chain (fail-before / pass-after, verified by temporarily disabling verification):

- A correctly-chained signed upload still succeeds (existing tests remain green).
- A tampered chunk body (valid framing, wrong bytes, otherwise-valid `chunk-signature`) → 403 `SignatureDoesNotMatch`, and the object is not stored — SigV4 and SigV4a.
- A mutated data-chunk signature (bytes intact) → 403 `SignatureDoesNotMatch` (SigV4).

Full suite: build clean (0 warnings), **1177/1177 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)