### PR TITLE
Ship 5 GiB default upload cap and bound aws-chunked temp-file spooling (#115)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Versions match the `VersionPrefix` in `src/IntegratedS3/Directory.Build.props`, 
 - **Presigned `DELETE`, `HEAD`, and multipart `UploadPart` URLs** — presign issuance and validation now cover `DeleteObject`, `HeadObject`, and `UploadPart` in addition to `GetObject`/`PutObject`.
 - **Pluggable SigV4 credential resolution** — new `IIntegratedS3CredentialResolver` abstraction (with a configuration-backed default) so hosts can resolve access keys from external stores and rotate keys without a restart.
 - **Object Lock default-retention enforcement in the disk provider** — bucket default retention from the Object Lock configuration now blocks in-window permanent version deletes instead of being stored without effect.
-- **`MaxObjectSizeBytes` host option** — object upload endpoints (`PutObject`, `UploadPart`) replace the Kestrel per-request body-size limit so uploads beyond ~28.6 MiB no longer fail with `413`; configurable cap, unlimited by default up to the S3 5 GiB per-request maximum.
+- **`MaxObjectSizeBytes` host option** — object upload endpoints (`PutObject`, `UploadPart`) replace the Kestrel per-request body-size limit so uploads beyond ~28.6 MiB no longer fail with `413`; configurable cap that now **defaults to 5 GiB** (the S3 per-request maximum) instead of being unbounded. Set it to `null` to opt out of the application-level limit.
 - **Scheduled maintenance: abandoned multipart upload expiry** — the maintenance job set can expire and abort stale multipart uploads.
 - **Replica repair divergence kinds and orphan reconciliation** — repair entries now describe content/metadata/version divergence explicitly, and reconciliation can garbage-collect orphaned provider-side artifacts.
 - **Code coverage in CI plus Dependabot** — CI collects and publishes coverage reports; Dependabot keeps NuGet and GitHub Actions dependencies current.
@@ -27,6 +27,10 @@ Versions match the `VersionPrefix` in `src/IntegratedS3/Directory.Build.props`, 
 - **CI consolidated into a single workflow** — one `ci.yml` (build/test matrix, AOT validation, pack) with concurrency cancellation and NuGet caching; the legacy track-specific workflow was removed.
 - **Publishing is traceable** — the NuGet publish workflow tags the release commit (`v{version}`) and creates a GitHub Release with the packed artifacts after a successful push.
 - **README claims qualified** — feature bullets now state per-provider limits (SSE, retention/legal hold, config-only bucket subresources) instead of implying uniform support.
+
+### Security
+
+- **Bounded upload size and aws-chunked temp spooling (disk-exhaustion DoS)** — `MaxObjectSizeBytes` now defaults to 5 GiB instead of `null`, so object uploads have an application-level cap out of the box. The `Content-Encoding: aws-chunked` decode path additionally enforces this cap while spooling to a temp file — rejecting a decoded body that exceeds the cap (or whose `x-amz-decoded-content-length` already declares an oversize) with `413 EntityTooLarge` — instead of writing an unbounded stream of client-controlled data to the temp volume.
 
 ### Fixed
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,8 +78,9 @@ The most important configuration types are:
 
 ASP.NET Core hosts cap request bodies at the server default (Kestrel rejects bodies over 30,000,000 bytes, roughly 28.6 MiB) unless configured otherwise, which would fail larger `PutObject` and `UploadPart` payloads with `413 Payload Too Large` before the endpoint runs. The object upload endpoints therefore replace the host's per-request body-size limit with `IntegratedS3Options.MaxObjectSizeBytes` before the body is read:
 
-- Leave `MaxObjectSizeBytes` at its default (`null`) to remove the limit on `PutObject` and `UploadPart`, so uploads up to the S3 maximum of 5 GiB per request succeed without host tuning.
-- Set an explicit byte count (for example `5368709120` for 5 GiB) to cap upload sizes; larger requests are rejected with `413 Payload Too Large`.
+- Leave `MaxObjectSizeBytes` at its default (`5368709120`, the S3 5 GiB per-request maximum) so uploads up to that size succeed without host tuning, while still rejecting anything larger with `413 EntityTooLarge`. This default also bounds the temporary spool file written while decoding `Content-Encoding: aws-chunked` bodies, so a client cannot exhaust the temp volume by streaming an unbounded body.
+- Set a smaller explicit byte count (for example `104857600` for 100 MiB) to tighten the cap; larger requests are rejected with `413 EntityTooLarge`.
+- Set `MaxObjectSizeBytes` to `null` to fully remove the application-level limit on `PutObject` and `UploadPart` (uploads are then bounded only by the host's own limit, if any). This is discouraged because it re-enables the aws-chunked disk-exhaustion risk.
 - All other endpoints keep the host-configured limit, so lifting it for uploads does not loosen the rest of the surface.
 
 The override only applies where the server exposes a mutable per-request limit (Kestrel and IIS in-process do). If a reverse proxy such as nginx or IIS ARR sits in front of the host, raise its request body limit as well or large uploads will still be rejected upstream.

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -7128,8 +7128,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     /// <summary>
     /// Replaces the host's per-request body-size limit (for example Kestrel's default of
     /// ~28.6 MiB) with <see cref="IntegratedS3Options.MaxObjectSizeBytes"/> on object upload
-    /// requests. Must run before the request body is read; once reading starts the limit
-    /// becomes read-only and the override is skipped.
+    /// requests. That option defaults to 5 GiB (the S3 per-request maximum), so the limit is
+    /// bounded by default; a <see langword="null"/> value removes the limit for these endpoints.
+    /// Must run before the request body is read; once reading starts the limit becomes read-only
+    /// and the override is skipped.
     /// </summary>
     private static void ApplyObjectUploadBodySizeLimit(HttpContext httpContext)
     {
@@ -7157,6 +7159,21 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             return new PreparedRequestBody(request.Body, request.ContentLength, tempFilePath: null, trailerHeaders: null, trailerHeaderEntries: null, finalChunkSignature: null);
         }
 
+        // Bound the decoded body that gets spooled to a temp file by the configured upload cap.
+        // Without this, a client can stream non-terminating aws-chunked frames and fill the temp
+        // volume (disk-exhaustion DoS) because the temp write happens before any size is consulted.
+        var maxDecodedBytes = request.HttpContext.RequestServices
+            .GetRequiredService<IOptions<IntegratedS3Options>>().Value.MaxObjectSizeBytes;
+
+        // Reject up front when the client's own declared decoded length already exceeds the cap,
+        // so an oversized upload fails before a single byte is written to disk.
+        var declaredDecodedLength = TryParseDecodedContentLength(request.Headers["x-amz-decoded-content-length"].ToString());
+        if (maxDecodedBytes is { } declaredCap && declaredDecodedLength is { } declared && declared > declaredCap) {
+            throw new BadHttpRequestException(
+                "Your proposed upload exceeds the maximum allowed object size.",
+                StatusCodes.Status413PayloadTooLarge);
+        }
+
         var tempFilePath = Path.Combine(Path.GetTempPath(), $"integrateds3-aws-chunked-{Guid.NewGuid():N}.tmp");
         var trailerHeaders = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         var trailerHeaderEntries = new List<KeyValuePair<string, string>>();
@@ -7168,13 +7185,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? finalChunkSignature = null;
         try {
             await using (var tempWriteStream = new FileStream(tempFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan)) {
-                finalChunkSignature = await CopyAwsChunkedContentToAsync(request.Body, tempWriteStream, trailerHeaders, trailerHeaderEntries, chunkSignatureVerifier, cancellationToken);
+                finalChunkSignature = await CopyAwsChunkedContentToAsync(request.Body, tempWriteStream, trailerHeaders, trailerHeaderEntries, chunkSignatureVerifier, maxDecodedBytes, cancellationToken);
                 await tempWriteStream.FlushAsync(cancellationToken);
             }
 
-            var decodedLength = TryParseDecodedContentLength(request.Headers["x-amz-decoded-content-length"].ToString());
             var tempReadStream = new FileStream(tempFilePath, FileMode.Open, FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
-            var contentLength = decodedLength ?? tempReadStream.Length;
+            var contentLength = declaredDecodedLength ?? tempReadStream.Length;
             return new PreparedRequestBody(tempReadStream, contentLength, tempFilePath, trailerHeaders, trailerHeaderEntries, finalChunkSignature);
         }
         catch {
@@ -7280,8 +7296,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         Dictionary<string, string> trailerHeaders,
         List<KeyValuePair<string, string>> trailerHeaderEntries,
         AwsChunkedChunkSignatureVerifier? chunkSignatureVerifier,
+        long? maxDecodedBytes,
         CancellationToken cancellationToken)
     {
+        var totalDecodedBytes = 0L;
         while (true) {
             var chunkHeader = await ReadLineAsync(source, cancellationToken)
                 ?? throw new FormatException("The aws-chunked request body ended unexpectedly.");
@@ -7289,6 +7307,17 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             var chunkLengthText = (separatorIndex >= 0 ? chunkHeader[..separatorIndex] : chunkHeader).Trim();
             if (!long.TryParse(chunkLengthText, NumberStyles.HexNumber, CultureInfo.InvariantCulture, out var chunkLength) || chunkLength < 0) {
                 throw new FormatException("The aws-chunked request body contains an invalid chunk length.");
+            }
+
+            // Enforce the decoded-size cap before spooling the chunk so a client cannot exhaust the
+            // temp volume by streaming unbounded (or non-terminating) chunk frames.
+            if (chunkLength > 0 && maxDecodedBytes is { } cap) {
+                totalDecodedBytes += chunkLength;
+                if (totalDecodedBytes > cap) {
+                    throw new BadHttpRequestException(
+                        "Your proposed upload exceeds the maximum allowed object size.",
+                        StatusCodes.Status413PayloadTooLarge);
+                }
             }
 
             if (chunkLength == 0) {

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/IntegratedS3Options.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/IntegratedS3Options.cs
@@ -58,17 +58,29 @@ public sealed class IntegratedS3Options
     public int MaximumPresignedUrlExpirySeconds { get; set; } = 60 * 60;
 
     /// <summary>
+    /// The S3 per-request maximum object size (5 GiB), used as the default value of
+    /// <see cref="MaxObjectSizeBytes"/>.
+    /// </summary>
+    public const long DefaultMaxObjectSizeBytes = 5L * 1024 * 1024 * 1024;
+
+    /// <summary>
     /// Maximum request-body size in bytes accepted by object upload endpoints
-    /// (<c>PutObject</c> and <c>UploadPart</c>). Defaults to <see langword="null"/>.
+    /// (<c>PutObject</c> and <c>UploadPart</c>). Defaults to
+    /// <see cref="DefaultMaxObjectSizeBytes"/> (5 GiB, the S3 per-request maximum).
     /// </summary>
     /// <remarks>
     /// The object upload endpoints override the host's per-request body-size limit
-    /// (for example Kestrel's default of ~28.6 MiB) with this value before the body is read.
-    /// <see langword="null"/> removes the limit for those endpoints so uploads up to the
-    /// S3 maximum of 5 GiB per request succeed; set an explicit value to cap upload sizes.
-    /// Other endpoints keep the host-configured limit.
+    /// (for example Kestrel's default of ~28.6 MiB) with this value before the body is read,
+    /// so legitimate uploads up to the S3 maximum of 5 GiB per request succeed without host tuning.
+    /// The same cap independently bounds the temporary spool file written while decoding
+    /// <c>Content-Encoding: aws-chunked</c> bodies: a request whose decoded size exceeds the cap is
+    /// rejected with <c>413 EntityTooLarge</c> instead of being written unbounded to disk.
+    /// Set a smaller explicit value to tighten the cap. Setting it to <see langword="null"/>
+    /// removes the application-level limit for these endpoints (uploads are then bounded only by the
+    /// host's own limit, if any); this is discouraged because it re-enables the disk-exhaustion risk
+    /// on the aws-chunked path. Other endpoints keep the host-configured limit.
     /// </remarks>
-    public long? MaxObjectSizeBytes { get; set; }
+    public long? MaxObjectSizeBytes { get; set; } = DefaultMaxObjectSizeBytes;
 
     /// <summary>
     /// List of access key / secret key pairs for SigV4 authentication.

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -5878,6 +5878,113 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public void IntegratedS3Options_MaxObjectSizeBytes_DefaultsToFiveGibibytes()
+    {
+        // Regression for the disk-exhaustion DoS: the shipped default must be a finite, non-null cap
+        // so object uploads (and aws-chunked temp-file spooling) are bounded out of the box.
+        Assert.Equal(5L * 1024 * 1024 * 1024, new IntegratedS3Options().MaxObjectSizeBytes);
+    }
+
+    [Fact]
+    public async Task PutObject_AwsChunkedBodyExceedingMaxObjectSizeBytes_ReturnsEntityTooLarge()
+    {
+        // Regression for the aws-chunked disk-exhaustion DoS: an actual chunk stream whose decoded size
+        // exceeds the cap must be rejected mid-spool with 413 EntityTooLarge even when the client
+        // understates x-amz-decoded-content-length, instead of being written unbounded to the temp volume.
+        await using var isolatedClient = await _factory.CreateIsolatedClientAsync(builder =>
+            builder.Services.Configure<IntegratedS3Options>(static options => options.MaxObjectSizeBytes = 1024));
+        using var client = isolatedClient.Client;
+
+        const string bucketName = "aws-chunked-oversized-body-bucket";
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // 4096 decoded bytes across chunk frames (> 1024 cap), but the header lies and declares only 8 bytes
+        // so the up-front declared-length check does not fire; the cumulative-byte cap in the spool loop must.
+        using var body = new MemoryStream();
+        WriteAscii(body, "800\r\n"); // 0x800 = 2048 bytes
+        body.Write(new byte[2048], 0, 2048);
+        WriteAscii(body, "\r\n800\r\n"); // another 2048 bytes
+        body.Write(new byte[2048], 0, 2048);
+        WriteAscii(body, "\r\n0\r\n\r\n");
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/docs/oversized.txt")
+        {
+            Content = new ByteArrayContent(body.ToArray())
+        };
+        putRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        putRequest.Content.Headers.ContentEncoding.Add("aws-chunked");
+        putRequest.Headers.TryAddWithoutValidation("x-amz-decoded-content-length", "8");
+        putRequest.Headers.TryAddWithoutValidation("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+
+        var response = await client.SendAsync(putRequest);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("EntityTooLarge", GetRequiredElementValue(document, "Code"));
+    }
+
+    [Fact]
+    public async Task PutObject_AwsChunkedDeclaredDecodedLengthExceedingCap_ReturnsEntityTooLargeBeforeSpooling()
+    {
+        // The declared x-amz-decoded-content-length is checked before any byte is written to disk, so an
+        // oversized upload is rejected up front.
+        await using var isolatedClient = await _factory.CreateIsolatedClientAsync(builder =>
+            builder.Services.Configure<IntegratedS3Options>(static options => options.MaxObjectSizeBytes = 1024));
+        using var client = isolatedClient.Client;
+
+        const string bucketName = "aws-chunked-declared-oversized-bucket";
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/docs/declared-oversized.txt")
+        {
+            Content = new ByteArrayContent(Encoding.ASCII.GetBytes("4\r\ndata\r\n0\r\n\r\n"))
+        };
+        putRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        putRequest.Content.Headers.ContentEncoding.Add("aws-chunked");
+        putRequest.Headers.TryAddWithoutValidation("x-amz-decoded-content-length", "1048576"); // 1 MiB > 1024 cap
+        putRequest.Headers.TryAddWithoutValidation("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+
+        var response = await client.SendAsync(putRequest);
+
+        Assert.Equal(HttpStatusCode.RequestEntityTooLarge, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("EntityTooLarge", GetRequiredElementValue(document, "Code"));
+    }
+
+    [Fact]
+    public async Task PutObject_AwsChunkedBodyWithinMaxObjectSizeBytes_Succeeds()
+    {
+        // A body within the configured cap still uploads normally, proving the cap does not over-reject.
+        await using var isolatedClient = await _factory.CreateIsolatedClientAsync(builder =>
+            builder.Services.Configure<IntegratedS3Options>(static options => options.MaxObjectSizeBytes = 1024));
+        using var client = isolatedClient.Client;
+
+        const string bucketName = "aws-chunked-within-cap-bucket";
+        const string objectKey = "docs/within-cap.txt";
+        const string payload = "hello from aws chunked within cap";
+        var checksum = ComputeSha256Base64(payload);
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var putRequest = CreateAwsChunkedPutObjectRequest(
+            $"/integrated-s3/{bucketName}/{objectKey}",
+            payload,
+            sdkChecksumAlgorithm: "SHA256",
+            trailerHeaders: new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["x-amz-checksum-sha256"] = checksum
+            },
+            declaredTrailerHeaderNames: ["x-amz-checksum-sha256"]);
+        putRequest.Headers.TryAddWithoutValidation("x-amz-content-sha256", "STREAMING-UNSIGNED-PAYLOAD-TRAILER");
+
+        var putResponse = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal(payload, await getResponse.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
     public async Task S3CompatiblePutObjectRetentionAndLegalHold_RouteAndEmitVersionHeaders()
     {
         var storageService = new RecordingStorageService();


### PR DESCRIPTION
## Summary

Fixes the disk-exhaustion DoS described in #115.

Object upload endpoints (`PutObject`, `UploadPart`) shipped with `MaxObjectSizeBytes = null`, which explicitly **removed** the host's per-request body-size limit, and the `Content-Encoding: aws-chunked` decode path spooled the decoded body to a temp file under `Path.GetTempPath()` with no size ceiling of its own. A single request could stream unbounded attacker-controlled data onto the temp volume before the storage backend was ever invoked.

## Changes

- **Non-null default cap:** `IntegratedS3Options.MaxObjectSizeBytes` now defaults to `5368709120` (5 GiB, the S3 per-request maximum) instead of `null`. Still configurable; setting it to `null` opts out of the application-level limit (documented as discouraged). This makes the plain upload path return `413` via Kestrel's own limit out of the box.
- **Bounded aws-chunked spooling:** `PrepareRequestBodyAsync` now
  - rejects up front when `x-amz-decoded-content-length` already declares a size over the cap (before any byte hits disk), and
  - tracks cumulative decoded bytes in `CopyAwsChunkedContentToAsync` and aborts with `413 EntityTooLarge` the moment the decoded stream would exceed the cap — even when the client understates the declared length or streams non-terminating chunks.
  Both surface as a well-formed S3 `<Error>` with `Code=EntityTooLarge` via the existing `BadHttpRequestException(413)` mapping.
- **Docs/changelog:** updated `docs/getting-started.md`, the `MaxObjectSizeBytes` XML docs, and `CHANGELOG.md` (new Security entry).

## Tests

Added regression tests (fail-before / pass-after):
- `IntegratedS3Options_MaxObjectSizeBytes_DefaultsToFiveGibibytes` — default is 5 GiB, not null.
- `PutObject_AwsChunkedBodyExceedingMaxObjectSizeBytes_ReturnsEntityTooLarge` — an actual chunk stream over the cap (with an understated declared length) → `413 EntityTooLarge`.
- `PutObject_AwsChunkedDeclaredDecodedLengthExceedingCap_ReturnsEntityTooLargeBeforeSpooling` — oversized declared length rejected up front.
- `PutObject_AwsChunkedBodyWithinMaxObjectSizeBytes_Succeeds` — within-cap upload still succeeds.

Full suite green: `dotnet build` (0 warnings) and `dotnet test` (1193 passed, 0 failed).

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)