### PR TITLE
fix: emit S3 xmlns at write time so empty configuration responses carry the namespace

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -32,7 +32,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "LocationConstraint");
+        return builder.ToString();
     }
 
     /// <summary>Writes a BucketVersioningConfiguration as an XML response body.</summary>
@@ -57,7 +57,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "VersioningConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a BucketEncryptionConfiguration as an XML response body.</summary>
@@ -72,7 +72,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ServerSideEncryptionConfiguration");
+        WriteStartRootElement(xmlWriter, "ServerSideEncryptionConfiguration");
 
         foreach (var rule in response.Rules) {
             xmlWriter.WriteStartElement("Rule");
@@ -99,7 +99,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ServerSideEncryptionConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a PublicAccessBlockConfiguration as an XML response body.</summary>
@@ -114,7 +114,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("PublicAccessBlockConfiguration");
+        WriteStartRootElement(xmlWriter, "PublicAccessBlockConfiguration");
 
         xmlWriter.WriteElementString("BlockPublicAcls", XmlConvert.ToString(response.BlockPublicAcls));
         xmlWriter.WriteElementString("IgnorePublicAcls", XmlConvert.ToString(response.IgnorePublicAcls));
@@ -125,7 +125,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "PublicAccessBlockConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a CorsConfiguration as an XML response body.</summary>
@@ -176,7 +176,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "CORSConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes an Error as an XML response body.</summary>
@@ -219,7 +219,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "Error");
+        return builder.ToString();
     }
 
     /// <summary>Writes a CopyObjectResult as an XML response body.</summary>
@@ -281,7 +281,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, rootElementName);
+        return builder.ToString();
     }
 
     /// <summary>Writes an InitiateMultipartUploadResult as an XML response body.</summary>
@@ -307,7 +307,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "InitiateMultipartUploadResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a CompleteMultipartUploadResult as an XML response body.</summary>
@@ -360,7 +360,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "CompleteMultipartUploadResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListBucketResult as an XML response body.</summary>
@@ -442,7 +442,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListBucketResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListObjectVersionsResult as an XML response body.</summary>
@@ -518,7 +518,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListVersionsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListMultipartUploadsResult as an XML response body.</summary>
@@ -591,7 +591,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListMultipartUploadsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListPartsResult as an XML response body.</summary>
@@ -678,7 +678,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListPartsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListAllMyBucketsResult as an XML response body.</summary>
@@ -710,7 +710,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListAllMyBucketsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a DeleteObjectsResult as an XML response body.</summary>
@@ -763,7 +763,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "DeleteResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes an ObjectTagging as an XML response body.</summary>
@@ -793,7 +793,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "Tagging");
+        return builder.ToString();
     }
 
     /// <summary>Writes an ObjectRetention as an XML response body.</summary>
@@ -808,7 +808,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("Retention");
+        WriteStartRootElement(xmlWriter, "Retention");
 
         if (!string.IsNullOrWhiteSpace(response.Mode)) {
             xmlWriter.WriteElementString("Mode", response.Mode);
@@ -822,7 +822,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "Retention");
+        return builder.ToString();
     }
 
     /// <summary>Writes an ObjectLegalHold as an XML response body.</summary>
@@ -837,7 +837,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("LegalHold");
+        WriteStartRootElement(xmlWriter, "LegalHold");
 
         if (!string.IsNullOrWhiteSpace(response.Status)) {
             xmlWriter.WriteElementString("Status", response.Status);
@@ -847,7 +847,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "LegalHold");
+        return builder.ToString();
     }
 
     /// <summary>Writes a GetObjectAttributesResponse as an XML response body.</summary>
@@ -862,7 +862,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("GetObjectAttributesResponse");
+        WriteStartRootElement(xmlWriter, "GetObjectAttributesResponse");
 
         if (response.ETag is not null)
         {
@@ -940,7 +940,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "GetObjectAttributesResponse");
+        return builder.ToString();
     }
 
     /// <summary>Writes an AccessControlPolicy as an XML response body.</summary>
@@ -993,7 +993,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "AccessControlPolicy");
+        return builder.ToString();
     }
 
     /// <summary>Writes a BucketTagging as an XML response body.</summary>
