### PR TITLE
fix: reduce shipped IntegratedS3.Testing xunit dependency to xunit.core + xunit.assert (#144)

### DIFF
--- a/src/IntegratedS3/Directory.Packages.props
+++ b/src/IntegratedS3/Directory.Packages.props
@@ -27,6 +27,8 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.16.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.16.0" />
     <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.assert" Version="2.9.2" />
+    <PackageVersion Include="xunit.core" Version="2.9.2" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/src/IntegratedS3/IntegratedS3.Testing/IntegratedS3.Testing.csproj
+++ b/src/IntegratedS3/IntegratedS3.Testing/IntegratedS3.Testing.csproj
@@ -6,7 +6,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
-    <PackageReference Include="xunit" />
+    <!--
+      Shipped helper library only uses [Fact] (xunit.core) and Assert (xunit.assert); see
+      StorageProviderContractTests.cs. Reference those two packages directly instead of the full
+      `xunit` meta-package so consumers of the published IntegratedS3.Testing NuGet package do not
+      inherit the analyzer/build surface of the meta-package. See issue #144.
+    -->
+    <PackageReference Include="xunit.core" />
+    <PackageReference Include="xunit.assert" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Closes #144.

The published `IntegratedS3.Testing` NuGet package declared a public `PackageReference` on the full `xunit` **meta-package** (pinned to `2.9.2`). Every consumer of the shipped package therefore inherited a hard transitive dependency on the whole `xunit` meta-package and was force-pinned to xUnit 2.9.2.

The shipped code (`StorageProviderContractTests.cs`) only uses:
- `[Fact]` → provided by **`xunit.core`** (`xunit.extensibility.core`)
- `Assert.*` → provided by **`xunit.assert`**

So this PR replaces the single `xunit` meta-package reference with direct references to those two minimal packages. The generated nuspec now reads:

```xml
<dependency id="xunit.assert" version="2.9.2" exclude="Build,Analyzers" />
<dependency id="xunit.core"   version="2.9.2" exclude="Build,Analyzers" />
```

instead of `<dependency id="xunit" version="2.9.2" ... />`. Consumers no longer drag in the meta-package (and its `xunit.analyzers` component); they receive only the assertion + core assemblies the helper library actually uses.

Note: `xunit.core` on its own does **not** include `Assert` in xUnit 2.x, hence both `xunit.core` and `xunit.assert` are required (an initial `xunit.core`-only attempt failed to compile).

## Changes

- `Directory.Packages.props`: add centrally-managed `xunit.assert` and `xunit.core` `PackageVersion` entries (`2.9.2`, matching the existing `xunit` pin).
- `IntegratedS3.Testing.csproj`: reference `xunit.core` + `xunit.assert` instead of `xunit`, with an explanatory comment.
- The actual test project (`IntegratedS3.Tests`) is unchanged — it keeps the full `xunit` meta-package + runner.

## Verification

- `dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` → 0 warnings, 0 errors.
- `dotnet test IntegratedS3.Tests` → **1200 passed**, 0 failed.
- `dotnet pack IntegratedS3.Testing -c Release` → confirmed nuspec deps reduced to `xunit.core` + `xunit.assert`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)