### PR TITLE
feat: implement bucket PublicAccessBlock subresource (#154)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
@@ -110,6 +110,9 @@ public enum StorageErrorCode
     /// <summary>No intelligent-tiering configuration exists for the bucket.</summary>
     IntelligentTieringConfigurationNotFound,
 
+    /// <summary>No public access block configuration exists for the bucket.</summary>
+    PublicAccessBlockConfigurationNotFound,
+
     /// <summary>The object is protected by an object-lock retention policy or legal hold.</summary>
     ObjectLocked,
 }

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/BucketPublicAccessBlockConfiguration.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/BucketPublicAccessBlockConfiguration.cs
@@ -1,0 +1,25 @@
+namespace IntegratedS3.Abstractions.Models;
+
+/// <summary>
+/// Public access block configuration for a bucket.
+/// Mirrors the S3 <c>PublicAccessBlockConfiguration</c> element.
+/// </summary>
+public sealed class BucketPublicAccessBlockConfiguration
+{
+    /// <summary>
+    /// The name of the bucket.
+    /// </summary>
+    public string BucketName { get; init; } = string.Empty;
+
+    /// <summary>Whether Amazon S3 should block public ACLs for this bucket.</summary>
+    public bool BlockPublicAcls { get; init; }
+
+    /// <summary>Whether Amazon S3 should ignore public ACLs for this bucket.</summary>
+    public bool IgnorePublicAcls { get; init; }
+
+    /// <summary>Whether Amazon S3 should block public bucket policies for this bucket.</summary>
+    public bool BlockPublicPolicy { get; init; }
+
+    /// <summary>Whether Amazon S3 should restrict public bucket policies for this bucket.</summary>
+    public bool RestrictPublicBuckets { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/DeleteBucketPublicAccessBlockRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/DeleteBucketPublicAccessBlockRequest.cs
@@ -1,0 +1,8 @@
+namespace IntegratedS3.Abstractions.Requests;
+
+/// <summary>Request parameters for the DeletePublicAccessBlock operation.</summary>
+public sealed class DeleteBucketPublicAccessBlockRequest
+{
+    /// <summary>The name of the bucket.</summary>
+    public required string BucketName { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/PutBucketPublicAccessBlockRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/PutBucketPublicAccessBlockRequest.cs
@@ -1,0 +1,20 @@
+namespace IntegratedS3.Abstractions.Requests;
+
+/// <summary>Request parameters for the PutPublicAccessBlock operation.</summary>
+public sealed class PutBucketPublicAccessBlockRequest
+{
+    /// <summary>The name of the bucket.</summary>
+    public required string BucketName { get; init; }
+
+    /// <summary>Whether Amazon S3 should block public ACLs for this bucket.</summary>
+    public bool BlockPublicAcls { get; init; }
+
+    /// <summary>Whether Amazon S3 should ignore public ACLs for this bucket.</summary>
+    public bool IgnorePublicAcls { get; init; }
+
+    /// <summary>Whether Amazon S3 should block public bucket policies for this bucket.</summary>
+    public bool BlockPublicPolicy { get; init; }
+
+    /// <summary>Whether Amazon S3 should restrict public bucket policies for this bucket.</summary>
+    public bool RestrictPublicBuckets { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageBackend.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageBackend.cs
@@ -184,6 +184,36 @@ public interface IStorageBackend
         => ValueTask.FromResult(StorageResult.Failure(StorageError.Unsupported("Bucket default encryption is not implemented by this storage backend.", request.BucketName)));
 
     /// <summary>
+    /// Retrieves the public access block configuration for the specified bucket. The default implementation returns
+    /// <see cref="StorageErrorCode.UnsupportedCapability"/>.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the <see cref="BucketPublicAccessBlockConfiguration"/> on success.</returns>
+    ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult<BucketPublicAccessBlockConfiguration>.Failure(StorageError.Unsupported("Bucket public access block is not implemented by this storage backend.", bucketName)));
+
+    /// <summary>
+    /// Sets the public access block configuration for the specified bucket. The default implementation returns
+    /// <see cref="StorageErrorCode.UnsupportedCapability"/>.
+    /// </summary>
+    /// <param name="request">The public access block configuration to apply.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the applied <see cref="BucketPublicAccessBlockConfiguration"/> on success.</returns>
+    ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult<BucketPublicAccessBlockConfiguration>.Failure(StorageError.Unsupported("Bucket public access block is not implemented by this storage backend.", request.BucketName)));
+
+    /// <summary>
+    /// Deletes the public access block configuration from the specified bucket. The default implementation returns
+    /// <see cref="StorageErrorCode.UnsupportedCapability"/>.
+    /// </summary>
+    /// <param name="request">The delete public access block request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult"/> indicating success or failure.</returns>
+    ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult.Failure(StorageError.Unsupported("Bucket public access block is not implemented by this storage backend.", request.BucketName)));
+
+    /// <summary>
     /// Checks whether the specified bucket exists and is accessible.
     /// </summary>
     /// <param name="bucketName">The name of the bucket.</param>

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageService.cs
@@ -103,6 +103,31 @@ public interface IStorageService
     ValueTask<StorageResult> DeleteBucketDefaultEncryptionAsync(DeleteBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Retrieves the public access block configuration for the specified bucket.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the <see cref="BucketPublicAccessBlockConfiguration"/> on success,
+    /// or a <see cref="Errors.StorageError"/> with <see cref="Errors.StorageErrorCode.PublicAccessBlockConfigurationNotFound"/> if none exists.</returns>
+    ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Sets the public access block configuration for the specified bucket.
+    /// </summary>
+    /// <param name="request">The public access block configuration to apply.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the applied <see cref="BucketPublicAccessBlockConfiguration"/> on success.</returns>
+    ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Deletes the public access block configuration from the specified bucket.
+    /// </summary>
+    /// <param name="request">The delete public access block request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult"/> indicating success or failure.</returns>
+    ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Checks whether the specified bucket exists and is accessible to the caller.
     /// </summary>
     /// <param name="bucketName">The name of the bucket.</param>

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -145,6 +145,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string MetricsQueryParameterName = "metrics";
     private const string InventoryQueryParameterName = "inventory";
     private const string IntelligentTieringQueryParameterName = "intelligent-tiering";
+    private const string PublicAccessBlockQueryParameterName = "publicAccessBlock";
     private const string IdQueryParameterName = "id";
     private const string RestoreQueryParameterName = "restore";
     private const string ResponseContentTypeQueryParameterName = "response-content-type";
@@ -199,10 +200,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static readonly HashSet<string> BucketMetricsQueryParameters = CreateQueryParameterSet(MetricsQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketInventoryQueryParameters = CreateQueryParameterSet(InventoryQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketIntelligentTieringQueryParameters = CreateQueryParameterSet(IntelligentTieringQueryParameterName, IdQueryParameterName);
+    private static readonly HashSet<string> BucketPublicAccessBlockQueryParameters = CreateQueryParameterSet(PublicAccessBlockQueryParameterName);
     private static readonly HashSet<string> BucketVersionListingQueryParameters = CreateQueryParameterSet(VersionsQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MaxKeysQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, EncodingTypeQueryParameterName);
     private static readonly HashSet<string> BucketMultipartUploadsQueryParameters = CreateQueryParameterSet(UploadsQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MaxUploadsQueryParameterName, KeyMarkerQueryParameterName, UploadIdMarkerQueryParameterName, EncodingTypeQueryParameterName);
     private static readonly HashSet<string> BucketDeleteQueryParameters = CreateQueryParameterSet(DeleteQueryParameterName);
-    private static readonly HashSet<string> KnownBucketQueryParameters = CreateQueryParameterSet(ListTypeQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MarkerQueryParameterName, StartAfterQueryParameterName, MaxKeysQueryParameterName, MaxUploadsQueryParameterName, ContinuationTokenQueryParameterName, EncodingTypeQueryParameterName, FetchOwnerQueryParameterName, LocationQueryParameterName, AclQueryParameterName, CorsQueryParameterName, PolicyQueryParameterName, VersioningQueryParameterName, EncryptionQueryParameterName, TaggingQueryParameterName, LoggingQueryParameterName, WebsiteQueryParameterName, RequestPaymentQueryParameterName, AccelerateQueryParameterName, LifecycleQueryParameterName, ReplicationQueryParameterName, NotificationQueryParameterName, ObjectLockQueryParameterName, AnalyticsQueryParameterName, MetricsQueryParameterName, InventoryQueryParameterName, IntelligentTieringQueryParameterName, IdQueryParameterName, VersionsQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, UploadIdMarkerQueryParameterName, UploadsQueryParameterName, DeleteQueryParameterName);
+    private static readonly HashSet<string> KnownBucketQueryParameters = CreateQueryParameterSet(ListTypeQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MarkerQueryParameterName, StartAfterQueryParameterName, MaxKeysQueryParameterName, MaxUploadsQueryParameterName, ContinuationTokenQueryParameterName, EncodingTypeQueryParameterName, FetchOwnerQueryParameterName, LocationQueryParameterName, AclQueryParameterName, CorsQueryParameterName, PolicyQueryParameterName, VersioningQueryParameterName, EncryptionQueryParameterName, TaggingQueryParameterName, LoggingQueryParameterName, WebsiteQueryParameterName, RequestPaymentQueryParameterName, AccelerateQueryParameterName, LifecycleQueryParameterName, ReplicationQueryParameterName, NotificationQueryParameterName, ObjectLockQueryParameterName, AnalyticsQueryParameterName, MetricsQueryParameterName, InventoryQueryParameterName, IntelligentTieringQueryParameterName, PublicAccessBlockQueryParameterName, IdQueryParameterName, VersionsQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, UploadIdMarkerQueryParameterName, UploadsQueryParameterName, DeleteQueryParameterName);
     private static readonly HashSet<string> ObjectVersionQueryParameters = CreateQueryParameterSet(VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectAclQueryParameters = CreateQueryParameterSet(AclQueryParameterName);
     private static readonly HashSet<string> ObjectTaggingQueryParameters = CreateQueryParameterSet(TaggingQueryParameterName, VersionIdQueryParameterName);
@@ -1724,6 +1726,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "GET" when httpContext.Request.Query.ContainsKey(PolicyQueryParameterName) => await GetBucketPolicyAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(VersioningQueryParameterName) => await GetBucketVersioningAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(EncryptionQueryParameterName) => await GetBucketDefaultEncryptionAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "GET" when httpContext.Request.Query.ContainsKey(PublicAccessBlockQueryParameterName) => await GetBucketPublicAccessBlockAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await GetBucketTaggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(LoggingQueryParameterName) => await GetBucketLoggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(WebsiteQueryParameterName) => await GetBucketWebsiteAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -1766,6 +1769,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "PUT" when httpContext.Request.Query.ContainsKey(PolicyQueryParameterName) => await PutBucketPolicyAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(VersioningQueryParameterName) => await PutBucketVersioningAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(EncryptionQueryParameterName) => await PutBucketDefaultEncryptionAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "PUT" when httpContext.Request.Query.ContainsKey(PublicAccessBlockQueryParameterName) => await PutBucketPublicAccessBlockAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await PutBucketTaggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(LoggingQueryParameterName) => await PutBucketLoggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(WebsiteQueryParameterName) => await PutBucketWebsiteAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -1782,6 +1786,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "DELETE" when httpContext.Request.Query.ContainsKey(CorsQueryParameterName) => await DeleteBucketCorsAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(PolicyQueryParameterName) => await DeleteBucketPolicyAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(EncryptionQueryParameterName) => await DeleteBucketDefaultEncryptionAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "DELETE" when httpContext.Request.Query.ContainsKey(PublicAccessBlockQueryParameterName) => await DeleteBucketPublicAccessBlockAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await DeleteBucketTaggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(WebsiteQueryParameterName) => await DeleteBucketWebsiteAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(LifecycleQueryParameterName) => await DeleteBucketLifecycleAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -4236,6 +4241,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.MetricsConfigurationNotFound => StatusCodes.Status404NotFound,
             StorageErrorCode.InventoryConfigurationNotFound => StatusCodes.Status404NotFound,
             StorageErrorCode.IntelligentTieringConfigurationNotFound => StatusCodes.Status404NotFound,
+            StorageErrorCode.PublicAccessBlockConfigurationNotFound => StatusCodes.Status404NotFound,
             StorageErrorCode.AccessDenied => StatusCodes.Status403Forbidden,
             StorageErrorCode.InvalidTag => StatusCodes.Status400BadRequest,
             StorageErrorCode.InvalidChecksum => StatusCodes.Status400BadRequest,
@@ -4279,6 +4285,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.MetricsConfigurationNotFound => "NoSuchConfiguration",
             StorageErrorCode.InventoryConfigurationNotFound => "NoSuchConfiguration",
             StorageErrorCode.IntelligentTieringConfigurationNotFound => "NoSuchConfiguration",
+            StorageErrorCode.PublicAccessBlockConfigurationNotFound => "NoSuchPublicAccessBlockConfiguration",
             StorageErrorCode.AccessDenied => "AccessDenied",
             StorageErrorCode.InvalidTag => "InvalidTag",
             StorageErrorCode.InvalidChecksum => "BadDigest",
@@ -4942,6 +4949,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         var isBucketMetricsRequest = queryKeys.Contains(MetricsQueryParameterName) && queryKeys.IsSubsetOf(BucketMetricsQueryParameters);
         var isBucketInventoryRequest = queryKeys.Contains(InventoryQueryParameterName) && queryKeys.IsSubsetOf(BucketInventoryQueryParameters);
         var isBucketIntelligentTieringRequest = queryKeys.Contains(IntelligentTieringQueryParameterName) && queryKeys.IsSubsetOf(BucketIntelligentTieringQueryParameters);
+        var isBucketPublicAccessBlockRequest = queryKeys.SetEquals(BucketPublicAccessBlockQueryParameters);
         var isListObjectVersionsRequest = queryKeys.Contains(VersionsQueryParameterName) && queryKeys.IsSubsetOf(BucketVersionListingQueryParameters);
         var isListMultipartUploadsRequest = queryKeys.Contains(UploadsQueryParameterName) && queryKeys.IsSubsetOf(BucketMultipartUploadsQueryParameters);
         var isDeleteObjectsRequest = queryKeys.SetEquals(BucketDeleteQueryParameters);
@@ -4983,6 +4991,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketMetricsRequest
                     || isBucketInventoryRequest
                     || isBucketIntelligentTieringRequest
+                    || isBucketPublicAccessBlockRequest
                     || isListObjectVersionsRequest
                     || isListMultipartUploadsRequest) {
                     break;
@@ -5026,7 +5035,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketAnalyticsRequest
                     || isBucketMetricsRequest
                     || isBucketInventoryRequest
-                    || isBucketIntelligentTieringRequest) {
+                    || isBucketIntelligentTieringRequest
+                    || isBucketPublicAccessBlockRequest) {
                     break;
                 }
 
@@ -5044,7 +5054,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketAnalyticsRequest
                     || isBucketMetricsRequest
                     || isBucketInventoryRequest
-                    || isBucketIntelligentTieringRequest) {
+                    || isBucketIntelligentTieringRequest
+                    || isBucketPublicAccessBlockRequest) {
                     break;
                 }
 
@@ -9796,6 +9807,100 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
     }
 
+    // ── Bucket Public Access Block ───────────────────────────────────────────
+
+    private static async Task<IResult> GetBucketPublicAccessBlockAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        IStorageService storageService,
+        CancellationToken cancellationToken)
+    {
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                var result = await storageService.GetBucketPublicAccessBlockAsync(bucketName, innerCancellationToken);
+                if (!result.IsSuccess) {
+                    return ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+                }
+
+                var config = result.Value!;
+                return new XmlContentResult(
+                    S3XmlResponseWriter.WritePublicAccessBlockConfiguration(new S3PublicAccessBlockConfiguration
+                    {
+                        BlockPublicAcls = config.BlockPublicAcls,
+                        IgnorePublicAcls = config.IgnorePublicAcls,
+                        BlockPublicPolicy = config.BlockPublicPolicy,
+                        RestrictPublicBuckets = config.RestrictPublicBuckets
+                    }),
+                    StatusCodes.Status200OK,
+                    XmlContentType);
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
+    private static async Task<IResult> PutBucketPublicAccessBlockAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        IStorageService storageService,
+        CancellationToken cancellationToken)
+    {
+        S3PublicAccessBlockConfiguration requestBody;
+        try {
+            requestBody = await S3XmlRequestReader.ReadPublicAccessBlockConfigurationAsync(httpContext.Request.Body, cancellationToken);
+        }
+        catch (FormatException exception) {
+            return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "MalformedXML", exception.Message, BuildObjectResource(bucketName, null), bucketName);
+        }
+
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                var result = await storageService.PutBucketPublicAccessBlockAsync(new PutBucketPublicAccessBlockRequest
+                {
+                    BucketName = bucketName,
+                    BlockPublicAcls = requestBody.BlockPublicAcls,
+                    IgnorePublicAcls = requestBody.IgnorePublicAcls,
+                    BlockPublicPolicy = requestBody.BlockPublicPolicy,
+                    RestrictPublicBuckets = requestBody.RestrictPublicBuckets
+                }, innerCancellationToken);
+
+                return result.IsSuccess
+                    ? TypedResults.Ok()
+                    : ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
+    private static async Task<IResult> DeleteBucketPublicAccessBlockAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        IStorageService storageService,
+        CancellationToken cancellationToken)
+    {
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                var result = await storageService.DeleteBucketPublicAccessBlockAsync(new DeleteBucketPublicAccessBlockRequest
+                {
+                    BucketName = bucketName
+                }, innerCancellationToken);
+
+                return result.IsSuccess
+                    ? TypedResults.NoContent()
+                    : ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
     // ── Bucket Logging ──────────────────────────────────────────────────────
 
     private static async Task<IResult> GetBucketLoggingAsync(
@@ -11577,6 +11682,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         if (request.Query.ContainsKey(PolicyQueryParameterName)) return $"{method}BucketPolicy";
         if (request.Query.ContainsKey(VersioningQueryParameterName)) return $"{method}BucketVersioning";
         if (request.Query.ContainsKey(EncryptionQueryParameterName)) return $"{method}BucketEncryption";
+        if (request.Query.ContainsKey(PublicAccessBlockQueryParameterName)) return $"{method}BucketPublicAccessBlock";
         if (request.Query.ContainsKey(TaggingQueryParameterName)) return $"{method}BucketTagging";
         if (request.Query.ContainsKey(LoggingQueryParameterName)) return $"{method}BucketLogging";
         if (request.Query.ContainsKey(WebsiteQueryParameterName)) return $"{method}BucketWebsite";

--- a/src/IntegratedS3/IntegratedS3.Core/Models/StorageOperationType.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Models/StorageOperationType.cs
@@ -316,4 +316,16 @@ public enum StorageOperationType
 
     /// <summary>Generate a presigned URL for uploading a single part of a multipart upload.</summary>
     PresignUploadPart,
+
+    // ── Bucket public access block ──────────────────────────────────
+    // New members are appended so existing numeric values stay stable.
+
+    /// <summary>Retrieve the public access block configuration of a bucket.</summary>
+    GetBucketPublicAccessBlock,
+
+    /// <summary>Set the public access block configuration of a bucket.</summary>
+    PutBucketPublicAccessBlock,
+
+    /// <summary>Delete the public access block configuration of a bucket.</summary>
+    DeleteBucketPublicAccessBlock,
 }

--- a/src/IntegratedS3/IntegratedS3.Core/Services/AuthorizingStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/AuthorizingStorageService.cs
@@ -118,6 +118,33 @@ internal sealed class AuthorizingStorageService(
         }, innerCancellationToken => inner.DeleteBucketDefaultEncryptionAsync(request, innerCancellationToken), cancellationToken);
     }
 
+    public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAuthorizedAsync(new StorageAuthorizationRequest
+        {
+            Operation = StorageOperationType.GetBucketPublicAccessBlock,
+            BucketName = bucketName
+        }, innerCancellationToken => inner.GetBucketPublicAccessBlockAsync(bucketName, innerCancellationToken), cancellationToken);
+    }
+
+    public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAuthorizedAsync(new StorageAuthorizationRequest
+        {
+            Operation = StorageOperationType.PutBucketPublicAccessBlock,
+            BucketName = request.BucketName
+        }, innerCancellationToken => inner.PutBucketPublicAccessBlockAsync(request, innerCancellationToken), cancellationToken);
+    }
+
+    public ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAuthorizedAsync(new StorageAuthorizationRequest
+        {
+            Operation = StorageOperationType.DeleteBucketPublicAccessBlock,
+            BucketName = request.BucketName
+        }, innerCancellationToken => inner.DeleteBucketPublicAccessBlockAsync(request, innerCancellationToken), cancellationToken);
+    }
+
     public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default)
     {
         return ExecuteAuthorizedAsync(new StorageAuthorizationRequest

--- a/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
@@ -749,6 +749,71 @@ internal sealed class OrchestratedStorageService(
         return result;
     }
 
+    // ── Bucket Public Access Block ───────────────────────────────────────
+
+    public async ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        return await ExecuteReadAsync(
+            StorageOperationType.GetBucketPublicAccessBlock,
+            (backend, ct) => backend.GetBucketPublicAccessBlockAsync(bucketName, ct),
+            onSuccess: null,
+            cancellationToken);
+    }
+
+    public async ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        var backend = GetPrimaryBackend();
+        var strictReplicationError = await GetStrictReplicaWritePreflightErrorAsync(backend, request.BucketName, objectKey: null, versionId: null, cancellationToken: cancellationToken);
+        if (strictReplicationError is not null) {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(strictReplicationError);
+        }
+
+        var result = await backend.PutBucketPublicAccessBlockAsync(request, cancellationToken);
+        ObserveResult(backend, result);
+        if (result.IsSuccess && result.Value is not null) {
+            var replicationError = await ApplyReplicaWritePolicyAsync(
+                StorageOperationType.PutBucketPublicAccessBlock,
+                backend,
+                request.BucketName,
+                objectKey: null,
+                versionId: null,
+                writeThroughOperation: (replicaBackend, ct) => WriteReplicaPutBucketPublicAccessBlockAsync(replicaBackend, request, ct),
+                cancellationToken: CancellationToken.None);
+            if (replicationError is not null) {
+                return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(replicationError);
+            }
+        }
+
+        return result;
+    }
+
+    public async ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        var backend = GetPrimaryBackend();
+        var strictReplicationError = await GetStrictReplicaWritePreflightErrorAsync(backend, request.BucketName, objectKey: null, versionId: null, cancellationToken: cancellationToken);
+        if (strictReplicationError is not null) {
+            return StorageResult.Failure(strictReplicationError);
+        }
+
+        var result = await backend.DeleteBucketPublicAccessBlockAsync(request, cancellationToken);
+        ObserveResult(backend, result);
+        if (result.IsSuccess) {
+            var replicationError = await ApplyReplicaWritePolicyAsync(
+                StorageOperationType.DeleteBucketPublicAccessBlock,
+                backend,
+                request.BucketName,
+                objectKey: null,
+                versionId: null,
+                writeThroughOperation: (replicaBackend, ct) => WriteReplicaDeleteBucketPublicAccessBlockAsync(replicaBackend, request, ct),
+                cancellationToken: CancellationToken.None);
+            if (replicationError is not null) {
+                return StorageResult.Failure(replicationError);
+            }
+        }
+
+        return result;
+    }
+
     // ── Bucket Logging ──────────────────────────────────────────────────
 
     public async ValueTask<StorageResult<BucketLoggingConfiguration>> GetBucketLoggingAsync(string bucketName, CancellationToken cancellationToken = default)
