### PR TITLE
fix: make multipart checksum-algorithm set consistent (reject CRC64NVME up front) (#119)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -1992,11 +1992,7 @@ internal sealed class DiskStorageService(
 
         var uploadState = uploadStateResult.Value!;
         var uploadChecksumAlgorithm = uploadState.State.ChecksumAlgorithm;
-        if (!string.IsNullOrWhiteSpace(uploadChecksumAlgorithm)
-            && !string.Equals(uploadChecksumAlgorithm, Sha256ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Sha1ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)) {
+        if (!IsMultipartSupportedChecksumAlgorithm(uploadChecksumAlgorithm)) {
             throw new NotSupportedException(
                 $"Checksum algorithm '{uploadChecksumAlgorithm}' is not currently supported for multipart uploads.");
         }
@@ -2686,12 +2682,7 @@ internal sealed class DiskStorageService(
                 request.Key)));
         }
 
-        if (!string.IsNullOrWhiteSpace(checksumAlgorithm)
-            && !string.Equals(checksumAlgorithm, Sha256ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(checksumAlgorithm, Sha1ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(checksumAlgorithm, Crc32ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(checksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(checksumAlgorithm, Crc64NvmeChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)) {
+        if (!IsMultipartSupportedChecksumAlgorithm(checksumAlgorithm)) {
             return ValueTask.FromResult(StorageResult<MultipartUploadInfo>.Failure(StorageError.Unsupported(
                 $"Checksum algorithm '{request.ChecksumAlgorithm}' is not currently supported for multipart uploads.",
                 request.BucketName,
@@ -2738,11 +2729,7 @@ internal sealed class DiskStorageService(
 
         var uploadDirectoryPath = uploadStateResult.Value!.UploadDirectoryPath;
         var uploadChecksumAlgorithm = uploadStateResult.Value.State.ChecksumAlgorithm;
-        if (!string.IsNullOrWhiteSpace(uploadChecksumAlgorithm)
-            && !string.Equals(uploadChecksumAlgorithm, Sha256ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Sha1ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)) {
+        if (!IsMultipartSupportedChecksumAlgorithm(uploadChecksumAlgorithm)) {
             return StorageResult<MultipartUploadPart>.Failure(StorageError.Unsupported(
                 $"Checksum algorithm '{uploadChecksumAlgorithm}' is not currently supported for multipart uploads.",
                 request.BucketName,
@@ -2974,11 +2961,7 @@ internal sealed class DiskStorageService(
 
         var uploadDirectoryPath = uploadStateResult.Value!.UploadDirectoryPath;
         var uploadChecksumAlgorithm = uploadStateResult.Value.State.ChecksumAlgorithm;
-        if (!string.IsNullOrWhiteSpace(uploadChecksumAlgorithm)
-            && !string.Equals(uploadChecksumAlgorithm, Sha256ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Sha1ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)) {
+        if (!IsMultipartSupportedChecksumAlgorithm(uploadChecksumAlgorithm)) {
             return StorageResult<MultipartUploadPart>.Failure(StorageError.Unsupported(
                 $"Checksum algorithm '{uploadChecksumAlgorithm}' is not currently supported for multipart uploads.",
                 request.BucketName,
@@ -3116,11 +3099,7 @@ internal sealed class DiskStorageService(
 
         var uploadState = uploadStateResult.Value!;
         var uploadChecksumAlgorithm = uploadState.State.ChecksumAlgorithm;
-        if (!string.IsNullOrWhiteSpace(uploadChecksumAlgorithm)
-            && !string.Equals(uploadChecksumAlgorithm, Sha256ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Sha1ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(uploadChecksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)) {
+        if (!IsMultipartSupportedChecksumAlgorithm(uploadChecksumAlgorithm)) {
             return StorageResult<ObjectInfo>.Failure(StorageError.Unsupported(
                 $"Checksum algorithm '{uploadChecksumAlgorithm}' is not currently supported for multipart uploads.",
                 request.BucketName,
@@ -6054,6 +6033,24 @@ internal sealed class DiskStorageService(
 
         checksumAlgorithm = null;
         return false;
+    }
+
+    // Single source of truth for which checksum algorithms the multipart lifecycle can carry end-to-end.
+    // A blank algorithm is always allowed (no checksum requested). CRC64NVME is intentionally excluded:
+    // although it is a valid single-part checksum (accepted as pass-through), the multipart composite
+    // path (BuildCompositeChecksum) cannot synthesize it, so accepting it at initiate would leave the
+    // upload dead at UploadPart/Complete. All multipart lifecycle gates (initiate, upload part,
+    // upload-part-copy, complete, list parts) must use this helper so the accepted set cannot drift.
+    private static bool IsMultipartSupportedChecksumAlgorithm(string? checksumAlgorithm)
+    {
+        if (string.IsNullOrWhiteSpace(checksumAlgorithm)) {
+            return true;
+        }
+
+        return string.Equals(checksumAlgorithm, Sha256ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(checksumAlgorithm, Sha1ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(checksumAlgorithm, Crc32ChecksumAlgorithm, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(checksumAlgorithm, Crc32cChecksumAlgorithm, StringComparison.OrdinalIgnoreCase);
     }
 
     private static bool TryGetChecksumValue(IReadOnlyDictionary<string, string>? checksums, string? algorithm, out string value)

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -3155,6 +3155,32 @@ public sealed class DiskStorageServiceTests
         Assert.Equal(compositeChecksum, response.Object.Checksums!["crc32c"]);
     }
 
+    [Theory]
+    [InlineData("CRC64NVME")]
+    [InlineData("crc64nvme")]
+    public async Task DiskStorage_InitiateMultipartUpload_RejectsCrc64NvmeUpFront(string checksumAlgorithm)
+    {
+        // Regression for #119: CRC64NVME was accepted at InitiateMultipartUpload but rejected by every
+        // subsequent lifecycle operation, leaving the caller with an "accepted then dead" UploadId and a
+        // leaked on-disk upload directory. The accepted-algorithm set must be consistent across the whole
+        // lifecycle: because the multipart composite-checksum path cannot synthesize CRC64NVME, it must be
+        // rejected up front at initiate rather than accepted-then-dead.
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        await storageService.CreateBucketAsync(new CreateBucketRequest { BucketName = "multipart-crc64nvme" });
+
+        var initiateResult = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
+        {
+            BucketName = "multipart-crc64nvme",
+            Key = "docs/assembled.txt",
+            ContentType = "text/plain",
+            ChecksumAlgorithm = checksumAlgorithm
+        });
+
+        Assert.False(initiateResult.IsSuccess);
+        Assert.Equal(StorageErrorCode.UnsupportedCapability, initiateResult.Error!.Code);
+    }
+
     [Fact]
     public async Task DiskStorage_InitiateMultipartUpload_RejectsInvalidTagCharacters()
     {


### PR DESCRIPTION
## Summary

Fixes #119. `InitiateMultipartUploadCoreAsync` accepted `CRC64NVME` as a valid multipart checksum algorithm and persisted it into the upload state, but every subsequent lifecycle operation — `UploadMultipartPartAsync`, `UploadPartCopyAsync`, `CompleteMultipartUploadCoreAsync`, and `ListMultipartUploadPartsAsync` — rejected it with `UnsupportedCapability`, and `BuildCompositeChecksum` has no `crc64nvme` branch. A client that started a CRC64NVME multipart upload received a valid `UploadId` but could never upload a part or complete the upload ("accepted then dead"), and the on-disk upload directory leaked until an explicit `AbortMultipartUpload`.

## Fix

The multipart composite-checksum path genuinely cannot synthesize CRC64NVME (unlike the single-part path, where CRC64NVME is valid pass-through). Per the issue's smallest-correct guidance, CRC64NVME is now **rejected up front at `InitiateMultipartUpload`** so the accepted-algorithm set is consistent across the entire lifecycle — nothing is accepted at create but fatal later, and no orphaned upload directory is created.

To prevent future drift, the five inline allow-list checks (initiate, upload part, upload-part-copy, complete, list parts) are factored into a single `IsMultipartSupportedChecksumAlgorithm` helper that is the one source of truth for the accepted set. Only the initiate gate changed behavior (it previously whitelisted `crc64nvme`); the other four are semantically unchanged.

## Tests

Adds `DiskStorage_InitiateMultipartUpload_RejectsCrc64NvmeUpFront` (Theory, both `CRC64NVME`/`crc64nvme` casings) asserting `InitiateMultipartUpload` with CRC64NVME now fails immediately with `UnsupportedCapability`. Fails on old code (initiate used to succeed), passes now.

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — green, 0 warnings.
- `dotnet test IntegratedS3.Tests` — 1191 passed, 0 failed.

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
