### PR TITLE
fix: gate x-amz-version-id on Enabled buckets & null-version suspended delete markers (#151)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -2353,17 +2353,15 @@ internal sealed class DiskStorageService(
 
             var checksums = CreateCopyObjectChecksums(actualChecksums, sourceMetadata.Checksums, checksumAlgorithm);
 
-            if (await HasCurrentVersionStateAsync(request.DestinationBucketName, request.DestinationKey, cancellationToken)
-                && await IsVersioningEnabledAsync(request.DestinationBucketName, cancellationToken)) {
-                await ArchiveCurrentObjectVersionAsync(request.DestinationBucketName, request.DestinationKey, destinationPath, cancellationToken);
-            }
+            var versioningStatus = await GetBucketVersioningStatusAsync(request.DestinationBucketName, cancellationToken);
+            await PreserveCurrentVersionBeforeOverwriteAsync(request.DestinationBucketName, request.DestinationKey, destinationPath, versioningStatus, cancellationToken);
 
             File.Move(tempDestinationPath, destinationPath, overwrite: true);
 
             var tags = request.TaggingDirective == ObjectTaggingDirective.Replace
                 ? NormalizeTags(request.Tags)
                 : NormalizeTags(sourceMetadata.Tags);
-            var versionId = CreateVersionId();
+            var versionId = AssignWriteVersionId(versioningStatus);
             var useReplacementMetadata = request.MetadataDirective == CopyObjectMetadataDirective.Replace;
             await WriteStoredObjectStateAsync(
                 request.DestinationBucketName,
@@ -2489,13 +2487,11 @@ internal sealed class DiskStorageService(
 
             var persistedChecksums = CreatePutObjectChecksums(actualChecksums, request.Checksums);
 
-            if (await HasCurrentVersionStateAsync(request.BucketName, request.Key, cancellationToken)
-                && await IsVersioningEnabledAsync(request.BucketName, cancellationToken)) {
-                await ArchiveCurrentObjectVersionAsync(request.BucketName, request.Key, objectPath, cancellationToken);
-            }
+            var versioningStatus = await GetBucketVersioningStatusAsync(request.BucketName, cancellationToken);
+            await PreserveCurrentVersionBeforeOverwriteAsync(request.BucketName, request.Key, objectPath, versioningStatus, cancellationToken);
 
             File.Move(tempFilePath, objectPath, overwrite: true);
-            var versionId = CreateVersionId();
+            var versionId = AssignWriteVersionId(versioningStatus);
             await WriteStoredObjectStateAsync(
                 request.BucketName,
                 request.Key,
@@ -3223,10 +3219,8 @@ internal sealed class DiskStorageService(
                 await FlushToStableStorageAsync(destinationStream, cancellationToken);
             }
 
-            if (await HasCurrentVersionStateAsync(request.BucketName, request.Key, cancellationToken)
-                && await IsVersioningEnabledAsync(request.BucketName, cancellationToken)) {
-                await ArchiveCurrentObjectVersionAsync(request.BucketName, request.Key, objectPath, cancellationToken);
-            }
+            var versioningStatus = await GetBucketVersioningStatusAsync(request.BucketName, cancellationToken);
+            await PreserveCurrentVersionBeforeOverwriteAsync(request.BucketName, request.Key, objectPath, versioningStatus, cancellationToken);
 
             File.Move(tempObjectPath, objectPath, overwrite: true);
             IReadOnlyDictionary<string, string> checksums = compositePartChecksums is not null
@@ -3238,7 +3232,7 @@ internal sealed class DiskStorageService(
             // A completed multipart object always exposes the composite S3 ETag
             // "<hex(MD5(concat(partMd5Bytes)))>-<partCount>", regardless of any checksum algorithm.
             var multipartETag = BuildMultipartETag(partMd5Checksums);
-            var versionId = CreateVersionId();
+            var versionId = AssignWriteVersionId(versioningStatus);
             await WriteStoredObjectStateAsync(
                 request.BucketName,
                 request.Key,
@@ -3450,7 +3444,11 @@ internal sealed class DiskStorageService(
         using var objectMutationLock = await AcquireObjectMutationLockAsync(request.BucketName, request.Key, cancellationToken);
 
         var filePath = GetObjectPath(request.BucketName, request.Key);
-        var versioningEnabled = await IsVersioningEnabledAsync(request.BucketName, cancellationToken);
+        var versioningStatus = await GetBucketVersioningStatusAsync(request.BucketName, cancellationToken);
+        var versioningEnabled = versioningStatus == BucketVersioningStatus.Enabled;
+        // Suspended buckets still create delete markers, but with the "null" version id (which
+        // overwrites any existing null version) rather than a fresh unique version id.
+        var createsDeleteMarker = versioningStatus != BucketVersioningStatus.Disabled;
 
         if (!string.IsNullOrWhiteSpace(request.VersionId)) {
             var storedObjectResult = await ResolveStoredObjectAsync(request.BucketName, request.Key, request.VersionId, cancellationToken);
@@ -3500,8 +3498,10 @@ internal sealed class DiskStorageService(
         }
 
         if (!await HasCurrentVersionStateAsync(request.BucketName, request.Key, cancellationToken)) {
-            if (versioningEnabled && !request.BypassDeleteMarkerCreation) {
-                var deleteMarker = await CreateCurrentDeleteMarkerAsync(request.BucketName, request.Key, cancellationToken);
+            if (createsDeleteMarker && !request.BypassDeleteMarkerCreation) {
+                // Enabled -> unique version id; Suspended -> null version (overwrites any prior null).
+                var deleteMarkerVersionId = AssignWriteVersionId(versioningStatus);
+                var deleteMarker = await CreateCurrentDeleteMarkerAsync(request.BucketName, request.Key, deleteMarkerVersionId, cancellationToken);
                 return StorageResult<DeleteObjectResult>.Success(new DeleteObjectResult
                 {
                     BucketName = request.BucketName,
@@ -3519,14 +3519,18 @@ internal sealed class DiskStorageService(
             });
         }
 
-        if (versioningEnabled && !request.BypassDeleteMarkerCreation) {
-            await ArchiveCurrentObjectVersionAsync(request.BucketName, request.Key, filePath, cancellationToken);
+        if (createsDeleteMarker && !request.BypassDeleteMarkerCreation) {
+            // Preserve a prior non-null version (Enabled always archives; Suspended archives only a
+            // real version, overwriting an existing null version). Then replace the current object
+            // with a delete marker: unique-versioned when Enabled, the null version when Suspended.
+            await PreserveCurrentVersionBeforeOverwriteAsync(request.BucketName, request.Key, filePath, versioningStatus, cancellationToken);
 
             if (File.Exists(filePath)) {
                 File.Delete(filePath);
             }
 
-            var deleteMarker = await CreateCurrentDeleteMarkerAsync(request.BucketName, request.Key, cancellationToken);
+            var deleteMarkerVersionId = AssignWriteVersionId(versioningStatus);
+            var deleteMarker = await CreateCurrentDeleteMarkerAsync(request.BucketName, request.Key, deleteMarkerVersionId, cancellationToken);
             return StorageResult<DeleteObjectResult>.Success(new DeleteObjectResult
             {
                 BucketName = request.BucketName,
@@ -4347,13 +4351,69 @@ internal sealed class DiskStorageService(
 
     private async Task<bool> IsVersioningEnabledAsync(string bucketName, CancellationToken cancellationToken)
     {
+        return await GetBucketVersioningStatusAsync(bucketName, cancellationToken) == BucketVersioningStatus.Enabled;
+    }
+
+    /// <summary>
+    /// Resolves the persisted versioning status for a bucket. A bucket that was never configured
+    /// (or whose directory is missing) reports <see cref="BucketVersioningStatus.Disabled"/>.
+    /// </summary>
+    private async Task<BucketVersioningStatus> GetBucketVersioningStatusAsync(string bucketName, CancellationToken cancellationToken)
+    {
         var bucketPath = GetBucketPath(bucketName);
         if (!Directory.Exists(bucketPath)) {
-            return false;
+            return BucketVersioningStatus.Disabled;
         }
 
         var metadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
-        return metadata.VersioningStatus == BucketVersioningStatus.Enabled;
+        return metadata.VersioningStatus;
+    }
+
+    /// <summary>
+    /// Returns the version id to stamp on a freshly written object for the supplied versioning
+    /// status. Only <see cref="BucketVersioningStatus.Enabled"/> buckets mint a new unique version;
+    /// unversioned (<see cref="BucketVersioningStatus.Disabled"/>) and
+    /// <see cref="BucketVersioningStatus.Suspended"/> buckets store the AWS "null" version, which is
+    /// represented internally as a <see langword="null"/> version id so no <c>x-amz-version-id</c>
+    /// response header is emitted and a subsequent write overwrites the same null-version slot.
+    /// </summary>
+    private static string? AssignWriteVersionId(BucketVersioningStatus versioningStatus)
+    {
+        return versioningStatus == BucketVersioningStatus.Enabled ? CreateVersionId() : null;
+    }
+
+    /// <summary>
+    /// Preserves the current object's history when it is about to be overwritten by a new write.
+    /// On an <see cref="BucketVersioningStatus.Enabled"/> bucket the current object is archived as a
+    /// non-current version. On a <see cref="BucketVersioningStatus.Suspended"/> bucket a prior
+    /// non-null version is likewise archived (AWS retains versions created while versioning was
+    /// enabled), whereas an existing null version is simply overwritten in place. Unversioned
+    /// buckets keep no history and archive nothing.
+    /// </summary>
+    private async Task PreserveCurrentVersionBeforeOverwriteAsync(
+        string bucketName,
+        string key,
+        string currentPath,
+        BucketVersioningStatus versioningStatus,
+        CancellationToken cancellationToken)
+    {
+        if (versioningStatus == BucketVersioningStatus.Disabled) {
+            return;
+        }
+
+        var currentObject = await TryResolveCurrentStoredObjectAsync(bucketName, key, currentPath, cancellationToken);
+        if (currentObject is null) {
+            return;
+        }
+
+        // Enabled: archive whatever is current (minting a version id for legacy null-version state).
+        // Suspended: only archive a real (non-null) version; the existing null version is overwritten.
+        if (versioningStatus == BucketVersioningStatus.Suspended
+            && string.IsNullOrWhiteSpace(currentObject.Metadata.VersionId)) {
+            return;
+        }
+
+        await ArchiveCurrentObjectVersionAsync(bucketName, key, currentPath, cancellationToken);
     }
 
     private async Task ArchiveCurrentObjectVersionAsync(string bucketName, string key, string currentPath, CancellationToken cancellationToken)
@@ -4556,10 +4616,9 @@ internal sealed class DiskStorageService(
         return await TryResolveCurrentStoredObjectAsync(bucketName, key, currentPath, cancellationToken) is not null;
     }
 
-    private async Task<ObjectInfo> CreateCurrentDeleteMarkerAsync(string bucketName, string key, CancellationToken cancellationToken)
+    private async Task<ObjectInfo> CreateCurrentDeleteMarkerAsync(string bucketName, string key, string? versionId, CancellationToken cancellationToken)
     {
         var currentPath = GetObjectPath(bucketName, key);
-        var versionId = CreateVersionId();
         var lastModifiedUtc = DateTimeOffset.UtcNow;
 
         await WriteStoredObjectStateAsync(

--- a/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/DiskStorageServiceTests.cs
@@ -42,7 +42,9 @@ public sealed class DiskStorageServiceTests
         });
 
         Assert.True(putResult.IsSuccess);
-        Assert.False(string.IsNullOrWhiteSpace(putResult.Value!.VersionId));
+        // Unversioned bucket: the object uses the AWS "null" version, so no version id is minted
+        // and no x-amz-version-id header is emitted (see issue #151).
+        Assert.Null(putResult.Value!.VersionId);
         Assert.Equal("text/plain", putResult.Value!.ContentType);
         Assert.Equal("copilot", putResult.Value.Metadata!["author"]);
         Assert.Equal(ComputeSha256Base64("hello integrated s3"), putResult.Value.Checksums!["sha256"]);
@@ -458,7 +460,8 @@ public sealed class DiskStorageServiceTests
 
         Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
         {
-            BucketName = "versions"
+            BucketName = "versions",
+            EnableVersioning = true
         })).IsSuccess);
 
         await using var uploadStream = new MemoryStream(Encoding.UTF8.GetBytes("versioned payload"));
@@ -2018,7 +2021,10 @@ public sealed class DiskStorageServiceTests
         Assert.False(copyResult.Value.Metadata.ContainsKey("source-only"));
         Assert.Equal(ComputeSha256Base64("copy me"), copyResult.Value.Checksums!["sha256"]);
         Assert.Equal(ComputeCrc32cBase64("copy me"), copyResult.Value.Checksums["crc32c"]);
-        Assert.NotEqual(putResult.Value!.VersionId, copyResult.Value.VersionId);
+        // Unversioned bucket: both the source PUT and the self-copy use the AWS "null" version, so
+        // neither carries a minted version id (see issue #151).
+        Assert.Null(putResult.Value!.VersionId);
+        Assert.Null(copyResult.Value.VersionId);
 
         var downloaded = await storageService.GetObjectAsync(new GetObjectRequest
         {
@@ -5180,7 +5186,7 @@ public sealed class DiskStorageServiceTests
     }
 
     [Fact]
-    public async Task DiskStorage_PermanentDeleteOfLockedObject_AfterVersioningSuspended_IsRefused()
+    public async Task DiskStorage_DeleteAfterVersioningSuspended_InsertsNullDeleteMarkerAndRetainsLockedVersion()
     {
         await using var fixture = new DiskStorageFixture();
         var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
@@ -5204,14 +5210,17 @@ public sealed class DiskStorageServiceTests
             }
         })).IsSuccess);
 
+        string lockedVersionId;
         await using (var content = new MemoryStream(Encoding.UTF8.GetBytes("suspended payload"))) {
-            Assert.True((await storageService.PutObjectAsync(new PutObjectRequest
+            var lockedPut = await storageService.PutObjectAsync(new PutObjectRequest
             {
                 BucketName = bucketName,
                 Key = key,
                 Content = content,
                 ContentType = "text/plain"
-            })).IsSuccess);
+            });
+            Assert.True(lockedPut.IsSuccess);
+            lockedVersionId = Assert.IsType<string>(lockedPut.Value!.VersionId);
         }
 
         Assert.True((await storageService.PutBucketVersioningAsync(new PutBucketVersioningRequest
@@ -5220,28 +5229,222 @@ public sealed class DiskStorageServiceTests
             Status = BucketVersioningStatus.Suspended
         })).IsSuccess);
 
-        // With versioning suspended a delete without a version id becomes a permanent
-        // delete, so the retention window must still refuse it.
-        var permanentDelete = await storageService.DeleteObjectAsync(new DeleteObjectRequest
+        // AWS semantics (issue #151): on a versioning-suspended bucket a delete without a version id
+        // inserts a "null"-version delete marker rather than permanently deleting the current object.
+        // The pre-existing locked version is retained, so Object Lock is not violated and the delete
+        // succeeds with the null version (no minted version id).
+        var suspendedDelete = await storageService.DeleteObjectAsync(new DeleteObjectRequest
         {
             BucketName = bucketName,
             Key = key
         });
 
-        Assert.False(permanentDelete.IsSuccess);
-        Assert.Equal(StorageErrorCode.ObjectLocked, permanentDelete.Error!.Code);
-        Assert.Equal(403, permanentDelete.Error.SuggestedHttpStatusCode);
+        Assert.True(suspendedDelete.IsSuccess);
+        Assert.True(suspendedDelete.Value!.IsDeleteMarker);
+        Assert.Null(suspendedDelete.Value.VersionId);
 
-        var stillReadable = await storageService.GetObjectAsync(new GetObjectRequest
+        // The current object now resolves to a delete marker.
+        var currentGet = await storageService.GetObjectAsync(new GetObjectRequest
         {
             BucketName = bucketName,
             Key = key
         });
+        Assert.False(currentGet.IsSuccess);
+        Assert.Equal(StorageErrorCode.ObjectNotFound, currentGet.Error!.Code);
 
-        Assert.True(stillReadable.IsSuccess);
-        await using var stillReadableResponse = stillReadable.Value!;
-        using var stillReadableReader = new StreamReader(stillReadableResponse.Content, Encoding.UTF8, leaveOpen: false);
-        Assert.Equal("suspended payload", await stillReadableReader.ReadToEndAsync());
+        // The locked version is preserved and still readable by its version id.
+        var lockedVersionGet = await storageService.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = lockedVersionId
+        });
+        Assert.True(lockedVersionGet.IsSuccess);
+        await using (var lockedResponse = lockedVersionGet.Value!) {
+            using var lockedReader = new StreamReader(lockedResponse.Content, Encoding.UTF8, leaveOpen: false);
+            Assert.Equal("suspended payload", await lockedReader.ReadToEndAsync());
+        }
+
+        // The retention window still refuses a permanent delete of the locked version by id.
+        var lockedVersionDelete = await storageService.DeleteObjectAsync(new DeleteObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = lockedVersionId
+        });
+        Assert.False(lockedVersionDelete.IsSuccess);
+        Assert.Equal(StorageErrorCode.ObjectLocked, lockedVersionDelete.Error!.Code);
+        Assert.Equal(403, lockedVersionDelete.Error.SuggestedHttpStatusCode);
+    }
+
+    // Regression tests for issue #151: unversioned / suspended buckets must not stamp a minted
+    // x-amz-version-id, and suspended deletes must use the "null"-version delete-marker semantics.
+    [Fact]
+    public async Task DiskStorage_UnversionedBucket_PutAndDelete_UseNullVersionAndEmitNoVersionId()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        const string bucketName = "unversioned-null-version";
+        const string key = "docs/plain.txt";
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = bucketName
+        })).IsSuccess);
+
+        await using (var v1 = new MemoryStream(Encoding.UTF8.GetBytes("first"))) {
+            var put1 = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Content = v1,
+                ContentType = "text/plain"
+            });
+            Assert.True(put1.IsSuccess);
+            // AWS returns no version id (the null version) for a bucket that never enabled versioning.
+            Assert.Null(put1.Value!.VersionId);
+        }
+
+        // Overwriting the object stays on the single null version; it never accumulates versions.
+        await using (var v2 = new MemoryStream(Encoding.UTF8.GetBytes("second"))) {
+            var put2 = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Content = v2,
+                ContentType = "text/plain"
+            });
+            Assert.True(put2.IsSuccess);
+            Assert.Null(put2.Value!.VersionId);
+        }
+
+        var head = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key
+        });
+        Assert.True(head.IsSuccess);
+        Assert.Null(head.Value!.VersionId);
+
+        var versionsBeforeDelete = await storageService.ListObjectVersionsAsync(new ListObjectVersionsRequest
+        {
+            BucketName = bucketName
+        }).ToArrayAsync();
+        var onlyVersion = Assert.Single(versionsBeforeDelete);
+        Assert.Null(onlyVersion.VersionId);
+        Assert.False(onlyVersion.IsDeleteMarker);
+
+        // A delete with no version id on an unversioned bucket permanently removes the object; it
+        // must not create a delete marker and must not report a version id.
+        var delete = await storageService.DeleteObjectAsync(new DeleteObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key
+        });
+        Assert.True(delete.IsSuccess);
+        Assert.False(delete.Value!.IsDeleteMarker);
+        Assert.Null(delete.Value.VersionId);
+
+        var afterDelete = await storageService.HeadObjectAsync(new HeadObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key
+        });
+        Assert.False(afterDelete.IsSuccess);
+        Assert.Equal(StorageErrorCode.ObjectNotFound, afterDelete.Error!.Code);
+
+        var versionsAfterDelete = await storageService.ListObjectVersionsAsync(new ListObjectVersionsRequest
+        {
+            BucketName = bucketName
+        }).ToArrayAsync();
+        Assert.Empty(versionsAfterDelete);
+    }
+
+    [Fact]
+    public async Task DiskStorage_SuspendedBucket_DeleteMarker_UsesNullVersionAndOverwritesPriorNullDeleteMarker()
+    {
+        await using var fixture = new DiskStorageFixture();
+        var storageService = fixture.Services.GetRequiredService<IStorageBackend>();
+        const string bucketName = "suspended-null-delete-marker";
+        const string key = "docs/history.txt";
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = bucketName,
+            EnableVersioning = true
+        })).IsSuccess);
+
+        // A real version minted while versioning is enabled must survive suspension.
+        string enabledVersionId;
+        await using (var enabled = new MemoryStream(Encoding.UTF8.GetBytes("enabled version"))) {
+            var enabledPut = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Content = enabled,
+                ContentType = "text/plain"
+            });
+            Assert.True(enabledPut.IsSuccess);
+            enabledVersionId = Assert.IsType<string>(enabledPut.Value!.VersionId);
+        }
+
+        Assert.True((await storageService.PutBucketVersioningAsync(new PutBucketVersioningRequest
+        {
+            BucketName = bucketName,
+            Status = BucketVersioningStatus.Suspended
+        })).IsSuccess);
+
+        // First suspended delete: inserts a null-version delete marker, preserving the real version.
+        var firstDelete = await storageService.DeleteObjectAsync(new DeleteObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key
+        });
+        Assert.True(firstDelete.IsSuccess);
+        Assert.True(firstDelete.Value!.IsDeleteMarker);
+        Assert.Null(firstDelete.Value.VersionId);
+
+        var afterFirstDelete = await storageService.ListObjectVersionsAsync(new ListObjectVersionsRequest
+        {
+            BucketName = bucketName
+        }).ToArrayAsync();
+        // Exactly two entries: the retained real version + the single null-version delete marker.
+        Assert.Equal(2, afterFirstDelete.Length);
+        Assert.Single(afterFirstDelete, v => v.IsDeleteMarker && v.VersionId is null && v.IsLatest);
+        Assert.Single(afterFirstDelete, v => !v.IsDeleteMarker && v.VersionId == enabledVersionId);
+
+        // Re-write the null version, then delete again: the null-version delete marker is replaced in
+        // place (still exactly one null delete marker), never accumulating multiple null markers.
+        await using (var suspendedPut = new MemoryStream(Encoding.UTF8.GetBytes("suspended overwrite"))) {
+            var putBack = await storageService.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = key,
+                Content = suspendedPut,
+                ContentType = "text/plain"
+            });
+            Assert.True(putBack.IsSuccess);
+            Assert.Null(putBack.Value!.VersionId);
+        }
+
+        var secondDelete = await storageService.DeleteObjectAsync(new DeleteObjectRequest
+        {
+            BucketName = bucketName,
+            Key = key
+        });
+        Assert.True(secondDelete.IsSuccess);
+        Assert.True(secondDelete.Value!.IsDeleteMarker);
+        Assert.Null(secondDelete.Value.VersionId);
+
+        var afterSecondDelete = await storageService.ListObjectVersionsAsync(new ListObjectVersionsRequest
+        {
+            BucketName = bucketName
+        }).ToArrayAsync();
+        // Still exactly one null-version delete marker (the prior one was overwritten), plus the
+        // retained enabled-era real version.
+        Assert.Equal(2, afterSecondDelete.Length);
+        Assert.Single(afterSecondDelete, v => v.IsDeleteMarker && v.VersionId is null && v.IsLatest);
+        Assert.Single(afterSecondDelete, v => !v.IsDeleteMarker && v.VersionId == enabledVersionId);
     }
 
     private static void AssertUnsupportedServerSideEncryption(StorageError? error, string bucketName, string objectKey)

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -494,6 +494,19 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         Assert.Equal(HttpStatusCode.Created, (await client.PutAsync("/integrated-s3/buckets/versioned-bucket", content: null)).StatusCode);
 