@@ -2456,6 +2521,28 @@ internal sealed class OrchestratedStorageService(
         ObserveResult(replicaBackend, replicaResult);
         if (!replicaResult.IsSuccess && replicaResult.Error?.Code is not (StorageErrorCode.TaggingConfigurationNotFound or StorageErrorCode.BucketNotFound)) {
             return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket tagging delete did not succeed.");
+        }
+
+        return null;
+    }
+
+    private async ValueTask<StorageError?> WriteReplicaPutBucketPublicAccessBlockAsync(IStorageBackend replicaBackend, PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken)
+    {
+        var replicaResult = await replicaBackend.PutBucketPublicAccessBlockAsync(request, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket public access block update did not return configuration metadata.");
+        }
+
+        return null;
+    }
+
+    private async ValueTask<StorageError?> WriteReplicaDeleteBucketPublicAccessBlockAsync(IStorageBackend replicaBackend, DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken)
+    {
+        var replicaResult = await replicaBackend.DeleteBucketPublicAccessBlockAsync(request, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess && replicaResult.Error?.Code is not (StorageErrorCode.PublicAccessBlockConfigurationNotFound or StorageErrorCode.BucketNotFound)) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket public access block delete did not succeed.");
         }
 
         return null;

--- a/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
@@ -41,6 +41,7 @@ internal sealed class StorageReplicaRepairService(
                 or StorageOperationType.PutBucketRequestPayment
                 or StorageOperationType.PutBucketAccelerate
                 or StorageOperationType.PutBucketLifecycle or StorageOperationType.DeleteBucketLifecycle
+                or StorageOperationType.PutBucketPublicAccessBlock or StorageOperationType.DeleteBucketPublicAccessBlock
                 => await RepairReplicaBucketConfigFallbackAsync(primaryBackend, replicaBackend, entry.BucketName, entry, cancellationToken),
             StorageOperationType.DeleteBucket => await RepairReplicaBucketDeleteAsync(replicaBackend, entry.BucketName, cancellationToken),
             StorageOperationType.CopyObject or StorageOperationType.PutObject => string.IsNullOrWhiteSpace(entry.ObjectKey)

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3PublicAccessBlockConfiguration.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3PublicAccessBlockConfiguration.cs
@@ -1,0 +1,19 @@
+namespace IntegratedS3.Protocol;
+
+/// <summary>
+/// Represents the public access block configuration for an S3 bucket.
+/// </summary>
+public sealed class S3PublicAccessBlockConfiguration
+{
+    /// <summary>Whether Amazon S3 should block public ACLs for this bucket.</summary>
+    public bool BlockPublicAcls { get; init; }
+
+    /// <summary>Whether Amazon S3 should ignore public ACLs for this bucket.</summary>
+    public bool IgnorePublicAcls { get; init; }
+
+    /// <summary>Whether Amazon S3 should block public bucket policies for this bucket.</summary>
+    public bool BlockPublicPolicy { get; init; }
+
+    /// <summary>Whether Amazon S3 should restrict public bucket policies for this bucket.</summary>
+    public bool RestrictPublicBuckets { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlRequestReader.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlRequestReader.cs
@@ -75,6 +75,57 @@ public static class S3XmlRequestReader
         }
     }
 
+    /// <summary>Reads a bucket public access block configuration from the XML request body.</summary>
+    /// <param name="content">The request body stream containing the XML payload.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The deserialized <see cref="S3PublicAccessBlockConfiguration"/>.</returns>
+    public static async Task<S3PublicAccessBlockConfiguration> ReadPublicAccessBlockConfigurationAsync(Stream content, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        try {
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
+            var root = document.Root;
+            if (root is null || !string.Equals(root.Name.LocalName, "PublicAccessBlockConfiguration", StringComparison.Ordinal)) {
+                throw new FormatException("The public access block request body must contain a root 'PublicAccessBlockConfiguration' element.");
+            }
+
+            return new S3PublicAccessBlockConfiguration
+            {
+                BlockPublicAcls = ParseOptionalBoolean(root, "BlockPublicAcls"),
+                IgnorePublicAcls = ParseOptionalBoolean(root, "IgnorePublicAcls"),
+                BlockPublicPolicy = ParseOptionalBoolean(root, "BlockPublicPolicy"),
+                RestrictPublicBuckets = ParseOptionalBoolean(root, "RestrictPublicBuckets")
+            };
+        }
+        catch (FormatException ex) {
+            ProtocolTelemetry.RecordXmlParseError("ReadPublicAccessBlockConfiguration", ex.Message);
+            throw;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException) {
+            ProtocolTelemetry.RecordXmlParseError("ReadPublicAccessBlockConfiguration", exception.Message);
+            throw new FormatException("The public access block request body is not valid XML.", exception);
+        }
+    }
+
+    private static bool ParseOptionalBoolean(XElement parent, string childName)
+    {
+        var text = GetSingleOptionalChildValue(
+            parent,
+            childName,
+            $"The public access block configuration must not contain multiple '{childName}' elements.");
+
+        if (text is null) {
+            return false;
+        }
+
+        if (!bool.TryParse(text, out var parsed)) {
+            throw new FormatException($"The '{childName}' element must be 'true' or 'false'.");
+        }
+
+        return parsed;
+    }
+
     /// <summary>Reads a CORS configuration from the XML request body.</summary>
     /// <param name="content">The request body stream containing the XML payload.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -102,6 +102,32 @@ public static class S3XmlResponseWriter
         return InjectS3Namespace(builder, "ServerSideEncryptionConfiguration");
     }
 