@@ -1008,7 +1008,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("Tagging");
+        WriteStartRootElement(xmlWriter, "Tagging");
         xmlWriter.WriteStartElement("TagSet");
 
         foreach (var tag in response.TagSet) {
@@ -1023,7 +1023,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "Tagging");
+        return builder.ToString();
     }
 
     /// <summary>Writes a BucketLoggingStatus as an XML response body.</summary>
@@ -1038,7 +1038,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("BucketLoggingStatus");
+        WriteStartRootElement(xmlWriter, "BucketLoggingStatus");
 
         if (response.LoggingEnabled is { } loggingEnabled) {
             xmlWriter.WriteStartElement("LoggingEnabled");
@@ -1051,7 +1051,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "BucketLoggingStatus");
+        return builder.ToString();
     }
 
     /// <summary>Writes a WebsiteConfiguration as an XML response body.</summary>
@@ -1066,7 +1066,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("WebsiteConfiguration");
+        WriteStartRootElement(xmlWriter, "WebsiteConfiguration");
 
         if (response.RedirectAllRequestsTo is { } redirect) {
             xmlWriter.WriteStartElement("RedirectAllRequestsTo");
@@ -1132,7 +1132,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "WebsiteConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a RequestPaymentConfiguration as an XML response body.</summary>
@@ -1147,13 +1147,13 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("RequestPaymentConfiguration");
+        WriteStartRootElement(xmlWriter, "RequestPaymentConfiguration");
         xmlWriter.WriteElementString("Payer", response.Payer);
         xmlWriter.WriteEndElement();
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "RequestPaymentConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes an AccelerateConfiguration as an XML response body.</summary>
@@ -1168,7 +1168,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("AccelerateConfiguration");
+        WriteStartRootElement(xmlWriter, "AccelerateConfiguration");
 
         if (!string.IsNullOrWhiteSpace(response.Status)) {
             xmlWriter.WriteElementString("Status", response.Status);
@@ -1178,7 +1178,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "AccelerateConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a LifecycleConfiguration as an XML response body.</summary>
@@ -1193,7 +1193,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("LifecycleConfiguration");
+        WriteStartRootElement(xmlWriter, "LifecycleConfiguration");
 
         foreach (var rule in response.Rules) {
             xmlWriter.WriteStartElement("Rule");
@@ -1291,7 +1291,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "LifecycleConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ReplicationConfiguration as an XML response body.</summary>
@@ -1306,7 +1306,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ReplicationConfiguration");
+        WriteStartRootElement(xmlWriter, "ReplicationConfiguration");
 
         if (!string.IsNullOrWhiteSpace(response.Role)) {
             xmlWriter.WriteElementString("Role", response.Role);
@@ -1354,7 +1354,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ReplicationConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a NotificationConfiguration as an XML response body.</summary>
@@ -1369,7 +1369,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("NotificationConfiguration");
+        WriteStartRootElement(xmlWriter, "NotificationConfiguration");
 
         foreach (var topic in response.TopicConfigurations) {
             xmlWriter.WriteStartElement("TopicConfiguration");
@@ -1414,7 +1414,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "NotificationConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes an ObjectLockConfiguration as an XML response body.</summary>
@@ -1429,7 +1429,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ObjectLockConfiguration");
+        WriteStartRootElement(xmlWriter, "ObjectLockConfiguration");
 
         if (!string.IsNullOrWhiteSpace(response.ObjectLockEnabled)) {
             xmlWriter.WriteElementString("ObjectLockEnabled", response.ObjectLockEnabled);
@@ -1455,7 +1455,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ObjectLockConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes an AnalyticsConfiguration as an XML response body.</summary>
@@ -1470,7 +1470,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("AnalyticsConfiguration");
+        WriteStartRootElement(xmlWriter, "AnalyticsConfiguration");
         xmlWriter.WriteElementString("Id", response.Id);
 
         var hasPrefix = !string.IsNullOrWhiteSpace(response.FilterPrefix);
@@ -1530,7 +1530,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "AnalyticsConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a MetricsConfiguration as an XML response body.</summary>
@@ -1545,7 +1545,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("MetricsConfiguration");
+        WriteStartRootElement(xmlWriter, "MetricsConfiguration");
         xmlWriter.WriteElementString("Id", response.Id);
 
         if (response.Filter is { } filter) {
@@ -1583,7 +1583,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "MetricsConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes an InventoryConfiguration as an XML response body.</summary>
@@ -1598,7 +1598,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("InventoryConfiguration");
+        WriteStartRootElement(xmlWriter, "InventoryConfiguration");
         xmlWriter.WriteElementString("Id", response.Id);
         xmlWriter.WriteElementString("IsEnabled", response.IsEnabled ? "true" : "false");
         xmlWriter.WriteElementString("IncludedObjectVersions", response.IncludedObjectVersions);
@@ -1646,7 +1646,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "InventoryConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes an IntelligentTieringConfiguration as an XML response body.</summary>
@@ -1661,7 +1661,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("IntelligentTieringConfiguration");
+        WriteStartRootElement(xmlWriter, "IntelligentTieringConfiguration");
         xmlWriter.WriteElementString("Id", response.Id);
         xmlWriter.WriteElementString("Status", response.Status);
 
@@ -1703,7 +1703,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "IntelligentTieringConfiguration");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListAnalyticsConfigurations result as an XML response body.</summary>
@@ -1718,7 +1718,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ListBucketAnalyticsConfigurationsResult");
+        WriteStartRootElement(xmlWriter, "ListBucketAnalyticsConfigurationsResult");
         xmlWriter.WriteElementString("IsTruncated", response.IsTruncated ? "true" : "false");
         if (!string.IsNullOrWhiteSpace(response.ContinuationToken)) {
             xmlWriter.WriteElementString("ContinuationToken", response.ContinuationToken);
@@ -1735,7 +1735,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListBucketAnalyticsConfigurationsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListMetricsConfigurations result as an XML response body.</summary>
@@ -1750,7 +1750,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ListMetricsConfigurationsResult");
+        WriteStartRootElement(xmlWriter, "ListMetricsConfigurationsResult");
         xmlWriter.WriteElementString("IsTruncated", response.IsTruncated ? "true" : "false");
         if (!string.IsNullOrWhiteSpace(response.ContinuationToken)) {
             xmlWriter.WriteElementString("ContinuationToken", response.ContinuationToken);
@@ -1767,7 +1767,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListMetricsConfigurationsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListInventoryConfigurations result as an XML response body.</summary>
@@ -1782,7 +1782,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ListInventoryConfigurationsResult");
+        WriteStartRootElement(xmlWriter, "ListInventoryConfigurationsResult");
         xmlWriter.WriteElementString("IsTruncated", response.IsTruncated ? "true" : "false");
         if (!string.IsNullOrWhiteSpace(response.ContinuationToken)) {
             xmlWriter.WriteElementString("ContinuationToken", response.ContinuationToken);
@@ -1799,7 +1799,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListInventoryConfigurationsResult");
+        return builder.ToString();
     }
 
     /// <summary>Writes a ListIntelligentTieringConfigurations result as an XML response body.</summary>
@@ -1814,7 +1814,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("ListBucketIntelligentTieringConfigurationsResult");
+        WriteStartRootElement(xmlWriter, "ListBucketIntelligentTieringConfigurationsResult");
         xmlWriter.WriteElementString("IsTruncated", response.IsTruncated ? "true" : "false");
         if (!string.IsNullOrWhiteSpace(response.ContinuationToken)) {
             xmlWriter.WriteElementString("ContinuationToken", response.ContinuationToken);
@@ -1831,7 +1831,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "ListBucketIntelligentTieringConfigurationsResult");
+        return builder.ToString();
     }
 
     private static void WriteAnalyticsConfigurationElement(XmlWriter xmlWriter, S3AnalyticsConfiguration config)
@@ -2038,7 +2038,7 @@ public static class S3XmlResponseWriter
         using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
 
         xmlWriter.WriteStartDocument();
-        xmlWriter.WriteStartElement("RestoreRequest");
+        WriteStartRootElement(xmlWriter, "RestoreRequest");
 
         if (response.Days is { } days) {
             xmlWriter.WriteElementString("Days", days.ToString(CultureInfo.InvariantCulture));
@@ -2054,7 +2054,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteEndDocument();
         xmlWriter.Flush();
 
-        return InjectS3Namespace(builder, "RestoreRequest");
+        return builder.ToString();
     }
 
     private static XmlWriterSettings CreateSettings()
@@ -2086,15 +2086,7 @@ public static class S3XmlResponseWriter
             : value.StartsWith('"') ? value : $"\"{value}\"";
     }
 
-    private const string S3Namespace = "http://s3.amazonaws.com/doc/2006-03-01/";
 
-    private static string InjectS3Namespace(StringBuilder builder, string rootElement)
-    {
-        var xml = builder.ToString();
-        return xml.Replace(
-            string.Concat("<", rootElement, ">"),
-            string.Concat("<", rootElement, " xmlns=\"", S3Namespace, "\">"));
-    }
 
     private static void WriteOwner(XmlWriter xmlWriter, string elementName, S3BucketOwner owner)
     {

--- a/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
@@ -314,6 +314,37 @@ public sealed class S3XmlResponseWriterTests
     }
 
     [Fact]
+    public void EmptyConfigurationResponses_EmitCanonicalS3NamespaceOnSelfClosingRoot()
+    {
+        // Regression for #117: empty configs serialize the root as a self-closing element
+        // (e.g. <NotificationConfiguration />). The namespace must still be present on the
+        // root, not dropped because a post-processing string Replace found no "<Root>".
+        var responses = new (string RootName, string Xml)[]
+        {
+            ("NotificationConfiguration",
+                S3XmlResponseWriter.WriteNotificationConfiguration(new S3NotificationConfiguration())),
+            ("BucketLoggingStatus",
+                S3XmlResponseWriter.WriteBucketLoggingStatus(new S3BucketLoggingStatus())),
+            ("LifecycleConfiguration",
+                S3XmlResponseWriter.WriteLifecycleConfiguration(new S3LifecycleConfiguration())),
+            ("ReplicationConfiguration",
+                S3XmlResponseWriter.WriteReplicationConfiguration(new S3ReplicationConfiguration())),
+            ("ObjectLockConfiguration",
+                S3XmlResponseWriter.WriteObjectLockConfiguration(new S3ObjectLockConfiguration()))
+        };
+
+        foreach (var (rootName, xml) in responses) {
+            // The root must be self-closing to exercise the original bug path.
+            Assert.Contains($"<{rootName} ", xml, StringComparison.Ordinal);
+            Assert.DoesNotContain($"</{rootName}>", xml, StringComparison.Ordinal);
+
+            var document = XDocument.Parse(xml);
+            S3XmlTestHelper.AssertRoot(document, rootName);
+            Assert.Equal(S3XmlTestHelper.CanonicalS3Namespace, document.Root!.Name.NamespaceName);
+        }
+    }
+
+    [Fact]
     public void WriteError_EmitsHostId_WhenProvided()
     {
         var ns = S3XmlTestHelper.CanonicalS3Namespace;


### PR DESCRIPTION
## Summary

`S3XmlResponseWriter` relied on the post-processing helper `InjectS3Namespace`, which added the S3 namespace via a literal `<Root>` → `<Root xmlns="...">` string `Replace`. When a configuration is **empty**, `XmlWriter` collapses the root to a self-closing `<Root />`, so the substring `<Root>` never appears — the `Replace` is a no-op and the response ships with **no `xmlns`**.

This broke common default states:
- `GET /{bucket}?notification` on a bucket with no topic/queue/lambda configs → `<NotificationConfiguration />`, namespace dropped.
- `GET /{bucket}?logging` when logging is disabled → `<BucketLoggingStatus />`, namespace dropped.
- Same for empty `LifecycleConfiguration`, `ReplicationConfiguration`, `ObjectLockConfiguration`.

Strict S3 clients / SDK XML deserializers that key off `http://s3.amazonaws.com/doc/2006-03-01/` could fail to parse these responses.

## Fix

Emit the namespace **at write time** instead of post-processing the string:
- Route every root writer through the existing `WriteStartRootElement` helper, which calls `WriteStartElement(string.Empty, localName, CanonicalS3Namespace)`.
- Delete `InjectS3Namespace` and its now-unused `S3Namespace` constant (and its fragile all-occurrences `Replace`).

The namespace is now correct regardless of whether the root is empty/self-closing. `WritePostObjectResult` is intentionally left namespace-free — the AWS PostObject success `<PostResponse>` carries no S3 xmlns.

## Test

Adds a regression test asserting empty `NotificationConfiguration` / `BucketLoggingStatus` / `LifecycleConfiguration` / `ReplicationConfiguration` / `ObjectLockConfiguration` responses serialize a self-closing root that still carries the canonical S3 namespace. **Fails before, passes after** (verified by stashing the source fix). Full suite: **1201 passed, 0 failed**; build 0 warnings.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)