### PR TITLE
perf: push max-keys and cursor into storage for ListObjects/V2 (#102)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -3520,11 +3520,19 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 var requestedPageSize = Math.Min(maxKeys ?? MaxKeysLimit, MaxKeysLimit);
 
                 try {
-                    var objects = await storageService.ListObjectsAsync(new ListObjectsRequest
-                    {
-                        BucketName = bucketName,
-                        Prefix = prefix
-                    }, innerCancellationToken).ToArrayAsync(innerCancellationToken);
+                    var normalizedPrefix = prefix ?? string.Empty;
+                    var normalizedDelimiter = string.IsNullOrEmpty(delimiter) ? null : delimiter;
+                    var cursorKey = string.IsNullOrWhiteSpace(marker) ? null : marker;
+
+                    var entries = await CollectListBucketEntriesAsync(
+                        storageService.ListObjectsAsync(
+                            BuildListObjectsPageRequest(bucketName, prefix, cursorKey, requestedPageSize, normalizedDelimiter),
+                            innerCancellationToken),
+                        normalizedPrefix,
+                        normalizedDelimiter,
+                        markerValue: cursorKey,
+                        requestedPageSize,
+                        innerCancellationToken);
 
                     var response = BuildListBucketResult(
                         bucketName,
@@ -3534,7 +3542,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         startAfter: null,
                         continuationToken: null,
                         requestedPageSize,
-                        objects,
+                        entries,
                         isV2: false,
                         includeOwner: true,
                         encodingType,
@@ -3584,11 +3592,21 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 var requestedPageSize = Math.Min(maxKeys ?? MaxKeysLimit, MaxKeysLimit);
 
                 try {
-                    var objects = await storageService.ListObjectsAsync(new ListObjectsRequest
-                    {
-                        BucketName = bucketName,
-                        Prefix = prefix
-                    }, innerCancellationToken).ToArrayAsync(innerCancellationToken);
+                    var normalizedPrefix = prefix ?? string.Empty;
+                    var normalizedDelimiter = string.IsNullOrEmpty(delimiter) ? null : delimiter;
+                    var cursorKey = !string.IsNullOrWhiteSpace(continuationToken)
+                        ? continuationToken
+                        : string.IsNullOrWhiteSpace(startAfter) ? null : startAfter;
+
+                    var entries = await CollectListBucketEntriesAsync(
+                        storageService.ListObjectsAsync(
+                            BuildListObjectsPageRequest(bucketName, prefix, cursorKey, requestedPageSize, normalizedDelimiter),
+                            innerCancellationToken),
+                        normalizedPrefix,
+                        normalizedDelimiter,
+                        markerValue: cursorKey,
+                        requestedPageSize,
+                        innerCancellationToken);
 
                     var response = BuildListBucketResult(
                         bucketName,
@@ -3598,7 +3616,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         startAfter,
                         continuationToken,
                         requestedPageSize,
-                        objects,
+                        entries,
                         isV2: true,
                         includeOwner: fetchOwner,
                         encodingType,
@@ -4558,6 +4576,113 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         return null;
     }
 
+    /// <summary>
+    /// Builds a bounded <see cref="ListObjectsRequest"/> that pushes the prefix, the resume cursor
+    /// (<paramref name="cursorKey"/>, the last key returned on the previous page), and — when no
+    /// delimiter is in play — a page-size bound of <paramref name="maxKeys"/> + 1 into the storage layer.
+    /// When a delimiter is present a single common-prefix run can span arbitrarily many object keys, so
+    /// no numeric page-size bound is pushed; the streaming collector terminates enumeration once enough
+    /// entries have been materialized instead. Either way the whole bucket is never read.
+    /// </summary>
+    private static ListObjectsRequest BuildListObjectsPageRequest(
+        string bucketName,
+        string? prefix,
+        string? cursorKey,
+        int maxKeys,
+        string? normalizedDelimiter)
+    {
+        int? pageSize = normalizedDelimiter is not null
+            ? null
+            : maxKeys == int.MaxValue ? int.MaxValue : maxKeys + 1;
+
+        return new ListObjectsRequest
+        {
+            BucketName = bucketName,
+            Prefix = prefix,
+            ContinuationToken = cursorKey,
+            PageSize = pageSize
+        };
+    }
+
+    /// <summary>
+    /// Streams objects (already prefix- and cursor-filtered by the storage layer) and materializes only
+    /// the list bucket entries needed to render one page plus a single-entry truncation probe.
+    /// Grouping (delimiter/common-prefix) matches <see cref="BuildListBucketResult"/> exactly, but the
+    /// enumeration stops as soon as <paramref name="maxKeys"/> + 1 entries have been finalized so the
+    /// whole bucket is never materialized. A common-prefix run is finalized only once a key outside the
+    /// run is observed, so early termination never splits a run across the page boundary.
+    /// </summary>
+    private static async Task<List<ListBucketResultEntry>> CollectListBucketEntriesAsync(
+        IAsyncEnumerable<ObjectInfo> objects,
+        string normalizedPrefix,
+        string? normalizedDelimiter,
+        string? markerValue,
+        int maxKeys,
+        CancellationToken cancellationToken)
+    {
+        var entries = new List<ListBucketResultEntry>();
+
+        // Entry budget: one page plus a single probe entry to detect truncation.
+        var entryBudget = maxKeys == int.MaxValue ? int.MaxValue : maxKeys + 1;
+
+        // Pending common-prefix run awaiting finalization (finalized when a key breaks out of it).
+        string? pendingCommonPrefix = null;
+        string? pendingLastObjectKey = null;
+
+        await foreach (var currentObject in objects.WithCancellation(cancellationToken)) {
+            var key = currentObject.Key;
+
+            if (!key.StartsWith(normalizedPrefix, StringComparison.Ordinal)) {
+                continue;
+            }
+
+            if (!string.IsNullOrWhiteSpace(markerValue)
+                && StringComparer.Ordinal.Compare(key, markerValue) <= 0) {
+                continue;
+            }
+
+            // Extend an in-flight common-prefix run without emitting a new entry.
+            if (pendingCommonPrefix is not null
+                && key.StartsWith(pendingCommonPrefix, StringComparison.Ordinal)) {
+                pendingLastObjectKey = key;
+                continue;
+            }
+
+            // A key broke out of the pending run: finalize it before handling the new key.
+            if (pendingCommonPrefix is not null) {
+                entries.Add(ListBucketResultEntry.ForCommonPrefix(pendingCommonPrefix, pendingLastObjectKey!));
+                pendingCommonPrefix = null;
+                pendingLastObjectKey = null;
+
+                if (entries.Count >= entryBudget) {
+                    return entries;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(normalizedDelimiter)) {
+                var suffix = key[normalizedPrefix.Length..];
+                var delimiterIndex = suffix.IndexOf(normalizedDelimiter, StringComparison.Ordinal);
+                if (delimiterIndex >= 0) {
+                    pendingCommonPrefix = normalizedPrefix + suffix[..(delimiterIndex + normalizedDelimiter.Length)];
+                    pendingLastObjectKey = key;
+                    continue;
+                }
+            }
+
+            entries.Add(ListBucketResultEntry.ForObject(currentObject));
+            if (entries.Count >= entryBudget) {
+                return entries;
+            }
+        }
+
+        // Flush any trailing common-prefix run once the stream is exhausted.
+        if (pendingCommonPrefix is not null) {
+            entries.Add(ListBucketResultEntry.ForCommonPrefix(pendingCommonPrefix, pendingLastObjectKey!));
+        }
+
+        return entries;
+    }
+
     private static S3ListBucketResult BuildListBucketResult(
         string bucketName,
         string? prefix,
@@ -4566,55 +4691,13 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         string? startAfter,
         string? continuationToken,
         int maxKeys,
-        IReadOnlyList<ObjectInfo> objects,
+        IReadOnlyList<ListBucketResultEntry> entries,
         bool isV2,
         bool includeOwner,
         string? encodingType,
         S3BucketOwner owner)
     {
-        var normalizedPrefix = prefix ?? string.Empty;
         var normalizedDelimiter = string.IsNullOrEmpty(delimiter) ? null : delimiter;
-        var markerValue = isV2 && string.IsNullOrWhiteSpace(continuationToken)
-            ? startAfter
-            : isV2 ? continuationToken : marker;
-
-        var entries = new List<ListBucketResultEntry>();
-
-        for (var index = 0; index < objects.Count; index++) {
-            var currentObject = objects[index];
-            if (!currentObject.Key.StartsWith(normalizedPrefix, StringComparison.Ordinal)) {
-                continue;
-            }
-
-            if (!string.IsNullOrWhiteSpace(markerValue)
-                && StringComparer.Ordinal.Compare(currentObject.Key, markerValue) <= 0) {
-                continue;
-            }
-
-            if (!string.IsNullOrEmpty(normalizedDelimiter)) {
-                var suffix = currentObject.Key[normalizedPrefix.Length..];
-                var delimiterIndex = suffix.IndexOf(normalizedDelimiter, StringComparison.Ordinal);
-                if (delimiterIndex >= 0) {
-                    var commonPrefix = normalizedPrefix + suffix[..(delimiterIndex + normalizedDelimiter.Length)];
-                    var lastObjectKey = currentObject.Key;
-
-                    while (index + 1 < objects.Count) {
-                        var nextObject = objects[index + 1];
-                        if (!nextObject.Key.StartsWith(commonPrefix, StringComparison.Ordinal)) {
-                            break;
-                        }
-
-                        lastObjectKey = nextObject.Key;
-                        index++;
-                    }
-
-                    entries.Add(ListBucketResultEntry.ForCommonPrefix(commonPrefix, lastObjectKey));
-                    continue;
-                }
-            }
-
-            entries.Add(ListBucketResultEntry.ForObject(currentObject));
-        }
 
         var isTruncated = entries.Count > maxKeys;
         var page = isTruncated

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ListObjectsPushdownTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ListObjectsPushdownTests.cs
@@ -1,0 +1,383 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Xml.Linq;
+using IntegratedS3.Abstractions.Models;
+using IntegratedS3.Abstractions.Requests;
+using IntegratedS3.Abstractions.Services;
+using IntegratedS3.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression tests for issue #102: <c>ListObjects</c> (V1) and <c>ListObjectsV2</c> must push
+/// <c>max-keys</c> (a page-size bound) and the client cursor (marker / continuation-token /
+/// start-after) into the storage layer instead of materializing the entire bucket in memory.
+///
+/// The tests wrap <see cref="IStorageService"/> with a recording proxy that captures the last
+/// <see cref="ListObjectsRequest"/> the endpoint issues and counts how many objects were actually
+/// pulled from the returned stream, proving the whole bucket is no longer read for a small page.
+/// </summary>
+public sealed class IntegratedS3ListObjectsPushdownTests
+{
+    private static readonly XNamespace S3Ns = "http://s3.amazonaws.com/doc/2006-03-01/";
+
+    private static async Task<WebUiApplicationFactory.IsolatedWebUiClient> CreateRecordingClientAsync(
+        WebUiApplicationFactory factory,
+        ListObjectsRecorder recorder)
+    {
+        return await factory.CreateIsolatedClientAsync(configureBuilder: builder =>
+        {
+            var descriptor = builder.Services.Single(static service => service.ServiceType == typeof(IStorageService));
+            builder.Services.Remove(descriptor);
+            builder.Services.AddSingleton<IStorageService>(provider =>
+            {
+                IStorageService inner;
+                if (descriptor.ImplementationFactory is not null)
+                {
+                    inner = (IStorageService)descriptor.ImplementationFactory(provider);
+                }
+                else if (descriptor.ImplementationInstance is not null)
+                {
+                    inner = (IStorageService)descriptor.ImplementationInstance;
+                }
+                else
+                {
+                    inner = (IStorageService)ActivatorUtilities.CreateInstance(provider, descriptor.ImplementationType!);
+                }
+
+                return RecordingStorageService.Create(inner, recorder);
+            });
+        });
+    }
+
+    private static async Task SeedObjectsAsync(HttpClient client, string bucketName, IEnumerable<string> keys)
+    {
+        var createBucket = await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null);
+        Assert.True(createBucket.IsSuccessStatusCode, $"Bucket create failed: {createBucket.StatusCode}");
+        foreach (var key in keys)
+        {
+            var response = await client.PutAsync(
+                $"/integrated-s3/buckets/{bucketName}/objects/{key}",
+                new StringContent(key, Encoding.UTF8, "text/plain"));
+            Assert.True(response.IsSuccessStatusCode, $"Object PUT failed for '{key}': {response.StatusCode}");
+        }
+    }
+
+    private static string GetValue(XDocument document, string name)
+        => document.Root!.Element(S3Ns + name)?.Value
+           ?? throw new InvalidOperationException($"Missing element '{name}'.");
+
+    private static string[] Contents(XDocument document)
+        => document.Root!.Elements(S3Ns + "Contents")
+            .Select(static element => element.Element(S3Ns + "Key")!.Value)
+            .ToArray();
+
+    private static string[] CommonPrefixes(XDocument document)
+        => document.Root!.Elements(S3Ns + "CommonPrefixes")
+            .Select(static element => element.Element(S3Ns + "Prefix")!.Value)
+            .ToArray();
+
+    [Fact]
+    public async Task ListObjectsV2_SmallPage_DoesNotMaterializeWholeBucket()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        // 20 objects, request only 2.
+        var keys = Enumerable.Range(0, 20).Select(static index => $"key-{index:D2}.txt").ToArray();
+        await SeedObjectsAsync(client, "pushdown-v2", keys);
+        recorder.Reset();
+
+        var response = await client.GetAsync("/integrated-s3/pushdown-v2?list-type=2&max-keys=2");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("2", GetValue(document, "KeyCount"));
+        Assert.Equal("true", GetValue(document, "IsTruncated"));
+        Assert.Equal("key-01.txt", GetValue(document, "NextContinuationToken"));
+        Assert.Equal(new[] { "key-00.txt", "key-01.txt" }, Contents(document));
+
+        var call = Assert.Single(recorder.Calls);
+        // No delimiter -> a numeric page-size bound of maxKeys + 1 must be pushed down.
+        Assert.Equal(3, call.Request.PageSize);
+        Assert.Null(call.Request.ContinuationToken);
+        // The endpoint must read at most maxKeys + 1 objects, never all 20.
+        Assert.True(call.ObjectsRead <= 3, $"Expected <= 3 objects read, but read {call.ObjectsRead}.");
+    }
+
+    [Fact]
+    public async Task ListObjectsV1_SmallPage_DoesNotMaterializeWholeBucket()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        var keys = Enumerable.Range(0, 20).Select(static index => $"key-{index:D2}.txt").ToArray();
+        await SeedObjectsAsync(client, "pushdown-v1", keys);
+        recorder.Reset();
+
+        var response = await client.GetAsync("/integrated-s3/pushdown-v1?max-keys=2");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("2", GetValue(document, "MaxKeys"));
+        Assert.Equal("true", GetValue(document, "IsTruncated"));
+        Assert.Equal(new[] { "key-00.txt", "key-01.txt" }, Contents(document));
+
+        var call = Assert.Single(recorder.Calls);
+        Assert.Equal(3, call.Request.PageSize);
+        Assert.Null(call.Request.ContinuationToken);
+        Assert.True(call.ObjectsRead <= 3, $"Expected <= 3 objects read, but read {call.ObjectsRead}.");
+    }
+
+    [Fact]
+    public async Task ListObjectsV2_ContinuationToken_PushedIntoStorageAndResumesCorrectly()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        var keys = new[] { "a.txt", "b.txt", "c.txt", "d.txt", "e.txt" };
+        await SeedObjectsAsync(client, "pushdown-continue", keys);
+        recorder.Reset();
+
+        var firstResponse = await client.GetAsync("/integrated-s3/pushdown-continue?list-type=2&max-keys=2");
+        var firstDocument = XDocument.Parse(await firstResponse.Content.ReadAsStringAsync());
+        Assert.Equal("true", GetValue(firstDocument, "IsTruncated"));
+        Assert.Equal(new[] { "a.txt", "b.txt" }, Contents(firstDocument));
+        var token = GetValue(firstDocument, "NextContinuationToken");
+        Assert.Equal("b.txt", token);
+
+        recorder.Reset();
+        var secondResponse = await client.GetAsync(
+            $"/integrated-s3/pushdown-continue?list-type=2&max-keys=2&continuation-token={Uri.EscapeDataString(token)}");
+        var secondDocument = XDocument.Parse(await secondResponse.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "c.txt", "d.txt" }, Contents(secondDocument));
+        Assert.Equal("true", GetValue(secondDocument, "IsTruncated"));
+        Assert.Equal("d.txt", GetValue(secondDocument, "NextContinuationToken"));
+
+        // The continuation token (a key cursor) must have been pushed into the storage request.
+        var secondCall = Assert.Single(recorder.Calls);
+        Assert.Equal("b.txt", secondCall.Request.ContinuationToken);
+        Assert.Equal(3, secondCall.Request.PageSize);
+
+        recorder.Reset();
+        var thirdResponse = await client.GetAsync(
+            $"/integrated-s3/pushdown-continue?list-type=2&max-keys=2&continuation-token={Uri.EscapeDataString("d.txt")}");
+        var thirdDocument = XDocument.Parse(await thirdResponse.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "e.txt" }, Contents(thirdDocument));
+        Assert.Equal("false", GetValue(thirdDocument, "IsTruncated"));
+        Assert.Empty(thirdDocument.Root!.Elements(S3Ns + "NextContinuationToken"));
+    }
+
+    [Fact]
+    public async Task ListObjectsV2_StartAfter_PushedIntoStorage()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        var keys = new[] { "a.txt", "b.txt", "c.txt", "d.txt" };
+        await SeedObjectsAsync(client, "pushdown-startafter", keys);
+        recorder.Reset();
+
+        var response = await client.GetAsync(
+            $"/integrated-s3/pushdown-startafter?list-type=2&max-keys=2&start-after={Uri.EscapeDataString("b.txt")}");
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "c.txt", "d.txt" }, Contents(document));
+        Assert.Equal("false", GetValue(document, "IsTruncated"));
+
+        var call = Assert.Single(recorder.Calls);
+        Assert.Equal("b.txt", call.Request.ContinuationToken);
+    }
+
+    [Fact]
+    public async Task ListObjectsV1_Marker_PushedIntoStorage()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        var keys = new[] { "a.txt", "b.txt", "c.txt", "d.txt" };
+        await SeedObjectsAsync(client, "pushdown-marker", keys);
+        recorder.Reset();
+
+        var response = await client.GetAsync(
+            $"/integrated-s3/pushdown-marker?marker={Uri.EscapeDataString("b.txt")}&max-keys=1");
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal(new[] { "c.txt" }, Contents(document));
+        Assert.Equal("true", GetValue(document, "IsTruncated"));
+
+        var call = Assert.Single(recorder.Calls);
+        Assert.Equal("b.txt", call.Request.ContinuationToken);
+    }
+
+    [Fact]
+    public async Task ListObjectsV2_Delimiter_GroupsCommonPrefixesAndPaginatesAcrossPages()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        // Two large common-prefix runs plus a top-level object. A common-prefix run spans more
+        // objects than maxKeys, so the collector must consume a full run before finalizing it.
+        var keys = new List<string> { "root.txt" };
+        keys.AddRange(Enumerable.Range(0, 5).Select(static index => $"docs/a{index}.txt"));
+        keys.AddRange(Enumerable.Range(0, 5).Select(static index => $"images/b{index}.png"));
+        await SeedObjectsAsync(client, "pushdown-delim", keys);
+        recorder.Reset();
+
+        // Page 1: expect first entry = "docs/" common prefix (keys sort before "images/" and "root.txt").
+        var firstResponse = await client.GetAsync("/integrated-s3/pushdown-delim?list-type=2&delimiter=/&max-keys=1");
+        var firstDocument = XDocument.Parse(await firstResponse.Content.ReadAsStringAsync());
+        Assert.Equal("true", GetValue(firstDocument, "IsTruncated"));
+        Assert.Equal(new[] { "docs/" }, CommonPrefixes(firstDocument));
+        Assert.Empty(Contents(firstDocument));
+        // Next token is the LAST object key consumed into the docs/ run, i.e. docs/a4.txt.
+        Assert.Equal("docs/a4.txt", GetValue(firstDocument, "NextContinuationToken"));
+
+        // Page 2: resume from docs/a4.txt -> images/ common prefix next.
+        var secondResponse = await client.GetAsync(
+            $"/integrated-s3/pushdown-delim?list-type=2&delimiter=/&max-keys=1&continuation-token={Uri.EscapeDataString("docs/a4.txt")}");
+        var secondDocument = XDocument.Parse(await secondResponse.Content.ReadAsStringAsync());
+        Assert.Equal("true", GetValue(secondDocument, "IsTruncated"));
+        Assert.Equal(new[] { "images/" }, CommonPrefixes(secondDocument));
+        Assert.Equal("images/b4.png", GetValue(secondDocument, "NextContinuationToken"));
+
+        // Page 3: resume from images/b4.png -> the top-level object "root.txt".
+        var thirdResponse = await client.GetAsync(
+            $"/integrated-s3/pushdown-delim?list-type=2&delimiter=/&max-keys=1&continuation-token={Uri.EscapeDataString("images/b4.png")}");
+        var thirdDocument = XDocument.Parse(await thirdResponse.Content.ReadAsStringAsync());
+        Assert.Equal("false", GetValue(thirdDocument, "IsTruncated"));
+        Assert.Empty(CommonPrefixes(thirdDocument));
+        Assert.Equal(new[] { "root.txt" }, Contents(thirdDocument));
+    }
+
+    [Fact]
+    public async Task ListObjectsV2_Delimiter_MatchesFullEnumerationForWholeBucket()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        var keys = new List<string>();
+        keys.AddRange(Enumerable.Range(0, 3).Select(static index => $"a/{index}.txt"));
+        keys.AddRange(Enumerable.Range(0, 3).Select(static index => $"b/{index}.txt"));
+        keys.Add("z.txt");
+        await SeedObjectsAsync(client, "pushdown-delim-full", keys);
+
+        var response = await client.GetAsync("/integrated-s3/pushdown-delim-full?list-type=2&delimiter=/&max-keys=1000");
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("false", GetValue(document, "IsTruncated"));
+        Assert.Equal(new[] { "a/", "b/" }, CommonPrefixes(document));
+        Assert.Equal(new[] { "z.txt" }, Contents(document));
+    }
+
+    [Fact]
+    public async Task ListObjectsV2_MaxKeysBoundary_ExactPageIsNotTruncated()
+    {
+        await using var factory = new WebUiApplicationFactory();
+        var recorder = new ListObjectsRecorder();
+        await using var isolated = await CreateRecordingClientAsync(factory, recorder);
+        var client = isolated.Client;
+
+        var keys = new[] { "a.txt", "b.txt", "c.txt" };
+        await SeedObjectsAsync(client, "pushdown-boundary", keys);
+        recorder.Reset();
+
+        // Exactly max-keys objects -> not truncated.
+        var exactResponse = await client.GetAsync("/integrated-s3/pushdown-boundary?list-type=2&max-keys=3");
+        var exactDocument = XDocument.Parse(await exactResponse.Content.ReadAsStringAsync());
+        Assert.Equal("false", GetValue(exactDocument, "IsTruncated"));
+        Assert.Equal(new[] { "a.txt", "b.txt", "c.txt" }, Contents(exactDocument));
+        Assert.Empty(exactDocument.Root!.Elements(S3Ns + "NextContinuationToken"));
+
+        // One fewer than available -> truncated with a next token.
+        var truncatedResponse = await client.GetAsync("/integrated-s3/pushdown-boundary?list-type=2&max-keys=2");
+        var truncatedDocument = XDocument.Parse(await truncatedResponse.Content.ReadAsStringAsync());
+        Assert.Equal("true", GetValue(truncatedDocument, "IsTruncated"));
+        Assert.Equal("b.txt", GetValue(truncatedDocument, "NextContinuationToken"));
+    }
+
+    private sealed record ListObjectsCall(ListObjectsRequest Request, int ObjectsRead)
+    {
+        public int ObjectsRead { get; set; } = ObjectsRead;
+    }
+
+    private sealed class ListObjectsRecorder
+    {
+        public ConcurrentQueue<ListObjectsCall> Calls { get; } = new();
+
+        public void Reset() => Calls.Clear();
+
+        public ListObjectsCall Record(ListObjectsRequest request)
+        {
+            var call = new ListObjectsCall(request, 0);
+            Calls.Enqueue(call);
+            return call;
+        }
+    }
+
+    /// <summary>
+    /// A <see cref="DispatchProxy"/> over <see cref="IStorageService"/> that records the
+    /// <see cref="ListObjectsRequest"/> issued and counts how many objects are pulled from the
+    /// returned stream, forwarding every other member to the real implementation.
+    /// </summary>
+    private class RecordingStorageService : DispatchProxy
+    {
+        private IStorageService _inner = null!;
+        private ListObjectsRecorder _recorder = null!;
+
+        internal static IStorageService Create(IStorageService inner, ListObjectsRecorder recorder)
+        {
+            var proxy = Create<IStorageService, RecordingStorageService>();
+            var recording = (RecordingStorageService)(object)proxy;
+            recording._inner = inner;
+            recording._recorder = recorder;
+            return proxy;
+        }
+
+        protected override object? Invoke(MethodInfo? targetMethod, object?[]? args)
+        {
+            if (targetMethod is null)
+            {
+                throw new ArgumentNullException(nameof(targetMethod));
+            }
+
+            if (targetMethod.Name == nameof(IStorageService.ListObjectsAsync)
+                && args is [ListObjectsRequest request, CancellationToken cancellationToken])
+            {
+                var call = _recorder.Record(request);
+                var inner = _inner.ListObjectsAsync(request, cancellationToken);
+                return CountingStream(inner, call, cancellationToken);
+            }
+
+            return targetMethod.Invoke(_inner, args);
+        }
+
+        private static async IAsyncEnumerable<ObjectInfo> CountingStream(
+            IAsyncEnumerable<ObjectInfo> source,
+            ListObjectsCall call,
+            [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            await foreach (var item in source.WithCancellation(cancellationToken))
+            {
+                call.ObjectsRead++;
+                yield return item;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #102.

The S3-compatible `ListObjectsV1Async` and `ListObjectsV2Async` handlers built the storage request with only `BucketName` + `Prefix` and then `.ToArrayAsync()` over the **entire** bucket, trimming to `max-keys` only in memory. This gave O(N) CPU/IO/allocations — plus O(N) catalog upserts via `OrchestratedStorageService` — on every request regardless of the requested page size, and O(N²/pageSize) to page a whole bucket. On large buckets that is a latency / GC / OutOfMemory (resource-exhaustion) vector reachable by any client authorized to list.

Both handlers now push the pagination bound and cursor into the storage layer, mirroring the already-correct native `ListObjectsAsync`.

## Changes

- **`BuildListObjectsPageRequest`** — pushes `Prefix`, the resume cursor (`marker` for V1; `continuation-token`, else `start-after` for V2) as `ListObjectsRequest.ContinuationToken`, and — when no delimiter is present — a `PageSize` bound of `max-keys + 1` (`int.MaxValue`-guarded). The disk provider already honours a key cursor (skip `<= token`) and the page-size early-break, so it stops after one page instead of walking + sorting the whole tree.
- **`CollectListBucketEntriesAsync`** — grouping logic extracted out of `BuildListBucketResult` into a streaming collector that consumes the (already prefix/cursor-filtered) `IAsyncEnumerable<ObjectInfo>` and stops as soon as `max-keys + 1` **entries** are finalized. A common-prefix run is finalized only when a key outside it is observed, so early termination never splits a run across the page boundary.
- **`BuildListBucketResult`** — now takes the pre-built entry list; `IsTruncated`, `NextContinuationToken`/`NextMarker`, `KeyCount`, delimiter/common-prefix grouping and the clamp-to-1000 keep their exact previous semantics.

With a delimiter a single common-prefix run may legitimately span more objects than `max-keys`, so no numeric page-size is pushed; the collector's lazy early-break bounds the read instead.

## Tests

New `IntegratedS3ListObjectsPushdownTests` wraps `IStorageService` with a `DispatchProxy` that records the pushed `ListObjectsRequest` and counts objects actually pulled from the stream:

- V1 + V2 small page over a 20-object bucket reads **≤ max-keys + 1** objects (not all 20), and pushes `PageSize = max-keys + 1`. *(Fails on the old code, which pushed no `PageSize` and read all 20.)*
- `continuation-token`, `start-after` and `marker` are pushed into `ListObjectsRequest.ContinuationToken`; multi-page resume returns the correct objects/tokens.
- Delimiter grouping paginates correctly across three pages (common prefixes then a top-level object) and matches full enumeration for a whole-bucket listing.
- `max-keys` truncation boundary (exact page not truncated; one-fewer truncated with next token).

`dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` and the full `IntegratedS3.Tests` suite (1208 tests) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