+    /// <summary>Writes a PublicAccessBlockConfiguration as an XML response body.</summary>
+    /// <param name="response">The <see cref="S3PublicAccessBlockConfiguration"/> to serialize.</param>
+    /// <returns>The XML string.</returns>
+    public static string WritePublicAccessBlockConfiguration(S3PublicAccessBlockConfiguration response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var builder = new StringBuilder(256);
+        using var stringWriter = new Utf8StringWriter(builder, CultureInfo.InvariantCulture);
+        using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
+
+        xmlWriter.WriteStartDocument();
+        xmlWriter.WriteStartElement("PublicAccessBlockConfiguration");
+
+        xmlWriter.WriteElementString("BlockPublicAcls", XmlConvert.ToString(response.BlockPublicAcls));
+        xmlWriter.WriteElementString("IgnorePublicAcls", XmlConvert.ToString(response.IgnorePublicAcls));
+        xmlWriter.WriteElementString("BlockPublicPolicy", XmlConvert.ToString(response.BlockPublicPolicy));
+        xmlWriter.WriteElementString("RestrictPublicBuckets", XmlConvert.ToString(response.RestrictPublicBuckets));
+
+        xmlWriter.WriteEndElement();
+        xmlWriter.WriteEndDocument();
+        xmlWriter.Flush();
+
+        return InjectS3Namespace(builder, "PublicAccessBlockConfiguration");
+    }
+
     /// <summary>Writes a CorsConfiguration as an XML response body.</summary>
     /// <param name="response">The <see cref="S3CorsConfiguration"/> to serialize.</param>
     /// <returns>The XML string.</returns>

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -261,6 +261,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         if (!ShouldPersistBucketMetadata(metadata)) {
@@ -326,6 +327,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         if (!ShouldPersistBucketMetadata(updatedMetadata)) {
@@ -367,6 +369,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         if (!ShouldPersistBucketMetadata(updatedMetadata)) {
@@ -438,6 +441,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -478,11 +482,129 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
         return StorageResult.Success();
     }
+
+    // -------------------------------------------------------------------------
+    // Bucket Public Access Block
+    // -------------------------------------------------------------------------
+
+    public async ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bucketPath = GetBucketPath(bucketName);
+        if (!Directory.Exists(bucketPath)) {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(BucketNotFound(bucketName));
+        }
+
+        var metadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
+        if (metadata.PublicAccessBlockConfiguration is null) {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(ConfigurationNotFound(StorageErrorCode.PublicAccessBlockConfigurationNotFound, bucketName, "public access block"));
+        }
+
+        return StorageResult<BucketPublicAccessBlockConfiguration>.Success(new BucketPublicAccessBlockConfiguration
+        {
+            BucketName = bucketName,
+            BlockPublicAcls = metadata.PublicAccessBlockConfiguration.BlockPublicAcls,
+            IgnorePublicAcls = metadata.PublicAccessBlockConfiguration.IgnorePublicAcls,
+            BlockPublicPolicy = metadata.PublicAccessBlockConfiguration.BlockPublicPolicy,
+            RestrictPublicBuckets = metadata.PublicAccessBlockConfiguration.RestrictPublicBuckets
+        });
+    }
+
+    public async ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bucketPath = GetBucketPath(request.BucketName);
+        if (!Directory.Exists(bucketPath)) {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(BucketNotFound(request.BucketName));
+        }
+
+        var diskConfig = new DiskBucketPublicAccessBlockConfiguration
+        {
+            BlockPublicAcls = request.BlockPublicAcls,
+            IgnorePublicAcls = request.IgnorePublicAcls,
+            BlockPublicPolicy = request.BlockPublicPolicy,
+            RestrictPublicBuckets = request.RestrictPublicBuckets
+        };
+
+        using var bucketMutationLock = await AcquireBucketMutationLockAsync(bucketPath, cancellationToken);
+        var existingMetadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
+        var updatedMetadata = new DiskBucketMetadata
+        {
+            VersioningStatus = existingMetadata.VersioningStatus,
+            CorsConfiguration = existingMetadata.CorsConfiguration,
+            TaggingConfiguration = existingMetadata.TaggingConfiguration,
+            LoggingConfiguration = existingMetadata.LoggingConfiguration,
+            WebsiteConfiguration = existingMetadata.WebsiteConfiguration,
+            RequestPaymentConfiguration = existingMetadata.RequestPaymentConfiguration,
+            AccelerateConfiguration = existingMetadata.AccelerateConfiguration,
+            LifecycleConfiguration = existingMetadata.LifecycleConfiguration,
+            ReplicationConfiguration = existingMetadata.ReplicationConfiguration,
+            NotificationConfiguration = existingMetadata.NotificationConfiguration,
+            ObjectLockConfiguration = existingMetadata.ObjectLockConfiguration,
+            AnalyticsConfigurations = existingMetadata.AnalyticsConfigurations,
+            MetricsConfigurations = existingMetadata.MetricsConfigurations,
+            InventoryConfigurations = existingMetadata.InventoryConfigurations,
+            IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = diskConfig,
+        };
+
+        await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
+
+        return StorageResult<BucketPublicAccessBlockConfiguration>.Success(new BucketPublicAccessBlockConfiguration
+        {
+            BucketName = request.BucketName,
+            BlockPublicAcls = diskConfig.BlockPublicAcls,
+            IgnorePublicAcls = diskConfig.IgnorePublicAcls,
+            BlockPublicPolicy = diskConfig.BlockPublicPolicy,
+            RestrictPublicBuckets = diskConfig.RestrictPublicBuckets
+        });
+    }
+
+    public async ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bucketPath = GetBucketPath(request.BucketName);
+        if (!Directory.Exists(bucketPath)) {
+            return StorageResult.Failure(BucketNotFound(request.BucketName));
+        }
+
+        using var bucketMutationLock = await AcquireBucketMutationLockAsync(bucketPath, cancellationToken);
+        var existingMetadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
+        var updatedMetadata = new DiskBucketMetadata
+        {
+            VersioningStatus = existingMetadata.VersioningStatus,
+            CorsConfiguration = existingMetadata.CorsConfiguration,
+            TaggingConfiguration = existingMetadata.TaggingConfiguration,
+            LoggingConfiguration = existingMetadata.LoggingConfiguration,
+            WebsiteConfiguration = existingMetadata.WebsiteConfiguration,
+            RequestPaymentConfiguration = existingMetadata.RequestPaymentConfiguration,
+            AccelerateConfiguration = existingMetadata.AccelerateConfiguration,
+            LifecycleConfiguration = existingMetadata.LifecycleConfiguration,
+            ReplicationConfiguration = existingMetadata.ReplicationConfiguration,
+            NotificationConfiguration = existingMetadata.NotificationConfiguration,
+            ObjectLockConfiguration = existingMetadata.ObjectLockConfiguration,
+            AnalyticsConfigurations = existingMetadata.AnalyticsConfigurations,
+            MetricsConfigurations = existingMetadata.MetricsConfigurations,
+            InventoryConfigurations = existingMetadata.InventoryConfigurations,
+            IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = null,
+        };
+
+        await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
+        return StorageResult.Success();
+    }
+
     // -------------------------------------------------------------------------
     // Bucket Logging
     // -------------------------------------------------------------------------
