### PR TITLE
fix: correct object header/attribute AWS-conformance nits (#165)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/MultipartUploadState.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/MultipartUploadState.cs
@@ -57,6 +57,12 @@ public class MultipartUploadState
     public DateTimeOffset? ExpiresUtc { get; init; }
 
     /// <summary>
+    /// The raw, verbatim <c>Expires</c> header value specified at upload initiation, or
+    /// <see langword="null"/> if none. AWS treats <c>Expires</c> as an opaque string.
+    /// </summary>
+    public string? Expires { get; init; }
+
+    /// <summary>
     /// User-defined key-value metadata specified at upload initiation.
     /// </summary>
     public IReadOnlyDictionary<string, string>? Metadata { get; init; }

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/ObjectInfo.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/ObjectInfo.cs
@@ -66,6 +66,14 @@ public sealed class ObjectInfo
     public DateTimeOffset? ExpiresUtc { get; init; }
 
     /// <summary>
+    /// The raw, verbatim <c>Expires</c> header value exactly as it was supplied when the object was
+    /// stored, or <see langword="null"/> if none was supplied. AWS S3 treats <c>Expires</c> as an
+    /// opaque string and returns it unchanged (it is not parsed or reformatted); this preserves that
+    /// value so GET/HEAD can echo it back verbatim.
+    /// </summary>
+    public string? Expires { get; init; }
+
+    /// <summary>
     /// The entity tag (ETag) for the object, typically the MD5 hash of the content.
     /// </summary>
     public string? ETag { get; init; }

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/CopyObjectRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/CopyObjectRequest.cs
@@ -53,6 +53,12 @@ public sealed class CopyObjectRequest
     /// <summary>The expiration date for the destination object, in UTC.</summary>
     public DateTimeOffset? ExpiresUtc { get; init; }
 
+    /// <summary>
+    /// The raw, verbatim <c>Expires</c> header value for the destination object (used when replacing
+    /// metadata). AWS treats <c>Expires</c> as an opaque string stored and returned unchanged.
+    /// </summary>
+    public string? Expires { get; init; }
+
     /// <summary>User-defined metadata for the destination object (used when replacing metadata).</summary>
     public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/InitiateMultipartUploadRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/InitiateMultipartUploadRequest.cs
@@ -29,6 +29,12 @@ public sealed class InitiateMultipartUploadRequest
     /// <summary>The date and time at which the object should expire, in UTC.</summary>
     public DateTimeOffset? ExpiresUtc { get; init; }
 
+    /// <summary>
+    /// The raw, verbatim <c>Expires</c> header value. AWS treats <c>Expires</c> as an opaque string
+    /// that is stored and returned unchanged; when set, this is preserved verbatim.
+    /// </summary>
+    public string? Expires { get; init; }
+
     /// <summary>User-defined metadata key-value pairs for the object.</summary>
     public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/PutObjectRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/PutObjectRequest.cs
@@ -35,6 +35,12 @@ public sealed class PutObjectRequest
     /// <summary>The date and time at which the object should expire, in UTC.</summary>
     public DateTimeOffset? ExpiresUtc { get; init; }
 
+    /// <summary>
+    /// The raw, verbatim <c>Expires</c> header value. AWS treats <c>Expires</c> as an opaque string
+    /// that is stored and returned unchanged; when set, this is preserved verbatim.
+    /// </summary>
+    public string? Expires { get; init; }
+
     /// <summary>User-defined metadata key-value pairs for the object.</summary>
     public IReadOnlyDictionary<string, string>? Metadata { get; init; }
 

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -120,6 +120,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string LegalHoldQueryParameterName = "legal-hold";
     private const string AttributesQueryParameterName = "attributes";
     private const string ObjectAttributesHeaderName = "x-amz-object-attributes";
+    // AWS S3 serves objects stored without a Content-Type as "binary/octet-stream".
+    private const string DefaultObjectContentType = "binary/octet-stream";
     private const string VersioningQueryParameterName = "versioning";
     private const string EncryptionQueryParameterName = "encryption";
     private const string VersionsQueryParameterName = "versions";
@@ -1357,7 +1359,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                             ContentDisposition = metadataDirective == CopyObjectMetadataDirective.Replace ? GetOptionalHeaderValue(request.Headers[HeaderNames.ContentDisposition].ToString()) : null,
                             ContentEncoding = metadataDirective == CopyObjectMetadataDirective.Replace ? GetOptionalHeaderValue(request.Headers[HeaderNames.ContentEncoding].ToString()) : null,
                             ContentLanguage = metadataDirective == CopyObjectMetadataDirective.Replace ? GetOptionalHeaderValue(request.Headers[HeaderNames.ContentLanguage].ToString()) : null,
-                            ExpiresUtc = metadataDirective == CopyObjectMetadataDirective.Replace ? ParseOptionalHttpDateHeader(request.Headers[HeaderNames.Expires].ToString()) : null,
+                            ExpiresUtc = metadataDirective == CopyObjectMetadataDirective.Replace ? ParseOptionalExpiresTimestamp(request.Headers[HeaderNames.Expires].ToString()) : null,
+                            Expires = metadataDirective == CopyObjectMetadataDirective.Replace ? ReadOptionalExpiresHeader(request.Headers[HeaderNames.Expires].ToString()) : null,
                             Metadata = metadataDirective == CopyObjectMetadataDirective.Replace ? ParseObjectMetadataHeaders(request.Headers) : null,
                             TaggingDirective = taggingDirective,
                             Tags = taggingDirective == ObjectTaggingDirective.Replace ? copyTags : null,
@@ -1417,7 +1420,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         ContentDisposition = GetOptionalHeaderValue(request.Headers[HeaderNames.ContentDisposition].ToString()),
                         ContentEncoding = GetOptionalHeaderValue(request.Headers[HeaderNames.ContentEncoding].ToString()),
                         ContentLanguage = GetOptionalHeaderValue(request.Headers[HeaderNames.ContentLanguage].ToString()),
-                        ExpiresUtc = ParseOptionalHttpDateHeader(request.Headers[HeaderNames.Expires].ToString()),
+                        ExpiresUtc = ParseOptionalExpiresTimestamp(request.Headers[HeaderNames.Expires].ToString()),
+                        Expires = ReadOptionalExpiresHeader(request.Headers[HeaderNames.Expires].ToString()),
                         Metadata = metadata,
                         Tags = tags,
                         Checksums = requestedChecksums,
@@ -1579,7 +1583,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 var objectInfo = result.Value!;
                 var responseOverrides = ResponseHeaderOverrides.FromRequest(httpContext.Request);
                 ApplyObjectHeaders(httpContext.Response, objectInfo);
-                ApplyObjectTaggingCountHeader(httpContext.Response, objectInfo);
+                // AWS emits x-amz-tagging-count on GET responses only, not on HEAD.
                 httpContext.Response.Headers.AcceptRanges = "bytes";
                 responseOverrides.Apply(httpContext.Response);
 
@@ -1603,7 +1607,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return TypedResults.StatusCode(StatusCodes.Status304NotModified);
                 }
 
