### PR TITLE
Route Object Lock replica repairs to re-apply lock state instead of re-PUTting the body (#108)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
@@ -3161,44 +3161,6 @@ internal sealed class OrchestratedStorageService(
         return null;
     }
 
-    private async ValueTask<StorageError?> RepairReplicaObjectRetentionFromPrimaryAsync(
-        IStorageBackend primaryBackend,
-        IStorageBackend replicaBackend,
-        string bucketName,
-        string key,
-        string? requestedVersionId,
-        CancellationToken cancellationToken)
-    {
-        var primaryResult = await primaryBackend.GetObjectRetentionAsync(new GetObjectRetentionRequest
-        {
-            BucketName = bucketName,
-            Key = key,
-            VersionId = requestedVersionId
-        }, cancellationToken);
-        ObserveResult(primaryBackend, primaryResult);
-        if (!primaryResult.IsSuccess || primaryResult.Value is null) {
-            if (primaryResult.Error?.Code is StorageErrorCode.ObjectNotFound or StorageErrorCode.BucketNotFound) {
-                return await WriteReplicaDeleteObjectAsync(replicaBackend, new DeleteObjectRequest
-                {
-                    BucketName = bucketName,
-                    Key = key,
-                    VersionId = requestedVersionId
-                }, cancellationToken);
-            }
-
-            return primaryResult.Error ?? CreatePrimaryReplicationSourceError(primaryBackend, bucketName, key, requestedVersionId, "Primary object retention could not be resolved for replica repair.");
-        }
-
-        return await WriteReplicaPutObjectRetentionAsync(replicaBackend, new PutObjectRetentionRequest
-        {
-            BucketName = bucketName,
-            Key = key,
-            VersionId = requestedVersionId,
-            Mode = primaryResult.Value.Mode,
-            RetainUntilDateUtc = primaryResult.Value.RetainUntilDateUtc
-        }, cancellationToken);
-    }
-
     // ── Object Legal Hold replication helpers ────────────────────────────
 
     private async ValueTask<StorageError?> WriteReplicaPutObjectLegalHoldAsync(IStorageBackend replicaBackend, PutObjectLegalHoldRequest request, CancellationToken cancellationToken)
@@ -3210,43 +3172,6 @@ internal sealed class OrchestratedStorageService(
         }
 
         return null;
-    }
-
-    private async ValueTask<StorageError?> RepairReplicaObjectLegalHoldFromPrimaryAsync(
-        IStorageBackend primaryBackend,
-        IStorageBackend replicaBackend,
-        string bucketName,
-        string key,
-        string? requestedVersionId,
-        CancellationToken cancellationToken)
-    {
-        var primaryResult = await primaryBackend.GetObjectLegalHoldAsync(new GetObjectLegalHoldRequest
-        {
-            BucketName = bucketName,
-            Key = key,
-            VersionId = requestedVersionId
-        }, cancellationToken);
-        ObserveResult(primaryBackend, primaryResult);
-        if (!primaryResult.IsSuccess || primaryResult.Value is null) {
-            if (primaryResult.Error?.Code is StorageErrorCode.ObjectNotFound or StorageErrorCode.BucketNotFound) {
-                return await WriteReplicaDeleteObjectAsync(replicaBackend, new DeleteObjectRequest
-                {
-                    BucketName = bucketName,
-                    Key = key,
-                    VersionId = requestedVersionId
-                }, cancellationToken);
-            }
-
-            return primaryResult.Error ?? CreatePrimaryReplicationSourceError(primaryBackend, bucketName, key, requestedVersionId, "Primary object legal hold could not be resolved for replica repair.");
-        }
-
-        return await WriteReplicaPutObjectLegalHoldAsync(replicaBackend, new PutObjectLegalHoldRequest
-        {
-            BucketName = bucketName,
-            Key = key,
-            VersionId = requestedVersionId,
-            Status = primaryResult.Value.Status ?? ObjectLegalHoldStatus.Off
-        }, cancellationToken);
     }
 
     private async ValueTask<StorageResult<GetObjectResponse>> GetObjectForReplicationAsync(

--- a/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
@@ -58,9 +58,12 @@ internal sealed class StorageReplicaRepairService(
                     Key = entry.ObjectKey,
                     VersionId = entry.VersionId
                 }, cancellationToken),
-            StorageOperationType.PutObjectRetention or StorageOperationType.PutObjectLegalHold => string.IsNullOrWhiteSpace(entry.ObjectKey)
+            StorageOperationType.PutObjectRetention => string.IsNullOrWhiteSpace(entry.ObjectKey)
                 ? CreateInvalidRepairTargetError(entry, "Object retention/legal-hold repairs require an object key.")