@@ -540,6 +662,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -603,6 +726,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -639,6 +763,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -703,6 +828,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -772,6 +898,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -834,6 +961,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -870,6 +998,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -927,6 +1056,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -963,6 +1093,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1019,6 +1150,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1090,6 +1222,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1152,6 +1285,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1193,6 +1327,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1275,6 +1410,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = updatedDict,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1316,6 +1452,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = updatedDict.Count > 0 ? updatedDict : null,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1398,6 +1535,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = updatedDict,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1439,6 +1577,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = updatedDict.Count > 0 ? updatedDict : null,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1521,6 +1660,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = updatedDict,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1562,6 +1702,7 @@ internal sealed class DiskStorageService(
             MetricsConfigurations = existingMetadata.MetricsConfigurations,
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = updatedDict.Count > 0 ? updatedDict : null,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -4723,7 +4864,8 @@ internal sealed class DiskStorageService(
             || metadata.AnalyticsConfigurations is { Count: > 0 }
             || metadata.MetricsConfigurations is { Count: > 0 }
             || metadata.InventoryConfigurations is { Count: > 0 }
-            || metadata.IntelligentTieringConfigurations is { Count: > 0 };
+            || metadata.IntelligentTieringConfigurations is { Count: > 0 }
+            || metadata.PublicAccessBlockConfiguration is not null;
     }
 
     private static BucketCorsConfiguration ToBucketCorsConfiguration(string bucketName, DiskBucketCorsConfiguration configuration)

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskBucketMetadata.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskBucketMetadata.cs
@@ -47,6 +47,9 @@ internal sealed class DiskBucketMetadata
 
     [JsonPropertyName("intelligentTieringConfigurations")]
     public Dictionary<string, DiskBucketIntelligentTieringConfiguration>? IntelligentTieringConfigurations { get; init; }
+
+    [JsonPropertyName("publicAccessBlockConfiguration")]
+    public DiskBucketPublicAccessBlockConfiguration? PublicAccessBlockConfiguration { get; init; }
 }
 
 internal sealed class DiskBucketCorsConfiguration