+        // Versioning must be enabled for the object PUT to emit a minted x-amz-version-id header
+        // (issue #151: unversioned buckets use the null version and emit no version-id header).
+        using (var enableVersioningRequest = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/versioned-bucket?versioning")
+        {
+            Content = new StringContent("""
+<VersioningConfiguration>
+  <Status>Enabled</Status>
+</VersioningConfiguration>
+""", Encoding.UTF8, "application/xml")
+        }) {
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(enableVersioningRequest)).StatusCode);
+        }
+
         const string payload = "hello versioned checksum";
         var checksum = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(payload)));
 
@@ -10237,13 +10250,25 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         var suspendResponse = await client.SendAsync(suspendRequest);
         Assert.Equal(HttpStatusCode.OK, suspendResponse.StatusCode);
 
+        // Issue #151: a PUT on a versioning-suspended bucket stores the "null" version, so no
+        // x-amz-version-id header is emitted and it overwrites any prior null version. The
+        // previously-enabled version (v1) is retained as a non-current version.
         var v2 = await client.PutAsync(
             "/integrated-s3/suspend-versioning-bucket/file.txt",
             new StringContent("v2", Encoding.UTF8, "text/plain"));
         Assert.Equal(HttpStatusCode.OK, v2.StatusCode);
-        var v2VersionId = Assert.Single(v2.Headers.GetValues("x-amz-version-id"));
+        Assert.False(v2.Headers.TryGetValues("x-amz-version-id", out _));
 