-                httpContext.Response.ContentType = responseOverrides.ContentType ?? objectInfo.ContentType ?? "application/octet-stream";
+                httpContext.Response.ContentType = responseOverrides.ContentType ?? objectInfo.ContentType ?? DefaultObjectContentType;
 
                 // AWS honors the Range header on HEAD, mirroring GET: a satisfiable range yields 206
                 // with Content-Range and the ranged Content-Length (no body); an unsatisfiable range
@@ -2961,7 +2965,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     ContentDisposition = GetOptionalHeaderValue(httpContext.Request.Headers[HeaderNames.ContentDisposition].ToString()),
                     ContentEncoding = GetOptionalHeaderValue(httpContext.Request.Headers[HeaderNames.ContentEncoding].ToString()),
                     ContentLanguage = GetOptionalHeaderValue(httpContext.Request.Headers[HeaderNames.ContentLanguage].ToString()),
-                    ExpiresUtc = ParseOptionalHttpDateHeader(httpContext.Request.Headers[HeaderNames.Expires].ToString()),
+                    ExpiresUtc = ParseOptionalExpiresTimestamp(httpContext.Request.Headers[HeaderNames.Expires].ToString()),
+                    Expires = ReadOptionalExpiresHeader(httpContext.Request.Headers[HeaderNames.Expires].ToString()),
                     Metadata = metadata,
                     Tags = tags,
                     ChecksumAlgorithm = checksumAlgorithm,
@@ -8668,6 +8673,28 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         return parsedValue;
     }
 
+    /// <summary>
+    /// Returns the verbatim <c>Expires</c> header value, or <see langword="null"/> when absent. AWS
+    /// treats <c>Expires</c> as an opaque string, so it is stored and returned unchanged rather than
+    /// parsed as an HTTP date (an unparseable value must not fail the request).
+    /// </summary>
+    private static string? ReadOptionalExpiresHeader(string? rawValue)
+    {
+        return string.IsNullOrEmpty(rawValue) ? null : rawValue;
+    }
+
+    /// <summary>
+    /// Best-effort parse of an opaque <c>Expires</c> value into a timestamp for stores that persist
+    /// only a <see cref="DateTimeOffset"/>. Unparseable values yield <see langword="null"/> (never a
+    /// <see cref="FormatException"/>), preserving the opaque round-trip carried by the raw string.
+    /// </summary>
+    private static DateTimeOffset? ParseOptionalExpiresTimestamp(string? rawValue)
+    {
+        return string.IsNullOrWhiteSpace(rawValue) || !DateTimeOffset.TryParse(rawValue, out var parsedValue)
+            ? null
+            : parsedValue;
+    }
+
     private static CopyObjectMetadataDirective ParseCopyObjectMetadataDirective(string? rawValue)
     {
         if (string.IsNullOrWhiteSpace(rawValue)
@@ -8911,7 +8938,14 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             httpResponse.Headers[HeaderNames.ContentLanguage] = objectInfo.ContentLanguage;
         }
 
-        if (objectInfo.ExpiresUtc is { } expiresUtc) {
+        // AWS treats the object Expires metadata as an opaque string: it is stored and returned
+        // verbatim, never parsed or reformatted. Echo the raw value when we have it; fall back to the
+        // parsed timestamp only for objects persisted before the raw value was captured (or by stores
+        // that keep just the timestamp).
+        if (!string.IsNullOrEmpty(objectInfo.Expires)) {
+            httpResponse.Headers.Expires = objectInfo.Expires;
+        }
+        else if (objectInfo.ExpiresUtc is { } expiresUtc) {
             httpResponse.Headers.Expires = expiresUtc.ToString("R");
         }
     }
@@ -9383,7 +9417,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 return;
             }
 