-                : await RepairReplicaObjectFromPrimaryAsync(primaryBackend, replicaBackend, entry.BucketName, entry.ObjectKey, entry.VersionId, cancellationToken),
+                : await RepairReplicaObjectRetentionFromPrimaryAsync(primaryBackend, replicaBackend, entry.BucketName, entry.ObjectKey, entry.VersionId, cancellationToken),
+            StorageOperationType.PutObjectLegalHold => string.IsNullOrWhiteSpace(entry.ObjectKey)
+                ? CreateInvalidRepairTargetError(entry, "Object retention/legal-hold repairs require an object key.")
+                : await RepairReplicaObjectLegalHoldFromPrimaryAsync(primaryBackend, replicaBackend, entry.BucketName, entry.ObjectKey, entry.VersionId, cancellationToken),
             _ => CreateUnsupportedRepairError(entry)
         };
     }
@@ -346,6 +349,83 @@ internal sealed class StorageReplicaRepairService(
         }
 
         await RefreshCatalogObjectAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+        return null;
+    }
+
+    private async ValueTask<StorageError?> RepairReplicaObjectRetentionFromPrimaryAsync(
+        IStorageBackend primaryBackend,
+        IStorageBackend replicaBackend,
+        string bucketName,
+        string key,
+        string? requestedVersionId,
+        CancellationToken cancellationToken)
+    {
+        var primaryResult = await primaryBackend.GetObjectRetentionAsync(new GetObjectRetentionRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = requestedVersionId
+        }, cancellationToken);
+        ObserveResult(primaryBackend, primaryResult);
+        if (!primaryResult.IsSuccess || primaryResult.Value is null) {
+            if (primaryResult.Error?.Code is StorageErrorCode.ObjectNotFound or StorageErrorCode.BucketNotFound) {
+                return await ReconcileReplicaObjectDeletionAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+            }
+
+            return primaryResult.Error ?? CreatePrimaryReplicationSourceError(primaryBackend, bucketName, key, requestedVersionId, "Primary object retention could not be resolved for replica repair.");
+        }
+
+        var replicaResult = await replicaBackend.PutObjectRetentionAsync(new PutObjectRetentionRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = requestedVersionId,
+            Mode = primaryResult.Value.Mode,
+            RetainUntilDateUtc = primaryResult.Value.RetainUntilDateUtc
+        }, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, bucketName, key, requestedVersionId, "Replica object retention repair did not return retention metadata.");
+        }
+
+        return null;
+    }
+
+    private async ValueTask<StorageError?> RepairReplicaObjectLegalHoldFromPrimaryAsync(
+        IStorageBackend primaryBackend,
+        IStorageBackend replicaBackend,
+        string bucketName,
+        string key,
+        string? requestedVersionId,
+        CancellationToken cancellationToken)
+    {
+        var primaryResult = await primaryBackend.GetObjectLegalHoldAsync(new GetObjectLegalHoldRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = requestedVersionId
+        }, cancellationToken);
+        ObserveResult(primaryBackend, primaryResult);
+        if (!primaryResult.IsSuccess || primaryResult.Value is null) {
+            if (primaryResult.Error?.Code is StorageErrorCode.ObjectNotFound or StorageErrorCode.BucketNotFound) {
+                return await ReconcileReplicaObjectDeletionAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+            }
+
+            return primaryResult.Error ?? CreatePrimaryReplicationSourceError(primaryBackend, bucketName, key, requestedVersionId, "Primary object legal hold could not be resolved for replica repair.");
+        }
+
+        var replicaResult = await replicaBackend.PutObjectLegalHoldAsync(new PutObjectLegalHoldRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = requestedVersionId,
+            Status = primaryResult.Value.Status ?? ObjectLegalHoldStatus.Off
+        }, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, bucketName, key, requestedVersionId, "Replica object legal hold repair did not return legal hold metadata.");
+        }
+
         return null;
     }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/StorageReplicaRepairObjectLockTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/StorageReplicaRepairObjectLockTests.cs
