### PR TITLE
fix: reject invalid PutBucketVersioning Status with IllegalVersioningConfigurationException (#160)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -2315,14 +2315,13 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
         var requestedStatus = requestBody.Status switch
         {
-            null or "" => BucketVersioningStatus.Disabled,
             "Enabled" => BucketVersioningStatus.Enabled,
             "Suspended" => BucketVersioningStatus.Suspended,
             _ => (BucketVersioningStatus?)null
         };
 
         if (requestedStatus is null) {
-            return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "Bucket versioning status must be 'Enabled' or 'Suspended'.", BuildObjectResource(bucketName, null), bucketName);
+            return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "IllegalVersioningConfigurationException", "The versioning configuration specified in the request is invalid. The Status element must be either 'Enabled' or 'Suspended'.", BuildObjectResource(bucketName, null), bucketName);
         }
 
         try {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -10140,6 +10140,71 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task PutBucketVersioning_WithAbsentStatus_ReturnsIllegalVersioningConfiguration()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/absent-status-versioning-bucket", content: null)).StatusCode);
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/absent-status-versioning-bucket?versioning")
+        {
+            Content = new StringContent("""
+<VersioningConfiguration>
+</VersioningConfiguration>
+""", Encoding.UTF8, "application/xml")
+        };
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("IllegalVersioningConfigurationException", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    [Fact]
+    public async Task PutBucketVersioning_WithEmptyStatus_ReturnsIllegalVersioningConfiguration()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/empty-status-versioning-bucket", content: null)).StatusCode);
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/empty-status-versioning-bucket?versioning")
+        {
+            Content = new StringContent("""
+<VersioningConfiguration>
+  <Status></Status>
+</VersioningConfiguration>
+""", Encoding.UTF8, "application/xml")
+        };
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("IllegalVersioningConfigurationException", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    [Fact]
+    public async Task PutBucketVersioning_WithInvalidStatus_ReturnsIllegalVersioningConfiguration()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/invalid-status-versioning-bucket", content: null)).StatusCode);
+
+        using var request = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/invalid-status-versioning-bucket?versioning")
+        {
+            Content = new StringContent("""
+<VersioningConfiguration>
+  <Status>Disabled</Status>
+</VersioningConfiguration>
+""", Encoding.UTF8, "application/xml")
+        };
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("IllegalVersioningConfigurationException", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    [Fact]
     public async Task GetBucketVersioning_ReturnsCurrentStatus()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary
`PutBucketVersioning` previously mapped an absent or empty `<Status>` element to `BucketVersioningStatus.Disabled` and **silently accepted** it as a no-op, and rejected unknown string values with the wrong error code (`InvalidArgument`).

Per AWS, the `<Status>` element must be exactly `Enabled` or `Suspended`. Anything else — missing, empty, or an invalid value such as `Disabled` — must return **`400 IllegalVersioningConfigurationException`**.

## Changes
- `IntegratedS3EndpointRouteBuilderExtensions.PutBucketVersioningAsync`: removed the `null or "" => Disabled` branch so all missing/empty/invalid statuses fall through to a 400 `IllegalVersioningConfigurationException` (previously `InvalidArgument`). Only `Enabled` / `Suspended` are accepted.

## Tests
Added three regression tests (fail before, pass after):
- absent `<Status>` → 400 `IllegalVersioningConfigurationException`
- empty `<Status></Status>` → 400 `IllegalVersioningConfigurationException`
- invalid `<Status>Disabled</Status>` → 400 `IllegalVersioningConfigurationException`

Existing `PutBucketVersioning_EnablesVersioning` / `_SuspendsVersioning` continue to pass. Full suite: **1192 passed, 0 failed**.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)