### PR TITLE
fix: always emit KeyMarker and VersionIdMarker in ListObjectVersions first-page response

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -465,13 +465,10 @@ public static class S3XmlResponseWriter
             xmlWriter.WriteElementString("Delimiter", EncodeS3ListValue(response.Delimiter, response.EncodingType));
         }
 
-        if (!string.IsNullOrWhiteSpace(response.KeyMarker)) {
-            xmlWriter.WriteElementString("KeyMarker", EncodeS3ListValue(response.KeyMarker, response.EncodingType));
-        }
-
-        if (!string.IsNullOrWhiteSpace(response.VersionIdMarker)) {
-            xmlWriter.WriteElementString("VersionIdMarker", response.VersionIdMarker);
-        }
+        // AWS always emits KeyMarker and VersionIdMarker in ListVersionsResult,
+        // present-but-empty on the first page (no marker supplied).
+        xmlWriter.WriteElementString("KeyMarker", EncodeS3ListValue(response.KeyMarker ?? string.Empty, response.EncodingType));
+        xmlWriter.WriteElementString("VersionIdMarker", response.VersionIdMarker ?? string.Empty);
 
         if (!string.IsNullOrWhiteSpace(response.NextKeyMarker)) {
             xmlWriter.WriteElementString("NextKeyMarker", EncodeS3ListValue(response.NextKeyMarker, response.EncodingType));

--- a/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/S3XmlResponseWriterTests.cs
@@ -314,6 +314,34 @@ public sealed class S3XmlResponseWriterTests
     }
 
     [Fact]
+    public void WriteListObjectVersionsResult_AlwaysEmitsEmptyKeyAndVersionIdMarkers_OnFirstPage()
+    {
+        // Regression for #136: AWS always emits <KeyMarker> and <VersionIdMarker> in
+        // ListVersionsResult, present-but-empty on the first page (no marker supplied).
+        var xml = S3XmlResponseWriter.WriteListObjectVersionsResult(new S3ListObjectVersionsResult
+        {
+            Name = "bucket",
+            Prefix = "docs/",
+            MaxKeys = 1,
+            KeyMarker = null,
+            VersionIdMarker = null,
+            Versions = [],
+            CommonPrefixes = []
+        });
+
+        var document = XDocument.Parse(xml);
+        var ns = S3XmlTestHelper.CanonicalS3Namespace;
+
+        var keyMarker = document.Root!.Element(XName.Get("KeyMarker", ns));
+        Assert.NotNull(keyMarker);
+        Assert.Equal(string.Empty, keyMarker!.Value);
+
+        var versionIdMarker = document.Root!.Element(XName.Get("VersionIdMarker", ns));
+        Assert.NotNull(versionIdMarker);
+        Assert.Equal(string.Empty, versionIdMarker!.Value);
+    }
+
+    [Fact]
     public void EmptyConfigurationResponses_EmitCanonicalS3NamespaceOnSelfClosingRoot()
     {
         // Regression for #117: empty configs serialize the root as a self-closing element


### PR DESCRIPTION
## Summary

`WriteListObjectVersionsResult` only emitted `<KeyMarker>` and `<VersionIdMarker>` when non-empty, so a first-page `ListObjectVersions` request (no `key-marker` / `version-id-marker` supplied) silently dropped both elements. Real AWS S3 always emits these two elements in `ListVersionsResult`, present-but-empty on the first page. The sibling `WriteListMultipartUploadsResult` writer already handles this correctly, so the two list-writers were internally inconsistent.

## Fix

Emit both elements unconditionally, mirroring the multipart writer:

```csharp
xmlWriter.WriteElementString("KeyMarker", EncodeS3ListValue(response.KeyMarker ?? string.Empty, response.EncodingType));
xmlWriter.WriteElementString("VersionIdMarker", response.VersionIdMarker ?? string.Empty);
```

Ordering is preserved (before `NextKeyMarker`/`NextVersionIdMarker`) to match AWS.

## Test

Adds `WriteListObjectVersionsResult_AlwaysEmitsEmptyKeyAndVersionIdMarkers_OnFirstPage`, asserting both elements are present-but-empty on a first-page (no-marker) versions request. Verified fails-before / passes-after. Full suite green (1212 passed).

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)