-        Assert.NotEqual(v1VersionId, v2VersionId);
+        // The current object is now the null-version "v2" payload.
+        var currentGet = await client.GetAsync("/integrated-s3/suspend-versioning-bucket/file.txt");
+        Assert.Equal(HttpStatusCode.OK, currentGet.StatusCode);
+        Assert.False(currentGet.Headers.TryGetValues("x-amz-version-id", out _));
+        Assert.Equal("v2", await currentGet.Content.ReadAsStringAsync());
+
+        // The enabled-era version v1 is preserved and still addressable by its version id.
+        var v1Get = await client.GetAsync($"/integrated-s3/suspend-versioning-bucket/file.txt?versionId={Uri.EscapeDataString(v1VersionId)}");
+        Assert.Equal(HttpStatusCode.OK, v1Get.StatusCode);
+        Assert.Equal("v1", await v1Get.Content.ReadAsStringAsync());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #151

## Problem
The disk provider called `CreateVersionId()` unconditionally on every `PutObject` / `CopyObject` / `CompleteMultipartUpload` and stamped the resulting GUID as `x-amz-version-id` on PUT/GET/HEAD/COPY — even for buckets that were never versioned or are `Suspended`. AWS returns `x-amz-version-id` **only** for versioning-`Enabled` buckets; unversioned/suspended objects use the `null` version and emit no version-id header. Clients (mc/rclone/boto) that infer "bucket is versioned" from the header were misled.