-            httpContext.Response.ContentType = response.Object.ContentType ?? "application/octet-stream";
+            httpContext.Response.ContentType = response.Object.ContentType ?? DefaultObjectContentType;
             responseOverrides.Apply(httpContext.Response);
             httpContext.Response.ContentLength = response.Object.ContentLength;
 
@@ -9465,7 +9499,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             }
 
             var totalLength = firstResponse.TotalContentLength;
-            var contentType = responseOverrides.ContentType ?? firstResponse.Object.ContentType ?? "application/octet-stream";
+            var contentType = responseOverrides.ContentType ?? firstResponse.Object.ContentType ?? DefaultObjectContentType;
 
             httpContext.Response.StatusCode = StatusCodes.Status206PartialContent;
             httpContext.Response.ContentType = $"multipart/byteranges; boundary={boundary}";

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -36,6 +36,12 @@ internal sealed class DiskStorageService(
     /// </summary>
     private const long MinimumMultipartPartSizeBytes = 5L * 1024 * 1024;
 
+    /// <summary>
+    /// The default object <c>Content-Type</c> AWS S3 assigns when a caller stores an object without
+    /// supplying one. AWS uses <c>binary/octet-stream</c> (not <c>application/octet-stream</c>).
+    /// </summary>
+    private const string DefaultObjectContentType = "binary/octet-stream";
+
     private const string Md5ChecksumAlgorithm = "md5";
     private const string Sha256ChecksumAlgorithm = "sha256";
     private const string Sha1ChecksumAlgorithm = "sha1";
@@ -2228,7 +2234,7 @@ internal sealed class DiskStorageService(
                 destinationPath,
                 versionId,
                 useReplacementMetadata
-                    ? string.IsNullOrWhiteSpace(request.ContentType) ? "application/octet-stream" : request.ContentType
+                    ? string.IsNullOrWhiteSpace(request.ContentType) ? DefaultObjectContentType : request.ContentType
                     : sourceMetadata.ContentType,
                 useReplacementMetadata
                     ? request.Metadata
@@ -2243,7 +2249,8 @@ internal sealed class DiskStorageService(
                 contentDisposition: useReplacementMetadata ? request.ContentDisposition : sourceMetadata.ContentDisposition,
                 contentEncoding: useReplacementMetadata ? request.ContentEncoding : sourceMetadata.ContentEncoding,
                 contentLanguage: useReplacementMetadata ? request.ContentLanguage : sourceMetadata.ContentLanguage,
-                expiresUtc: useReplacementMetadata ? request.ExpiresUtc : sourceMetadata.ExpiresUtc);
+                expiresUtc: useReplacementMetadata ? request.ExpiresUtc : sourceMetadata.ExpiresUtc,
+                expires: useReplacementMetadata ? request.Expires : sourceMetadata.Expires);
         }
         finally {
             if (File.Exists(tempDestinationPath)) {
@@ -2357,7 +2364,7 @@ internal sealed class DiskStorageService(
                 request.Key,
                 objectPath,
                 versionId,
-                string.IsNullOrWhiteSpace(request.ContentType) ? "application/octet-stream" : request.ContentType,
+                string.IsNullOrWhiteSpace(request.ContentType) ? DefaultObjectContentType : request.ContentType,
                 request.Metadata,
                 NormalizeTags(request.Tags),
                 persistedChecksums,
@@ -2369,7 +2376,8 @@ internal sealed class DiskStorageService(
                 contentDisposition: request.ContentDisposition,
                 contentEncoding: request.ContentEncoding,
                 contentLanguage: request.ContentLanguage,
-                expiresUtc: request.ExpiresUtc);
+                expiresUtc: request.ExpiresUtc,
+                expires: request.Expires);
         }
         finally {
             if (File.Exists(tempFilePath)) {
@@ -3073,7 +3081,7 @@ internal sealed class DiskStorageService(
                 request.Key,
                 objectPath,
                 versionId,
-                string.IsNullOrWhiteSpace(uploadState.State.ContentType) ? "application/octet-stream" : uploadState.State.ContentType,
+                string.IsNullOrWhiteSpace(uploadState.State.ContentType) ? DefaultObjectContentType : uploadState.State.ContentType,
                 uploadState.State.Metadata,
                 uploadState.State.Tags,
                 checksums,
@@ -3086,6 +3094,7 @@ internal sealed class DiskStorageService(
                 contentEncoding: uploadState.State.ContentEncoding,
                 contentLanguage: uploadState.State.ContentLanguage,
                 expiresUtc: uploadState.State.ExpiresUtc,
+                expires: uploadState.State.Expires,
                 etag: multipartETag);
 
             await DeleteStoredMultipartStateAsync(request.BucketName, request.Key, request.UploadId, uploadState.UploadDirectoryPath, cancellationToken);
@@ -3144,6 +3153,22 @@ internal sealed class DiskStorageService(
         var obj = headResult.Value!;
         var attrs = request.ObjectAttributes;
 
+        // AWS returns the ObjectParts element only when the caller requests the "ObjectParts"
+        // attribute AND the object was produced by a multipart upload. A completed multipart object
+        // carries the composite ETag "<hex(MD5)>-<partCount>"; that suffix is the authoritative part
+        // count. AWS omits the individual <Part> list unless MaxParts pagination is requested (which
+        // this endpoint does not accept), so we surface TotalPartsCount with an empty, non-truncated
+        // listing — matching a default GetObjectAttributes(ObjectParts) response.
+        ObjectPartsInfo? objectParts = null;
+        if (attrs.Any(a => string.Equals(a, "ObjectParts", StringComparison.OrdinalIgnoreCase))
+            && TryGetMultipartPartCount(obj.ETag, out var totalPartsCount)) {
+            objectParts = new ObjectPartsInfo
+            {
+                TotalPartsCount = totalPartsCount,
+                IsTruncated = false,
+            };
+        }
+
         var response = new GetObjectAttributesResponse
         {
             VersionId = obj.VersionId,
@@ -3153,6 +3178,7 @@ internal sealed class DiskStorageService(
             ObjectSize = attrs.Any(a => string.Equals(a, "ObjectSize", StringComparison.OrdinalIgnoreCase)) ? obj.ContentLength : null,
             StorageClass = attrs.Any(a => string.Equals(a, "StorageClass", StringComparison.OrdinalIgnoreCase)) ? "STANDARD" : null,
             Checksums = attrs.Any(a => string.Equals(a, "Checksum", StringComparison.OrdinalIgnoreCase)) ? obj.Checksums : null,
+            ObjectParts = objectParts,
         };
 
         return StorageResult<GetObjectAttributesResponse>.Success(response);
@@ -3813,12 +3839,13 @@ internal sealed class DiskStorageService(
             IsLatest = isLatest,
             IsDeleteMarker = metadata.IsDeleteMarker,
             ContentLength = metadata.IsDeleteMarker ? 0 : fileInfo?.Length ?? 0,
-            ContentType = metadata.IsDeleteMarker ? null : metadata.ContentType ?? "application/octet-stream",
+            ContentType = metadata.IsDeleteMarker ? null : metadata.ContentType ?? DefaultObjectContentType,
             CacheControl = metadata.IsDeleteMarker ? null : metadata.CacheControl,
             ContentDisposition = metadata.IsDeleteMarker ? null : metadata.ContentDisposition,
             ContentEncoding = metadata.IsDeleteMarker ? null : metadata.ContentEncoding,
             ContentLanguage = metadata.IsDeleteMarker ? null : metadata.ContentLanguage,
             ExpiresUtc = metadata.IsDeleteMarker ? null : metadata.ExpiresUtc,
+            Expires = metadata.IsDeleteMarker ? null : metadata.Expires,
             ETag = ResolveObjectETag(metadata, fileInfo),
             LastModifiedUtc = lastModifiedUtc,
             Metadata = metadata.Metadata,
@@ -3976,6 +4003,7 @@ internal sealed class DiskStorageService(
         string? contentEncoding = null,
         string? contentLanguage = null,
         DateTimeOffset? expiresUtc = null,
+        string? expires = null,
         string? etag = null)
     {
         // Persist the S3 content ETag so it never depends on filesystem mtime. Multipart callers
@@ -4000,6 +4028,7 @@ internal sealed class DiskStorageService(
                 ContentEncoding = isDeleteMarker ? null : contentEncoding,
                 ContentLanguage = isDeleteMarker ? null : contentLanguage,
                 ExpiresUtc = isDeleteMarker ? null : expiresUtc,
+                Expires = isDeleteMarker ? null : expires,
                 Metadata = metadata is null ? null : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
                 Tags = tags is null ? null : new Dictionary<string, string>(tags, StringComparer.Ordinal),
                 Checksums = checksums is null ? null : new Dictionary<string, string>(checksums, StringComparer.OrdinalIgnoreCase)
@@ -4026,6 +4055,7 @@ internal sealed class DiskStorageService(
             ContentEncoding = isDeleteMarker ? null : contentEncoding,
             ContentLanguage = isDeleteMarker ? null : contentLanguage,
             ExpiresUtc = isDeleteMarker ? null : expiresUtc,
+            Expires = isDeleteMarker ? null : expires,
             ETag = resolvedETag,
             LastModifiedUtc = lastModifiedUtc ?? fileInfo?.LastWriteTimeUtc ?? DateTimeOffset.UtcNow,
             Metadata = metadata is null ? null : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
@@ -4050,7 +4080,8 @@ internal sealed class DiskStorageService(
         string? contentDisposition = null,
         string? contentEncoding = null,
         string? contentLanguage = null,
-        DateTimeOffset? expiresUtc = null)
+        DateTimeOffset? expiresUtc = null,
+        string? expires = null)
     {
         return WriteStoredObjectStateAsync(
             bucketName,
@@ -4069,7 +4100,8 @@ internal sealed class DiskStorageService(
             contentDisposition: contentDisposition,
             contentEncoding: contentEncoding,
             contentLanguage: contentLanguage,
-            expiresUtc: expiresUtc);
+            expiresUtc: expiresUtc,
+            expires: expires);
     }
 
     private async Task DeleteStoredObjectStateAsync(string bucketName, string key, string objectPath, string? versionId, CancellationToken cancellationToken)
@@ -4630,6 +4662,7 @@ internal sealed class DiskStorageService(
             ContentEncoding = diskState.ContentEncoding,
             ContentLanguage = diskState.ContentLanguage,
             ExpiresUtc = diskState.ExpiresUtc,
+            Expires = diskState.Expires,
             Metadata = diskState.Metadata,
             Tags = NormalizeTags(diskState.Tags),
             ChecksumAlgorithm = diskState.ChecksumAlgorithm
@@ -4650,6 +4683,7 @@ internal sealed class DiskStorageService(
             ContentEncoding = state.ContentEncoding,
             ContentLanguage = state.ContentLanguage,
             ExpiresUtc = state.ExpiresUtc,
+            Expires = state.Expires,
             Metadata = state.Metadata is null ? null : new Dictionary<string, string>(state.Metadata, StringComparer.Ordinal),
             Tags = NormalizeTags(state.Tags) is { } tags ? new Dictionary<string, string>(tags, StringComparer.Ordinal) : null,
             ChecksumAlgorithm = state.ChecksumAlgorithm
@@ -4696,6 +4730,7 @@ internal sealed class DiskStorageService(
                 ContentEncoding = objectInfo.ContentEncoding,
                 ContentLanguage = objectInfo.ContentLanguage,
                 ExpiresUtc = objectInfo.ExpiresUtc,
+                Expires = objectInfo.Expires,
                 Metadata = objectInfo.Metadata is null ? null : new Dictionary<string, string>(objectInfo.Metadata, StringComparer.Ordinal),
                 Tags = objectInfo.Tags is null ? null : new Dictionary<string, string>(objectInfo.Tags, StringComparer.Ordinal),
                 Checksums = objectInfo.Checksums is null ? null : new Dictionary<string, string>(objectInfo.Checksums, StringComparer.OrdinalIgnoreCase)
@@ -5408,6 +5443,7 @@ internal sealed class DiskStorageService(
             ContentEncoding = request.ContentEncoding,
             ContentLanguage = request.ContentLanguage,
             ExpiresUtc = request.ExpiresUtc,
+            Expires = request.Expires,
             Metadata = request.Metadata is null ? null : new Dictionary<string, string>(request.Metadata),
             Tags = NormalizeTags(request.Tags),
             ChecksumAlgorithm = uploadInfo.ChecksumAlgorithm
@@ -5609,6 +5645,31 @@ internal sealed class DiskStorageService(
         }
 
         return $"{Convert.ToHexStringLower(md5.GetHashAndReset())}-{partMd5Base64.Count}";
+    }
+
+    /// <summary>
+    /// Determines whether <paramref name="etag"/> is a multipart composite ETag of the form
+    /// <c>&lt;hex(MD5)&gt;-&lt;partCount&gt;</c> and, if so, extracts the trailing part count. Single-part
+    /// objects (plain hex MD5, no suffix) and delete markers return <see langword="false"/>.
+    /// </summary>
+    private static bool TryGetMultipartPartCount(string? etag, out int partCount)
+    {
+        partCount = 0;
+        if (string.IsNullOrEmpty(etag)) {
+            return false;
+        }
+
+        var separatorIndex = etag.LastIndexOf('-');
+        if (separatorIndex <= 0 || separatorIndex == etag.Length - 1) {
+            return false;
+        }
+
+        return int.TryParse(
+            etag.AsSpan(separatorIndex + 1),
+            NumberStyles.None,
+            CultureInfo.InvariantCulture,
+            out partCount)
+            && partCount > 0;
     }
 
     /// <summary>

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskMultipartUploadState.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskMultipartUploadState.cs
@@ -22,6 +22,12 @@ internal sealed class DiskMultipartUploadState
 
     public DateTimeOffset? ExpiresUtc { get; init; }
 
+    /// <summary>
+    /// The verbatim <c>Expires</c> header value supplied at upload initiation, preserved so the
+    /// completed object echoes it back unchanged. Null for legacy state written before this field.
+    /// </summary>
+    public string? Expires { get; init; }
+
     public Dictionary<string, string>? Metadata { get; init; }
 
     public Dictionary<string, string>? Tags { get; init; }

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskObjectMetadata.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskObjectMetadata.cs
@@ -31,6 +31,13 @@ internal sealed class DiskObjectMetadata
 
     public DateTimeOffset? ExpiresUtc { get; init; }
 
+    /// <summary>
+    /// The verbatim <c>Expires</c> header value as supplied at write time. AWS treats <c>Expires</c>
+    /// as an opaque string that round-trips unchanged; this preserves it so GET/HEAD echo it back
+    /// exactly. Null for legacy metadata written before this field existed.
+    /// </summary>
+    public string? Expires { get; init; }
+
     public Dictionary<string, string>? Metadata { get; init; }
 
     public Dictionary<string, string>? Tags { get; init; }

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -91,6 +91,91 @@ public sealed class DiskStorageServiceTests
     }
 
     [Fact]
+    public async Task DiskStorage_RoundTripsOpaqueExpiresVerbatim()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "expires-bucket" })).IsSuccess);
+
+        // A value that is not an HTTP date; AWS stores and returns Expires as an opaque string.
+        const string opaqueExpires = "opaque-not-a-date";
+        await using var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes("payload"));
+        var putResult = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "expires-bucket",
+            Key = "docs/opaque.txt",
+            Content = uploadStream,
+            Expires = opaqueExpires
+        });
+        Assert.True(putResult.IsSuccess);
+
+        var head = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = "expires-bucket",
+            Key = "docs/opaque.txt"
+        });
+        Assert.True(head.IsSuccess);
+        Assert.Equal(opaqueExpires, head.Value!.Expires);
+    }
+
+    [Fact]
+    public async Task DiskStorage_GetObjectAttributes_PopulatesObjectPartsForMultipartObject()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "mpu-attrs-bucket" })).IsSuccess);
+
+        var initiate = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "mpu-attrs-bucket",
+            Key = "docs/mpu.bin"
+        });
+        Assert.True(initiate.IsSuccess);
+        var uploadId = initiate.Value!.UploadId;
+
+        var firstPart = new byte[5 * 1024 * 1024];
+        var secondPart = Encoding.UTF8.GetBytes("tail");
+        Random.Shared.NextBytes(firstPart);
+
+        var completedParts = new List<MultipartUploadPart>();
+        foreach (var (partNumber, body) in new[] { (1, firstPart), (2, secondPart) }) {
+            await using var partStream = new MemoryStream(body);
+            var uploadPart = await storageService.UploadMultipartPartAsync(new UploadMultipartPartRequest
+            {
+                BucketName = "mpu-attrs-bucket",
+                Key = "docs/mpu.bin",
+                UploadId = uploadId,
+                PartNumber = partNumber,
+                Content = partStream
+            });
+            Assert.True(uploadPart.IsSuccess);
+            completedParts.Add(new MultipartUploadPart { PartNumber = partNumber, ETag = uploadPart.Value!.ETag });
+        }
+
+        var complete = await storageService.CompleteMultipartUploadAsync(new CompleteMultipartUploadRequest
+        {
+            BucketName = "mpu-attrs-bucket",
+            Key = "docs/mpu.bin",
+            UploadId = uploadId,
+            Parts = completedParts
+        });
+        Assert.True(complete.IsSuccess);
+
+        var attributes = await storageService.GetObjectAttributesAsync(new GetObjectAttributesRequest
+        {
+            BucketName = "mpu-attrs-bucket",
+            Key = "docs/mpu.bin",
+            ObjectAttributes = ["ObjectParts", "ObjectSize"]
+        });
+        Assert.True(attributes.IsSuccess);
+        Assert.NotNull(attributes.Value!.ObjectParts);
+        Assert.Equal(2, attributes.Value.ObjectParts!.TotalPartsCount);
+        Assert.False(attributes.Value.ObjectParts.IsTruncated);
+    }
+
+    [Fact]
     public async Task DeleteBucketAsync_ReturnsBucketNotEmpty_WhenBucketContainsObjects()
     {
         await using var fixture = new DiskStorageFixture();

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -159,6 +159,228 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task PutObject_WithoutContentType_DefaultsToBinaryOctetStreamOnGetAndHead()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "default-content-type-bucket";
+        const string objectKey = "docs/no-type.bin";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // PUT with no Content-Type header at all.
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new ByteArrayContent(Encoding.UTF8.GetBytes("untyped payload"))
+        }) {
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        // AWS S3 serves objects stored without a Content-Type as "binary/octet-stream" (not
+        // "application/octet-stream").
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal("binary/octet-stream", getResponse.Content.Headers.ContentType?.MediaType);
+
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}");
+        var headResponse = await client.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.Equal("binary/octet-stream", headResponse.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task PutObject_WithNonDateExpires_RoundTripsOpaqueValueVerbatim()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "opaque-expires-bucket";
+        const string objectKey = "docs/opaque-expires.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // AWS treats Expires as an opaque string: an unparseable value must not fail the PUT, and it
+        // must be echoed back verbatim on GET/HEAD (not reformatted).
+        const string opaqueExpires = "not-a-date-just-opaque";
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("opaque expires payload", Encoding.UTF8, "text/plain")
+        }) {
+            // Expires is an entity header; set it on the content so HttpClient transmits it.
+            putRequest.Content.Headers.TryAddWithoutValidation("Expires", opaqueExpires);
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal(opaqueExpires, GetExpiresHeaderValue(getResponse));
+
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}");
+        var headResponse = await client.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.Equal(opaqueExpires, GetExpiresHeaderValue(headResponse));
+    }
+
+    [Fact]
+    public async Task PutObject_WithNonRfc1123Expires_RoundTripsVerbatimWithoutReformatting()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "verbatim-expires-bucket";
+        const string objectKey = "docs/iso-expires.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // An ISO-8601 value parses as a date but is NOT RFC1123; AWS returns it exactly as supplied
+        // rather than reformatting to RFC1123 ("Fri, 01 Jan 2027 ...").
+        const string isoExpires = "2027-01-01T00:00:00Z";
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("verbatim expires payload", Encoding.UTF8, "text/plain")
+        }) {
+            // Expires is an entity header; set it on the content so HttpClient transmits it.
+            putRequest.Content.Headers.TryAddWithoutValidation("Expires", isoExpires);
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal(isoExpires, GetExpiresHeaderValue(getResponse));
+    }
+
+    // The Expires response header may surface on either the content or the message header collection
+    // depending on how HttpClient classifies a non-RFC1123 value; read it from whichever holds it.
+    private static string GetExpiresHeaderValue(HttpResponseMessage response)
+    {
+        if (response.Content.Headers.TryGetValues("Expires", out var contentValues)) {
+            return Assert.Single(contentValues);
+        }
+
+        Assert.True(response.Headers.TryGetValues("Expires", out var messageValues), "Expected an Expires header on the response.");
+        return Assert.Single(messageValues!);
+    }
+
+    [Fact]
+    public async Task GetAndHeadObject_TaggingCountHeaderEmittedOnGetOnly()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "tagging-count-head-bucket";
+        const string objectKey = "docs/tagged.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("tagged payload", Encoding.UTF8, "text/plain")
+        }) {
+            putRequest.Headers.TryAddWithoutValidation("x-amz-tagging", "owner=copilot&team=storage");
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        // AWS emits x-amz-tagging-count on GET responses...
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal("2", Assert.Single(getResponse.Headers.GetValues("x-amz-tagging-count")));
+
+        // ...but never on HEAD.
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}");
+        var headResponse = await client.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.False(headResponse.Headers.Contains("x-amz-tagging-count"));
+    }
+
+    [Fact]
+    public async Task GetObjectAttributes_ForMultipartObject_ReportsObjectPartsTotalCount()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "attributes-object-parts-bucket";
+        const string objectKey = "docs/multipart.bin";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // Two parts of >= 5 MiB (all but the last must meet the minimum) so completion yields a
+        // composite ETag "<md5>-2".
+        var firstPart = new byte[5 * 1024 * 1024];
+        var secondPart = new byte[1024];
+        Random.Shared.NextBytes(firstPart);
+        Random.Shared.NextBytes(secondPart);
+
+        using var initiateRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploads")
+        {
+            Content = new ByteArrayContent([])
+        };
+        initiateRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+        var initiateResponse = await client.SendAsync(initiateRequest);
+        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
+        var uploadId = GetRequiredElementValue(XDocument.Parse(await initiateResponse.Content.ReadAsStringAsync()), "UploadId");
+
+        var partETags = new string[2];
+        var partBodies = new[] { firstPart, secondPart };
+        for (var partNumber = 1; partNumber <= 2; partNumber++) {
+            using var partRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}?partNumber={partNumber}&uploadId={Uri.EscapeDataString(uploadId)}")
+            {
+                Content = new ByteArrayContent(partBodies[partNumber - 1])
+            };
+            var partResponse = await client.SendAsync(partRequest);
+            Assert.Equal(HttpStatusCode.OK, partResponse.StatusCode);
+            partETags[partNumber - 1] = partResponse.Headers.ETag?.Tag ?? throw new Xunit.Sdk.XunitException("Expected multipart part ETag header.");
+        }
+
+        using var completeRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploadId={Uri.EscapeDataString(uploadId)}")
+        {
+            Content = new StringContent($"""
+<CompleteMultipartUpload>
+  <Part>
+    <PartNumber>1</PartNumber>
+    <ETag>{partETags[0]}</ETag>
+  </Part>
+  <Part>
+    <PartNumber>2</PartNumber>
+    <ETag>{partETags[1]}</ETag>
+  </Part>
+</CompleteMultipartUpload>
+""", Encoding.UTF8, "application/xml")
+        };
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(completeRequest)).StatusCode);
+
+        // GetObjectAttributes(ObjectParts) must report the multipart part count for the completed
+        // object rather than an empty result.
+        using var attributesRequest = new HttpRequestMessage(HttpMethod.Get, $"/integrated-s3/{bucketName}/{objectKey}?attributes");
+        attributesRequest.Headers.TryAddWithoutValidation("x-amz-object-attributes", "ObjectParts,ObjectSize");
+        var attributesResponse = await client.SendAsync(attributesRequest);
+        Assert.Equal(HttpStatusCode.OK, attributesResponse.StatusCode);
+
+        var attributesDocument = XDocument.Parse(await attributesResponse.Content.ReadAsStringAsync());
+        var objectPartsElement = attributesDocument.Root!.S3Element("ObjectParts");
+        Assert.NotNull(objectPartsElement);
+        Assert.Equal("2", objectPartsElement!.S3Element("TotalPartsCount")?.Value);
+        Assert.Equal("false", objectPartsElement.S3Element("IsTruncated")?.Value);
+    }
+
+    [Fact]
+    public async Task GetObjectAttributes_ForSinglePartObject_OmitsObjectParts()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "attributes-single-part-bucket";
+        const string objectKey = "docs/single.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("single part payload", Encoding.UTF8, "text/plain")
+        }) {
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        // A non-multipart object carries a plain hex-MD5 ETag with no "-<count>" suffix, so AWS does
+        // not return an ObjectParts element even when it is requested.
+        using var attributesRequest = new HttpRequestMessage(HttpMethod.Get, $"/integrated-s3/{bucketName}/{objectKey}?attributes");
+        attributesRequest.Headers.TryAddWithoutValidation("x-amz-object-attributes", "ObjectParts,ObjectSize");
+        var attributesResponse = await client.SendAsync(attributesRequest);
+        Assert.Equal(HttpStatusCode.OK, attributesResponse.StatusCode);
+
+        var attributesDocument = XDocument.Parse(await attributesResponse.Content.ReadAsStringAsync());
+        Assert.Null(attributesDocument.Root!.S3Element("ObjectParts"));
+    }
+
+    [Fact]
     public async Task GetObject_WithResponseHeaderOverrideQueryParams_OverridesResponseHeaders()
     {
         using var client = await _factory.CreateClientAsync();
@@ -314,7 +536,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         var headVersionedObjectResponse = await client.SendAsync(headVersionedObjectRequest);
         Assert.Equal(HttpStatusCode.OK, headVersionedObjectResponse.StatusCode);
         Assert.Equal(checksum, Assert.Single(headVersionedObjectResponse.Headers.GetValues("x-amz-checksum-sha256")));
-        Assert.Equal("1", Assert.Single(headVersionedObjectResponse.Headers.GetValues("x-amz-tagging-count")));
+        // AWS emits x-amz-tagging-count on GET only, never on HEAD.
+        Assert.False(headVersionedObjectResponse.Headers.Contains("x-amz-tagging-count"));
         Assert.Equal(versionId, Assert.Single(headVersionedObjectResponse.Headers.GetValues("x-amz-version-id")));
 
         var getTaggingResponse = await client.GetAsync($"/integrated-s3/versioned-bucket/docs/versioned.txt?tagging&versionId={Uri.EscapeDataString(versionId)}");
@@ -4288,7 +4511,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         var headObjectResponse = await client.SendAsync(new HttpRequestMessage(HttpMethod.Head, "/integrated-s3/buckets/tagging-bucket/objects/docs/tagged.txt"));
         Assert.Equal(HttpStatusCode.OK, headObjectResponse.StatusCode);
-        Assert.Equal("2", Assert.Single(headObjectResponse.Headers.GetValues("x-amz-tagging-count")));
+        // AWS emits x-amz-tagging-count on GET only, never on HEAD.
+        Assert.False(headObjectResponse.Headers.Contains("x-amz-tagging-count"));
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Fixes the four object header/attribute divergences from AWS S3 reported in #165:

1. **Default `Content-Type`** — objects stored without a `Content-Type` are now served as `binary/octet-stream` (the AWS default) rather than `application/octet-stream`, on GET, HEAD, and in stored metadata. A `DefaultObjectContentType` constant replaces the scattered literals in the disk provider and the object GET/HEAD/ranged-GET endpoints.

2. **`Expires` opaque round-trip** — AWS treats the object `Expires` metadata as an opaque string: it is stored and returned verbatim, never parsed or reformatted, and an unparseable value must not fail the request. A raw `Expires` string is now threaded through `PutObjectRequest`/`CopyObjectRequest`/`InitiateMultipartUploadRequest`, `ObjectInfo`, `MultipartUploadState`, and the disk provider (`DiskObjectMetadata`/`DiskMultipartUploadState`). GET/HEAD echo the raw value verbatim. `ExpiresUtc` is retained for backward compatibility and for stores that persist only a timestamp; the endpoint now parses it leniently (null on failure) instead of throwing a `FormatException` (400).

3. **`x-amz-tagging-count` on HEAD** — this header is now emitted on GET responses only, matching AWS. It was previously emitted unconditionally on HEAD as well.

4. **`GetObjectAttributes` `ObjectParts`** — for multipart-uploaded objects, the response now populates `ObjectParts.TotalPartsCount`, derived from the composite `<md5>-<partCount>` ETag, instead of returning an empty result. Single-part objects (plain hex-MD5 ETag) correctly omit `ObjectParts`.

## Scope note

The opaque `Expires` round-trip is wired through the disk provider (the S3-compatible endpoint's primary/tested path). The AWS-backed S3 provider continues to carry `ExpiresUtc`, since real AWS handles the opaque round-trip itself.

## Tests

Adds fail-before/pass-after regression tests at both the HTTP endpoint and disk-provider level:
- default `binary/octet-stream` on GET/HEAD for an untyped object
- `Expires` verbatim round-trip for both an unparseable value and a non-RFC1123 (ISO-8601) value
- `x-amz-tagging-count` present on GET, absent on HEAD
- `GetObjectAttributes(ObjectParts)` reports `TotalPartsCount` for a multipart object and omits `ObjectParts` for a single-part object

Two existing tests that asserted the pre-fix HEAD tagging-count behavior were updated. Full suite: **1182 passed, 0 failed**.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)