### PR TITLE
fix: roll resumed download append back to original length on I/O error and cancellation (#112)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Client/IntegratedS3ClientTransferExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.Client/IntegratedS3ClientTransferExtensions.cs
@@ -856,7 +856,17 @@ public static class IntegratedS3ClientTransferExtensions
             RestorePartialDownload(fileStream, filePath, originalLength, exception);
             throw;
         }
+        catch (OperationCanceledException exception) {
+            // Roll the file back so a cancelled resume leaves the partial file at its
+            // pre-append length rather than the caller's real file torn beyond originalLength.
+            RestorePartialDownload(fileStream, filePath, originalLength, exception);
+            throw;
+        }
         catch (Exception exception) {
+            // Any other mid-append failure (transient socket IOException, HttpRequestException,
+            // etc.) must also roll back; otherwise the already-flushed bytes past originalLength
+            // silently corrupt the caller's file and poison the next resume attempt.
+            RestorePartialDownload(fileStream, filePath, originalLength, exception);
             if (exception is IOException ioException) {
                 throw CreateTransferHttpRequestException("The resumed download failed while appending to the destination file.", ioException);
             }

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ClientTransferTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3ClientTransferTests.cs
@@ -1476,7 +1476,59 @@ public sealed class IntegratedS3ClientTransferTests(WebUiApplicationFactory fact
             var innerException = Assert.IsType<IOException>(exception.InnerException);
             Assert.Equal("Simulated resume failure.", innerException.Message);
             Assert.True(File.Exists(destPath), "Pre-existing partial files should be preserved on resume failure.");
-            Assert.Equal("partial-ta", await File.ReadAllTextAsync(destPath));
+            // Regression for #112: an IOException after some appended bytes were already flushed
+            // must roll the file back to its pre-append length rather than leaving the torn bytes
+            // ("partial-ta") on disk, which would silently corrupt the caller's file and poison the
+            // next resume attempt.
+            Assert.Equal("partial-", await File.ReadAllTextAsync(destPath));
+        }
+        finally {
+            Directory.Delete(tempDir, recursive: true);
+        }
+    }
+
+    // Regression for #112: a mid-append cancellation (OperationCanceledException while reading the
+    // response body) must also roll the destination back to its original length. Before the fix
+    // only InvalidDataException rolled back; cancellation re-threw with the already-flushed bytes
+    // ("partial-ta") left committed past originalLength, silently corrupting the caller's file.
+    [Fact]
+    public async Task DownloadToFileWithResumeAsync_ResumeCancelledMidAppend_RollsFileBackToOriginalLength()
+    {
+        var tempDir = CreateTransferTempDirectory();
+        Directory.CreateDirectory(tempDir);
+        try {
+            var destPath = Path.Combine(tempDir, "resume-cancelled.txt");
+            const string existingPayload = "partial-";
+            await File.WriteAllTextAsync(destPath, existingPayload);
+
+            var capturingClient = new CapturingIntegratedS3Client();
+            var existingLength = new FileInfo(destPath).Length;
+            using var transferClient = new HttpClient(new DelegateHttpMessageHandler((request, cancellationToken) => {
+                var response = new HttpResponseMessage(HttpStatusCode.PartialContent)
+                {
+                    Content = new StreamContent(new ThrowingReadStream(
+                        Encoding.UTF8.GetBytes("tail"),
+                        bytesBeforeFailure: 2,
+                        new OperationCanceledException("Simulated resume cancellation.")))
+                };
+                response.Content.Headers.ContentRange = new ContentRangeHeaderValue(
+                    existingLength,
+                    existingLength + 3,
+                    existingLength + 4);
+                return Task.FromResult(response);
+            }));
+
+            await Assert.ThrowsAsync<OperationCanceledException>(() =>
+                capturingClient.DownloadToFileWithResumeAsync(
+                    transferClient,
+                    "bucket",
+                    "key",
+                    destPath,
+                    expiresInSeconds: 60));
+
+            Assert.True(File.Exists(destPath), "Pre-existing partial files should be preserved on resume cancellation.");
+            Assert.Equal(existingPayload, await File.ReadAllTextAsync(destPath));
+            Assert.Equal(existingLength, new FileInfo(destPath).Length);
         }
         finally {
             Directory.Delete(tempDir, recursive: true);


### PR DESCRIPTION
## Summary

`AppendPartialDownloadAsync` (in `IntegratedS3.Client/IntegratedS3ClientTransferExtensions.cs`) only rolled the destination file back to its original length when checksum validation failed (`InvalidDataException`). A mid-append network `IOException` or an `OperationCanceledException` re-threw **without** truncating the file back to `originalLength`.

Because the resume path opens the caller's real file (`FileMode.Open`), seeks to the end, and writes incrementally, a mid-stream failure left an arbitrary number of appended bytes committed past `originalLength`. The next `DownloadToFileWithResumeAsyncCore` call read the now-longer length, issued a `Range` request from the torn offset, and appended the next slice after the incomplete bytes — silently producing a corrupted file. S3 range responses typically carry no `x-amz-checksum-*` headers, so no download-side integrity check caught the mismatch.

## Fix

The `catch (Exception)` block now calls `RestorePartialDownload` (which flushes and `SetLength`s back to `originalLength`) before re-throwing, and a dedicated `catch (OperationCanceledException)` does the same for cancellation. This restores the documented *"Pre-existing partial files are preserved on resume failures so callers can retry"* guarantee, mirroring the cleanup already done by the sibling `DownloadPresignedToFileAsync` and `RewriteDownloadFromStartAsync` paths.

## Tests

- `DownloadToFileWithResumeAsync_ResumeTransferFails_PreservesExistingPartialFile` now asserts the file is rolled back to `"partial-"` (previously it asserted the torn `"partial-ta"`, which encoded the bug).
- New `DownloadToFileWithResumeAsync_ResumeCancelledMidAppend_RollsFileBackToOriginalLength` covers the previously-uncovered cancellation path.

Both tests were verified to **fail before** the fix (file left as `"partial-ta"`) and **pass after**. Full suite: 1212 passed, 0 failed.

Closes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)