Separately, a `DELETE` (no `versionId`) on a `Suspended` bucket **hard-deleted** the current object, because `Suspended` was treated as fully unversioned. AWS inserts a `null`-version delete marker instead, preserving prior non-null versions and overwriting any existing null version.

## Fix (`IntegratedS3.Provider.Disk/DiskStorageService.cs`)
- **`GetBucketVersioningStatusAsync` + `AssignWriteVersionId`** — only `Enabled` buckets mint a unique version id; `Disabled`/`Suspended` use the null version (internally a C# `null` id), so `ApplyVersionIdHeader` emits no `x-amz-version-id` and writes overwrite the single null-version slot.
- Route PUT / COPY / multipart-complete version-id assignment through `AssignWriteVersionId`.
- **`PreserveCurrentVersionBeforeOverwriteAsync`** — `Enabled` archives the current version; `Suspended` archives only a prior **non-null** version (retaining enabled-era history) and overwrites an existing null version in place; `Disabled` keeps no history.
- **`DeleteObject`** — `Suspended` now inserts a `null`-version delete marker (overwriting any prior null version/marker) instead of hard-deleting. `CreateCurrentDeleteMarkerAsync` takes the version id to stamp (`null` for `Suspended`).

## Behavior now matches AWS
| Bucket | PUT | DELETE (no versionId) |
|---|---|---|
| Disabled | null version, no `x-amz-version-id` | permanent delete, no marker |
| Suspended | null version (overwrites prior null; preserves non-null), no `x-amz-version-id` | null-version delete marker (overwrites prior null; preserves non-null), `x-amz-delete-marker: true` |
| Enabled | unique version, `x-amz-version-id` returned | unique-version delete marker, `x-amz-version-id` returned |

## Tests
- Updated tests that asserted the old (buggy) behavior to the AWS-correct expectation.
- Added regression tests (fail-before / pass-after):
  - `DiskStorage_UnversionedBucket_PutAndDelete_UseNullVersionAndEmitNoVersionId`
  - `DiskStorage_SuspendedBucket_DeleteMarker_UsesNullVersionAndOverwritesPriorNullDeleteMarker`
  - Rewrote `DiskStorage_DeleteAfterVersioningSuspended_...` to assert null-version delete-marker + retained locked version.
  - `PutBucketVersioning_SuspendsVersioning` (HTTP) now asserts no `x-amz-version-id` on suspended PUT and that the enabled-era version is preserved.

Full suite green: **1202 passed, 0 failed**. Clean build, 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)