@@ -1,0 +1,276 @@
+using IntegratedS3.Abstractions.Capabilities;
+using IntegratedS3.Abstractions.Errors;
+using IntegratedS3.Abstractions.Models;
+using IntegratedS3.Abstractions.Requests;
+using IntegratedS3.Abstractions.Responses;
+using IntegratedS3.Abstractions.Results;
+using IntegratedS3.Abstractions.Services;
+using IntegratedS3.Core.Models;
+using IntegratedS3.Core.Options;
+using IntegratedS3.Core.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression tests for issue #108: a retention / legal-hold (Object Lock) divergence must be
+/// repaired by re-applying the lock state to the replica (PutObjectRetention / PutObjectLegalHold),
+/// not by re-PUTting the object body. The old code routed both operations to a body-only re-PUT,
+/// so the WORM state was never written to the replica while the repair reported success.
+/// </summary>
+public sealed class StorageReplicaRepairObjectLockTests
+{
+    private const string PrimaryName = "primary";
+    private const string ReplicaName = "replica";
+    private const string Bucket = "compliance-bucket";
+    private const string Key = "locked-object";
+
+    [Fact]
+    public async Task RepairAsync_RetentionDivergence_ReAppliesRetentionOnReplica_WithoutBodyRePut()
+    {
+        var retainUntil = new DateTimeOffset(2030, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        var primary = new RecordingLockBackend(PrimaryName, isPrimary: true)
+        {
+            Retention = new ObjectRetentionInfo
+            {
+                BucketName = Bucket,
+                Key = Key,
+                Mode = ObjectRetentionMode.Compliance,
+                RetainUntilDateUtc = retainUntil
+            }
+        };
+        var replica = new RecordingLockBackend(ReplicaName);
+
+        var service = CreateService(primary, replica);
+
+        var error = await service.RepairAsync(CreateEntry(StorageOperationType.PutObjectRetention));
+
+        Assert.Null(error);
+
+        // The lock state must have been re-applied on the replica…
+        Assert.NotNull(replica.LastRetentionApplied);
+        Assert.Equal(ObjectRetentionMode.Compliance, replica.LastRetentionApplied!.Mode);
+        Assert.Equal(retainUntil, replica.LastRetentionApplied.RetainUntilDateUtc);
+
+        // …and the object body must NOT have been re-PUT to the replica.
+        Assert.Equal(0, replica.PutObjectCallCount);
+        Assert.Equal(0, primary.GetObjectCallCount);
+    }
+
+    [Fact]
+    public async Task RepairAsync_LegalHoldDivergence_ReAppliesLegalHoldOnReplica_WithoutBodyRePut()
+    {
+        var primary = new RecordingLockBackend(PrimaryName, isPrimary: true)
+        {
+            LegalHold = new ObjectLegalHoldInfo
+            {
+                BucketName = Bucket,
+                Key = Key,
+                Status = ObjectLegalHoldStatus.On
+            }
+        };
+        var replica = new RecordingLockBackend(ReplicaName);
+
+        var service = CreateService(primary, replica);
+
+        var error = await service.RepairAsync(CreateEntry(StorageOperationType.PutObjectLegalHold));
+
+        Assert.Null(error);
+
+        Assert.NotNull(replica.LastLegalHoldApplied);
+        Assert.Equal(ObjectLegalHoldStatus.On, replica.LastLegalHoldApplied!.Status);
+
+        Assert.Equal(0, replica.PutObjectCallCount);
+        Assert.Equal(0, primary.GetObjectCallCount);
+    }
+
+    private static StorageReplicaRepairService CreateService(RecordingLockBackend primary, RecordingLockBackend replica)
+    {
+        var options = Options.Create(new IntegratedS3CoreOptions());
+        var evaluator = new AlwaysHealthyEvaluator();
+        var probe = new AlwaysHealthyProbe();
+        var monitor = new StorageBackendHealthMonitor(
+            evaluator,
+            probe,
+            options,
+            TimeProvider.System,
+            NullLogger<StorageBackendHealthMonitor>.Instance);
+
+        return new StorageReplicaRepairService(new IStorageBackend[] { primary, replica }, new NoOpCatalogStore(), monitor);
+    }
+
+    private static StorageReplicaRepairEntry CreateEntry(StorageOperationType operation) => new()
+    {
+        Id = "repair-108",
+        Origin = StorageReplicaRepairOrigin.AsyncReplication,
+        Status = StorageReplicaRepairStatus.Pending,
+        Operation = operation,
+        PrimaryBackendName = PrimaryName,
+        ReplicaBackendName = ReplicaName,
+        BucketName = Bucket,
+        ObjectKey = Key,
+        CreatedAtUtc = DateTimeOffset.UnixEpoch,
+        UpdatedAtUtc = DateTimeOffset.UnixEpoch
+    };
+
+    private sealed class AlwaysHealthyEvaluator : IStorageBackendHealthEvaluator
+    {
+        public ValueTask<StorageBackendHealthStatus> GetStatusAsync(IStorageBackend backend, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(StorageBackendHealthStatus.Healthy);
+    }
+
+    private sealed class AlwaysHealthyProbe : IStorageBackendHealthProbe
+    {
+        public ValueTask<StorageBackendHealthStatus> ProbeAsync(IStorageBackend backend, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(StorageBackendHealthStatus.Healthy);
+    }
+
+    private sealed class NoOpCatalogStore : IStorageCatalogStore
+    {
+        public ValueTask UpsertBucketAsync(string providerName, BucketInfo bucket, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask RemoveBucketAsync(string providerName, string bucketName, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask<IReadOnlyList<StoredBucketEntry>> ListBucketsAsync(string? providerName = null, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyList<StoredBucketEntry>>([]);
+
+        public ValueTask UpsertObjectAsync(string providerName, ObjectInfo @object, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask RemoveObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
+
+        public ValueTask<StoredObjectEntry?> GetObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<StoredObjectEntry?>(null);
+
+        public ValueTask<IReadOnlyList<StoredObjectEntry>> ListObjectsAsync(string? providerName = null, string? bucketName = null, string? keyPrefix = null, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<IReadOnlyList<StoredObjectEntry>>([]);
+    }
+
+    /// <summary>
+    /// A backend that records Object Lock re-applications and any object body re-PUT / body fetch,
+    /// so a test can distinguish a lock repair from a wasteful body re-PUT.
+    /// </summary>
+    private sealed class RecordingLockBackend(string name, bool isPrimary = false) : IStorageBackend
+    {
+        public string Name => name;
+
+        public string Kind => "test-lock";
+
+        public bool IsPrimary => isPrimary;
+
+        public string? Description => $"Recording lock backend '{name}'.";
+
+        public ObjectRetentionInfo? Retention { get; set; }
+
+        public ObjectLegalHoldInfo? LegalHold { get; set; }
+
+        public PutObjectRetentionRequest? LastRetentionApplied { get; private set; }
+
+        public PutObjectLegalHoldRequest? LastLegalHoldApplied { get; private set; }
+
+        public int PutObjectCallCount { get; private set; }
+
+        public int GetObjectCallCount { get; private set; }
+
+        public ValueTask<StorageResult<ObjectRetentionInfo>> GetObjectRetentionAsync(GetObjectRetentionRequest request, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(Retention is null
+                ? StorageResult<ObjectRetentionInfo>.Failure(new StorageError { Code = StorageErrorCode.ObjectNotFound, Message = "no retention", BucketName = request.BucketName, ObjectKey = request.Key })
+                : StorageResult<ObjectRetentionInfo>.Success(Retention));
+
+        public ValueTask<StorageResult<ObjectLegalHoldInfo>> GetObjectLegalHoldAsync(GetObjectLegalHoldRequest request, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(LegalHold is null
+                ? StorageResult<ObjectLegalHoldInfo>.Failure(new StorageError { Code = StorageErrorCode.ObjectNotFound, Message = "no legal hold", BucketName = request.BucketName, ObjectKey = request.Key })
+                : StorageResult<ObjectLegalHoldInfo>.Success(LegalHold));
+
+        public ValueTask<StorageResult<ObjectRetentionInfo>> PutObjectRetentionAsync(PutObjectRetentionRequest request, CancellationToken cancellationToken = default)
+        {
+            LastRetentionApplied = request;
+            return ValueTask.FromResult(StorageResult<ObjectRetentionInfo>.Success(new ObjectRetentionInfo
+            {
+                BucketName = request.BucketName,
+                Key = request.Key,
+                VersionId = request.VersionId,
+                Mode = request.Mode,
+                RetainUntilDateUtc = request.RetainUntilDateUtc
+            }));
+        }
+
+        public ValueTask<StorageResult<ObjectLegalHoldInfo>> PutObjectLegalHoldAsync(PutObjectLegalHoldRequest request, CancellationToken cancellationToken = default)
+        {
+            LastLegalHoldApplied = request;
+            return ValueTask.FromResult(StorageResult<ObjectLegalHoldInfo>.Success(new ObjectLegalHoldInfo
+            {
+                BucketName = request.BucketName,
+                Key = request.Key,
+                VersionId = request.VersionId,
+                Status = request.Status
+            }));
+        }
+
+        public ValueTask<StorageResult<GetObjectResponse>> GetObjectAsync(GetObjectRequest request, CancellationToken cancellationToken = default)
+        {
+            GetObjectCallCount++;
+            var response = new GetObjectResponse
+            {
+                Object = new ObjectInfo { BucketName = request.BucketName, Key = request.Key },
+                Content = new MemoryStream([])
+            };
+            return ValueTask.FromResult(StorageResult<GetObjectResponse>.Success(response));
+        }
+
+        public ValueTask<StorageResult<ObjectInfo>> PutObjectAsync(PutObjectRequest request, CancellationToken cancellationToken = default)
+        {
+            PutObjectCallCount++;
+            return ValueTask.FromResult(StorageResult<ObjectInfo>.Success(new ObjectInfo { BucketName = request.BucketName, Key = request.Key }));
+        }
+
+        // ── Unused members: this test only drives the Object Lock repair path. ──
+
+        public ValueTask<StorageCapabilities> GetCapabilitiesAsync(CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageSupportStateDescriptor> GetSupportStateDescriptorAsync(CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageProviderMode> GetProviderModeAsync(CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageObjectLocationDescriptor> GetObjectLocationDescriptorAsync(CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public IAsyncEnumerable<BucketInfo> ListBucketsAsync(CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<BucketInfo>> CreateBucketAsync(CreateBucketRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<BucketVersioningInfo>> GetBucketVersioningAsync(string bucketName, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<BucketVersioningInfo>> PutBucketVersioningAsync(PutBucketVersioningRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult> DeleteBucketAsync(DeleteBucketRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public IAsyncEnumerable<ObjectInfo> ListObjectsAsync(ListObjectsRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public IAsyncEnumerable<ObjectInfo> ListObjectVersionsAsync(ListObjectVersionsRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<ObjectTagSet>> GetObjectTagsAsync(GetObjectTagsRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<ObjectInfo>> CopyObjectAsync(CopyObjectRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<ObjectTagSet>> PutObjectTagsAsync(PutObjectTagsRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<ObjectTagSet>> DeleteObjectTagsAsync(DeleteObjectTagsRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<MultipartUploadInfo>> InitiateMultipartUploadAsync(InitiateMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<MultipartUploadPart>> UploadMultipartPartAsync(UploadMultipartPartRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<ObjectInfo>> CompleteMultipartUploadAsync(CompleteMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult> AbortMultipartUploadAsync(AbortMultipartUploadRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<ObjectInfo>> HeadObjectAsync(HeadObjectRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        public ValueTask<StorageResult<DeleteObjectResult>> DeleteObjectAsync(DeleteObjectRequest request, CancellationToken cancellationToken = default) => throw NotUsed();
+
+        private static NotSupportedException NotUsed() => new("Member not exercised by the Object Lock repair test.");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #108. `StorageReplicaRepairService.RepairAsync` routed `PutObjectRetention` and `PutObjectLegalHold` repair entries to `RepairReplicaObjectFromPrimaryAsync`, which only fetches the primary object body and re-`PutObject`s it to the replica. It never issued `PutObjectRetentionAsync` / `PutObjectLegalHoldAsync` on the replica, so the retention mode / `RetainUntilDate` / legal-hold flag that failed to replicate was never written — yet the repair returned `null` (success), upserted the catalog, and the dispatcher marked the entry `Completed`.

Impact: replica copies of Object-Lock-protected objects were left unprotected (deletable/overwritable) while the system reported the WORM state as replicated/repaired, defeating the compliance guarantee and hiding the divergence from operators. The body re-PUT (`OverwriteIfExists = true`) was also wasteful and could perturb the replica's own version/lock metadata.

## Changes

- `StorageReplicaRepairService`: split the `PutObjectRetention` / `PutObjectLegalHold` dispatch arms and route each to a dedicated repair method:
  - `RepairReplicaObjectRetentionFromPrimaryAsync` — `GetObjectRetentionAsync` on primary, then `PutObjectRetentionAsync` on the replica.
  - `RepairReplicaObjectLegalHoldFromPrimaryAsync` — `GetObjectLegalHoldAsync` on primary, then `PutObjectLegalHoldAsync` on the replica.
  - `ObjectNotFound` / `BucketNotFound` on the primary is reconciled as a replica deletion via the existing `ReconcileReplicaObjectDeletionAsync` (also cleans the catalog). No object body is re-PUT for lock-metadata divergences.
- `OrchestratedStorageService`: removed the two confirmed-dead helpers (`RepairReplicaObjectRetentionFromPrimaryAsync` / `RepairReplicaObjectLegalHoldFromPrimaryAsync`) that were never wired into any dispatch path, to avoid future confusion. The still-used sync write-through helpers (`WriteReplicaPutObjectRetentionAsync` / `WriteReplicaPutObjectLegalHoldAsync`) are retained.

## Tests

Adds `StorageReplicaRepairObjectLockTests` with two regression tests asserting that a retention / legal-hold divergence re-applies the lock on the replica and performs **no** body re-PUT and **no** primary body fetch. Verified fails-before (2 failed on the original dispatch) / passes-after. Full suite green (1196 passed, 0 failed).

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)