@@ -75,6 +78,23 @@ internal sealed class DiskBucketTaggingConfiguration
 {
     [JsonPropertyName("tags")]
     public Dictionary<string, string> Tags { get; init; } = new();
+}
+
+// --- Public Access Block ---
+
+internal sealed class DiskBucketPublicAccessBlockConfiguration
+{
+    [JsonPropertyName("blockPublicAcls")]
+    public bool BlockPublicAcls { get; init; }
+
+    [JsonPropertyName("ignorePublicAcls")]
+    public bool IgnorePublicAcls { get; init; }
+
+    [JsonPropertyName("blockPublicPolicy")]
+    public bool BlockPublicPolicy { get; init; }
+
+    [JsonPropertyName("restrictPublicBuckets")]
+    public bool RestrictPublicBuckets { get; init; }
 }
 
 // --- Logging ---

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskStorageJsonSerializerContext.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskStorageJsonSerializerContext.cs
@@ -8,6 +8,7 @@ namespace IntegratedS3.Provider.Disk.Internal;
 [JsonSerializable(typeof(DiskBucketCorsRule))]
 [JsonSerializable(typeof(DiskMultipartUploadState))]
 [JsonSerializable(typeof(DiskBucketTaggingConfiguration))]
+[JsonSerializable(typeof(DiskBucketPublicAccessBlockConfiguration))]
 [JsonSerializable(typeof(DiskBucketLoggingConfiguration))]
 [JsonSerializable(typeof(DiskBucketWebsiteConfiguration))]
 [JsonSerializable(typeof(DiskBucketWebsiteRedirectAllRequestsTo))]

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/AwsS3StorageClient.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/AwsS3StorageClient.cs
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Logging;
 using PutBucketDefaultEncryptionStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketDefaultEncryptionRequest;
 using UploadPartCopyStorageRequest = IntegratedS3.Abstractions.Requests.UploadPartCopyRequest;
 using PutBucketTaggingStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketTaggingRequest;
+using PutBucketPublicAccessBlockStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketPublicAccessBlockRequest;
 using PutBucketLoggingStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketLoggingRequest;
 using PutBucketWebsiteStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketWebsiteRequest;
 using PutBucketRequestPaymentStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketRequestPaymentRequest;
@@ -326,6 +327,66 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
         };
 
         await _s3.DeleteBucketEncryptionAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bucket Public Access Block
+    // -------------------------------------------------------------------------
+
+    public async Task<BucketPublicAccessBlockConfiguration> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        var request = new GetPublicAccessBlockRequest
+        {
+            BucketName = bucketName
+        };
+
+        var response = await _s3.GetPublicAccessBlockAsync(request, cancellationToken).ConfigureAwait(false);
+        var config = response.PublicAccessBlockConfiguration;
+        return new BucketPublicAccessBlockConfiguration
+        {
+            BucketName = bucketName,
+            BlockPublicAcls = config?.BlockPublicAcls ?? false,
+            IgnorePublicAcls = config?.IgnorePublicAcls ?? false,
+            BlockPublicPolicy = config?.BlockPublicPolicy ?? false,
+            RestrictPublicBuckets = config?.RestrictPublicBuckets ?? false
+        };
+    }
+
+    public async Task<BucketPublicAccessBlockConfiguration> SetBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockStorageRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var putRequest = new PutPublicAccessBlockRequest
+        {
+            BucketName = request.BucketName,
+            PublicAccessBlockConfiguration = new Amazon.S3.Model.PublicAccessBlockConfiguration
+            {
+                BlockPublicAcls = request.BlockPublicAcls,
+                IgnorePublicAcls = request.IgnorePublicAcls,
+                BlockPublicPolicy = request.BlockPublicPolicy,
+                RestrictPublicBuckets = request.RestrictPublicBuckets
+            }
+        };
+
+        await _s3.PutPublicAccessBlockAsync(putRequest, cancellationToken).ConfigureAwait(false);
+        return new BucketPublicAccessBlockConfiguration
+        {
+            BucketName = request.BucketName,
+            BlockPublicAcls = request.BlockPublicAcls,
+            IgnorePublicAcls = request.IgnorePublicAcls,
+            BlockPublicPolicy = request.BlockPublicPolicy,
+            RestrictPublicBuckets = request.RestrictPublicBuckets
+        };
+    }
+
+    public async Task DeleteBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        var request = new DeletePublicAccessBlockRequest
+        {
+            BucketName = bucketName
+        };
+
+        await _s3.DeletePublicAccessBlockAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
     // -------------------------------------------------------------------------

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/IS3StorageClient.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/IS3StorageClient.cs
@@ -33,6 +33,14 @@ internal interface IS3StorageClient : IDisposable
     Task DeleteBucketDefaultEncryptionAsync(string bucketName, CancellationToken cancellationToken = default)
         => Task.FromException(new NotSupportedException("Bucket default encryption is not implemented by this S3 storage client."));
 
+    // Bucket Public Access Block
+    Task<BucketPublicAccessBlockConfiguration> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+        => Task.FromException<BucketPublicAccessBlockConfiguration>(new NotSupportedException("Bucket public access block is not implemented by this S3 storage client."));
+    Task<BucketPublicAccessBlockConfiguration> SetBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+        => Task.FromException<BucketPublicAccessBlockConfiguration>(new NotSupportedException("Bucket public access block is not implemented by this S3 storage client."));
+    Task DeleteBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+        => Task.FromException(new NotSupportedException("Bucket public access block is not implemented by this S3 storage client."));
+
     // Object listing
     Task<S3ObjectListPage> ListObjectsAsync(
         string bucketName,

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
@@ -356,6 +356,61 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
     }
 
     // -------------------------------------------------------------------------
+    // Bucket Public Access Block
+    // -------------------------------------------------------------------------
+
+    public async ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _client.GetBucketPublicAccessBlockAsync(bucketName, cancellationToken).ConfigureAwait(false);
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Success(config);
+        }
+        catch (AmazonServiceException ex)
+        {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
+        }
+    }
+
+    public async ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _client.SetBucketPublicAccessBlockAsync(request, cancellationToken).ConfigureAwait(false);
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Success(config);
+        }
+        catch (AmazonServiceException ex)
+        {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketPublicAccessBlockConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
+        }
+    }
+
+    public async ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _client.DeleteBucketPublicAccessBlockAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
+            return StorageResult.Success();
+        }
+        catch (AmazonServiceException ex)
+        {
+            return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Bucket Tagging
     // -------------------------------------------------------------------------
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -1496,6 +1496,93 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         await AssertErrorResponseAsync(missingResponse, HttpStatusCode.NotFound, "ServerSideEncryptionConfigurationNotFoundError");
     }
 
+    [Fact]
+    public async Task S3CompatibleBucketPublicAccessBlock_RoundTripsXmlPayload()
+    {
+        var storageService = new RecordingStorageService();
+        await using var isolatedClient = await CreateStorageServiceIsolatedClientAsync(storageService);
+        using var client = isolatedClient.Client;
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/public-access-block-bucket?publicAccessBlock")
+        {
+            Content = new StringContent("""
+<PublicAccessBlockConfiguration>
+  <BlockPublicAcls>true</BlockPublicAcls>
+  <IgnorePublicAcls>false</IgnorePublicAcls>
+  <BlockPublicPolicy>true</BlockPublicPolicy>
+  <RestrictPublicBuckets>false</RestrictPublicBuckets>
+</PublicAccessBlockConfiguration>
+""", Encoding.UTF8, "application/xml")
+        };
+
+        var putResponse = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        var putPublicAccessBlock = storageService.LastPutBucketPublicAccessBlockRequest
+            ?? throw new Xunit.Sdk.XunitException("Expected bucket public access block request to reach the storage service.");
+        Assert.True(putPublicAccessBlock.BlockPublicAcls);
+        Assert.False(putPublicAccessBlock.IgnorePublicAcls);
+        Assert.True(putPublicAccessBlock.BlockPublicPolicy);
+        Assert.False(putPublicAccessBlock.RestrictPublicBuckets);
+
+        var getResponse = await client.GetAsync("/integrated-s3/public-access-block-bucket?publicAccessBlock");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal("application/xml", getResponse.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await getResponse.Content.ReadAsStringAsync());
+        Assert.Equal("PublicAccessBlockConfiguration", document.Root?.Name.LocalName);
+        Assert.Equal("true", document.Root!.Element(S3Ns + "BlockPublicAcls")?.Value);
+        Assert.Equal("false", document.Root!.Element(S3Ns + "IgnorePublicAcls")?.Value);
+        Assert.Equal("true", document.Root!.Element(S3Ns + "BlockPublicPolicy")?.Value);
+        Assert.Equal("false", document.Root!.Element(S3Ns + "RestrictPublicBuckets")?.Value);
+
+        var deleteResponse = await client.DeleteAsync("/integrated-s3/public-access-block-bucket?publicAccessBlock");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var missingResponse = await client.GetAsync("/integrated-s3/public-access-block-bucket?publicAccessBlock");
+        await AssertErrorResponseAsync(missingResponse, HttpStatusCode.NotFound, "NoSuchPublicAccessBlockConfiguration");
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketPublicAccessBlock_PersistsThroughDiskProvider()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "public-access-block-disk-bucket";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // GET before any config is set surfaces the specific NoSuch* 404.
+        var missingBefore = await client.GetAsync($"/integrated-s3/{bucketName}?publicAccessBlock");
+        await AssertErrorResponseAsync(missingBefore, HttpStatusCode.NotFound, "NoSuchPublicAccessBlockConfiguration");
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}?publicAccessBlock")
+        {
+            Content = new StringContent("""
+<PublicAccessBlockConfiguration>
+  <BlockPublicAcls>true</BlockPublicAcls>
+  <IgnorePublicAcls>true</IgnorePublicAcls>
+  <BlockPublicPolicy>false</BlockPublicPolicy>
+  <RestrictPublicBuckets>true</RestrictPublicBuckets>
+</PublicAccessBlockConfiguration>
+""", Encoding.UTF8, "application/xml")
+        };
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}?publicAccessBlock");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var document = XDocument.Parse(await getResponse.Content.ReadAsStringAsync());
+        Assert.Equal("PublicAccessBlockConfiguration", document.Root?.Name.LocalName);
+        Assert.Equal("true", document.Root!.Element(S3Ns + "BlockPublicAcls")?.Value);
+        Assert.Equal("true", document.Root!.Element(S3Ns + "IgnorePublicAcls")?.Value);
+        Assert.Equal("false", document.Root!.Element(S3Ns + "BlockPublicPolicy")?.Value);
+        Assert.Equal("true", document.Root!.Element(S3Ns + "RestrictPublicBuckets")?.Value);
+
+        Assert.Equal(HttpStatusCode.NoContent, (await client.DeleteAsync($"/integrated-s3/{bucketName}?publicAccessBlock")).StatusCode);
+
+        var missingAfter = await client.GetAsync($"/integrated-s3/{bucketName}?publicAccessBlock");
+        await AssertErrorResponseAsync(missingAfter, HttpStatusCode.NotFound, "NoSuchPublicAccessBlockConfiguration");
+    }
+
     [Theory]
     [InlineData("?tagging", "NoSuchTagSet")]
     [InlineData("?website", "NoSuchWebsiteConfiguration")]
@@ -1508,6 +1595,7 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     // Regression for #153: ?intelligent-tiering was rejected by the request validator before dispatch,
     // so the (existing) handler was unreachable. It must now route through and surface the mapped 404.
     [InlineData("?intelligent-tiering&id=report", "NoSuchConfiguration")]
+    [InlineData("?publicAccessBlock", "NoSuchPublicAccessBlockConfiguration")]
     public async Task S3CompatibleBucketSubresource_WhenConfigAbsent_ReturnsNoSuchCodeWithNotFoundStatus(string query, string expectedCode)
     {
         // Regression test for #152: absent bucket subresource configs must surface the specific
@@ -10189,6 +10277,9 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         public ValueTask<StorageResult<BucketTaggingConfiguration>> GetBucketTaggingAsync(string bucketName, CancellationToken cancellationToken = default)
             => ValueTask.FromResult(StorageResult<BucketTaggingConfiguration>.Failure(NotFound(StorageErrorCode.TaggingConfigurationNotFound, bucketName)));
 
+        public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(StorageResult<BucketPublicAccessBlockConfiguration>.Failure(NotFound(StorageErrorCode.PublicAccessBlockConfigurationNotFound, bucketName)));
+
         public ValueTask<StorageResult<BucketWebsiteConfiguration>> GetBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = default)
             => ValueTask.FromResult(StorageResult<BucketWebsiteConfiguration>.Failure(NotFound(StorageErrorCode.WebsiteConfigurationNotFound, bucketName)));
 
@@ -10222,6 +10313,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         public ValueTask<StorageResult<BucketDefaultEncryptionConfiguration>> GetBucketDefaultEncryptionAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult<BucketDefaultEncryptionConfiguration>> PutBucketDefaultEncryptionAsync(PutBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult> DeleteBucketDefaultEncryptionAsync(DeleteBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw Boom();
+        public ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
         public ValueTask<StorageResult> DeleteBucketAsync(DeleteBucketRequest request, CancellationToken cancellationToken = default) => throw Boom();
         public IAsyncEnumerable<ObjectInfo> ListObjectsAsync(ListObjectsRequest request, CancellationToken cancellationToken = default) => throw Boom();
@@ -10317,6 +10410,12 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         public ValueTask<StorageResult<BucketDefaultEncryptionConfiguration>> PutBucketDefaultEncryptionAsync(PutBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default) => throw Boom();
 
         public ValueTask<StorageResult> DeleteBucketDefaultEncryptionAsync(DeleteBucketDefaultEncryptionRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw Boom();
+
+        public ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default) => throw Boom();
 
         public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw Boom();
 
@@ -10480,6 +10579,10 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         public DeleteBucketDefaultEncryptionRequest? LastDeleteBucketDefaultEncryptionRequest { get; private set; }
 
+        public PutBucketPublicAccessBlockRequest? LastPutBucketPublicAccessBlockRequest { get; private set; }
+
+        public DeleteBucketPublicAccessBlockRequest? LastDeleteBucketPublicAccessBlockRequest { get; private set; }
+
         public ObjectInfo? PutObjectResult { get; set; }
 
         public ObjectInfo? CopyObjectResult { get; set; }
@@ -10508,6 +10611,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         public MultipartUploadPart? UploadPartCopyResult { get; set; }
 
         private readonly Dictionary<string, BucketDefaultEncryptionConfiguration> _bucketDefaultEncryptions = new(StringComparer.Ordinal);
+
+        private readonly Dictionary<string, BucketPublicAccessBlockConfiguration> _bucketPublicAccessBlocks = new(StringComparer.Ordinal);
 
         public IAsyncEnumerable<BucketInfo> ListBucketsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
@@ -10552,6 +10657,39 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         {
             LastDeleteBucketDefaultEncryptionRequest = request;
             _bucketDefaultEncryptions.Remove(request.BucketName);
+            return ValueTask.FromResult(StorageResult.Success());
+        }
+
+        public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult(_bucketPublicAccessBlocks.TryGetValue(bucketName, out var configuration)
+                ? StorageResult<BucketPublicAccessBlockConfiguration>.Success(ClonePublicAccessBlock(bucketName, configuration))
+                : StorageResult<BucketPublicAccessBlockConfiguration>.Failure(CreatePublicAccessBlockNotFound(bucketName)));
+        }
+
+        public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> PutBucketPublicAccessBlockAsync(PutBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+        {
+            LastPutBucketPublicAccessBlockRequest = request;
+
+            var configuration = new BucketPublicAccessBlockConfiguration
+            {
+                BucketName = request.BucketName,
+                BlockPublicAcls = request.BlockPublicAcls,
+                IgnorePublicAcls = request.IgnorePublicAcls,
+                BlockPublicPolicy = request.BlockPublicPolicy,
+                RestrictPublicBuckets = request.RestrictPublicBuckets
+            };
+
+            _bucketPublicAccessBlocks[request.BucketName] = configuration;
+            return ValueTask.FromResult(StorageResult<BucketPublicAccessBlockConfiguration>.Success(ClonePublicAccessBlock(request.BucketName, configuration)));
+        }
+
+        public ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default)
+        {
+            LastDeleteBucketPublicAccessBlockRequest = request;
+            _bucketPublicAccessBlocks.Remove(request.BucketName);
             return ValueTask.FromResult(StorageResult.Success());
         }
 
@@ -10847,6 +10985,29 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
             {
                 Code = StorageErrorCode.BucketEncryptionConfigurationNotFound,
                 Message = $"Bucket '{bucketName}' does not have a default encryption configuration.",
+                BucketName = bucketName,
+                SuggestedHttpStatusCode = 404
+            };
+        }
+
+        private static BucketPublicAccessBlockConfiguration ClonePublicAccessBlock(string bucketName, BucketPublicAccessBlockConfiguration configuration)
+        {
+            return new BucketPublicAccessBlockConfiguration
+            {
+                BucketName = bucketName,
+                BlockPublicAcls = configuration.BlockPublicAcls,
+                IgnorePublicAcls = configuration.IgnorePublicAcls,
+                BlockPublicPolicy = configuration.BlockPublicPolicy,
+                RestrictPublicBuckets = configuration.RestrictPublicBuckets
+            };
+        }
+
+        private static StorageError CreatePublicAccessBlockNotFound(string bucketName)
+        {
+            return new StorageError
+            {
+                Code = StorageErrorCode.PublicAccessBlockConfigurationNotFound,
+                Message = $"Bucket '{bucketName}' does not have a public access block configuration.",
                 BucketName = bucketName,
                 SuggestedHttpStatusCode = 404
             };


### PR DESCRIPTION
## Summary

Implements the bucket `?publicAccessBlock` subresource, which previously had no route/handler and returned `501 NotImplemented`. Closes #154.

- **`PUT ?publicAccessBlock`** — accepts the `PublicAccessBlockConfiguration` XML (`BlockPublicAcls`/`IgnorePublicAcls`/`BlockPublicPolicy`/`RestrictPublicBuckets`), persisted per-bucket.
- **`GET ?publicAccessBlock`** — returns the stored config as XML, or `404 NoSuchPublicAccessBlockConfiguration` when never set.
- **`DELETE ?publicAccessBlock`** — removes the config, `204 No Content` (idempotent).

Follows the existing tagging/encryption subresource pattern across every layer.

## Changes
- **Validator**: added `publicAccessBlock` to `KnownBucketQueryParameters` and the GET/PUT/DELETE subresource allow-lists (extends the same list PR #205 touched for `intelligent-tiering`), so requests route instead of failing validation.
- **Endpoints**: `Get/Put/DeleteBucketPublicAccessBlockAsync` handlers — inbound XML via the hardened reader (`ReadPublicAccessBlockConfigurationAsync`), outbound XML via `WritePublicAccessBlockConfiguration` with the S3 xmlns; `MalformedXML` guard on PUT.
- **Error mapping**: `PublicAccessBlockConfigurationNotFound` → `404` + `NoSuchPublicAccessBlockConfiguration` in **both** endpoint switch maps (status + S3 error code).
- **Abstractions**: `IStorageService`/`IStorageBackend` methods (backend default → `501`), `BucketPublicAccessBlockConfiguration` model, `Put`/`Delete` request DTOs, `StorageErrorCode` value, and `StorageOperationType` values (appended for stable ordinals).
- **Core**: `OrchestratedStorageService` (with replica write-through) and `AuthorizingStorageService` forwarders; replica-repair fallback wiring in `StorageReplicaRepairService`.
- **Disk provider**: real per-bucket persistence in the `.integrateds3.bucket.json` metadata sidecar — DTO field + source-gen JSON registration, `ShouldPersistBucketMetadata` extended, and every `DiskBucketMetadata` copy-site updated to carry the new field.
- **S3 provider**: passthrough to the AWS SDK `Put/Get/DeletePublicAccessBlockAsync`.

## Tests
- `RecordingStorageService` round-trip (PUT → GET → DELETE → GET 404).
- Real disk-provider round-trip proving on-disk persistence (and pre-set GET → 404).
- New `?publicAccessBlock` row on the absent-config `NoSuch*` theory.

Fails-before / passes-after. Full suite green: **1177 passed, 0 failed**; build clean with 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
