### PR TITLE
test: header-signed SigV4/SigV4a clock-skew & absent x-amz-date regression tests

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
@@ -1971,6 +1971,91 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
         Assert.Contains("future", GetRequiredElementValue(errorDocument, "Message"), StringComparison.OrdinalIgnoreCase);
     }
 
+    // Regression for #113: the primary (Authorization-header) SigV4 path must reject a request whose
+    // x-amz-date is too far in the PAST (a captured, replayed request). This freshness check is the
+    // only barrier against indefinite replay of a header-signed request, yet had zero coverage — the
+    // sole prior RequestTimeTooSkewed assertion drives the separate presigned-query future-only path.
+    [Fact]
+    public async Task SigV4HeaderAuthentication_StaleTimestampOutsideClockSkew_ReturnsRequestTimeTooSkewed()
+    {
+        const string accessKeyId = "sigv4-header-stale-access";
+        const string secretAccessKey = "sigv4-header-stale-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(
+            accessKeyId,
+            secretAccessKey,
+            options => options.AllowedSignatureClockSkewMinutes = 1);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4HeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-2));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("RequestTimeTooSkewed", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    // Regression for #113: the symmetric ".Duration()" skew barrier must also reject a header request
+    // whose x-amz-date is too far in the FUTURE. A refactor that dropped ".Duration()" (checking only
+    // future skew) or inverted the comparison would be caught here but not by the stale-only case.
+    [Fact]
+    public async Task SigV4HeaderAuthentication_FutureTimestampOutsideClockSkew_ReturnsRequestTimeTooSkewed()
+    {
+        const string accessKeyId = "sigv4-header-future-access";
+        const string secretAccessKey = "sigv4-header-future-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(
+            accessKeyId,
+            secretAccessKey,
+            options => options.AllowedSignatureClockSkewMinutes = 1);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4HeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(2));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("RequestTimeTooSkewed", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    // Regression for #113: proves the skew barrier is a boundary and not a blanket rejection — a
+    // header request timestamped just INSIDE the allowed window must still authenticate successfully.
+    // Without this, the two rejection tests above could pass against code that rejects everything.
+    [Fact]
+    public async Task SigV4HeaderAuthentication_TimestampWithinClockSkew_Succeeds()
+    {
+        const string accessKeyId = "sigv4-header-within-skew-access";
+        const string secretAccessKey = "sigv4-header-within-skew-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(
+            accessKeyId,
+            secretAccessKey,
+            options => options.AllowedSignatureClockSkewMinutes = 5);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4HeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-2));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
     [Fact]
     public async Task SigV4HeaderAuthentication_DeleteMarkerAndHistoricalVersionOperations_ReturnExpectedResponses()
     {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4aConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4aConformanceTests.cs
@@ -149,6 +149,111 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 
+    // Regression for #113: the SigV4a header path shares the same symmetric clock-skew barrier as
+    // SigV4 (IsOutsideAllowedClockSkew) but had zero coverage. A request whose x-amz-date is too far
+    // in the PAST — a captured, replayed request — must be rejected with RequestTimeTooSkewed.
+    // Default AllowedSignatureClockSkewMinutes is 5, so a 6-minute-stale timestamp is outside it.
+    [Fact]
+    public async Task SigV4aHeaderAuthentication_StaleTimestampOutsideClockSkew_ReturnsRequestTimeTooSkewed()
+    {
+        const string accessKeyId = "sigv4a-header-stale-access";
+        const string secretAccessKey = "sigv4a-header-stale-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4aHeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-6));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("RequestTimeTooSkewed", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    // Regression for #113: the ".Duration()" symmetry of the skew barrier must reject a SigV4a header
+    // request whose x-amz-date is too far in the FUTURE as well. Guards against a future-only refactor.
+    [Fact]
+    public async Task SigV4aHeaderAuthentication_FutureTimestampOutsideClockSkew_ReturnsRequestTimeTooSkewed()
+    {
+        const string accessKeyId = "sigv4a-header-future-access";
+        const string secretAccessKey = "sigv4a-header-future-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4aHeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(6));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("RequestTimeTooSkewed", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
+    // Regression for #113: proves the SigV4a skew barrier is a boundary and not a blanket rejection —
+    // a request timestamped inside the allowed window must still authenticate.
+    [Fact]
+    public async Task SigV4aHeaderAuthentication_TimestampWithinClockSkew_Succeeds()
+    {
+        const string accessKeyId = "sigv4a-header-within-skew-access";
+        const string secretAccessKey = "sigv4a-header-within-skew-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4aHeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-2));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    // Regression for #113: the SigV4a header path must reject a request carrying neither x-amz-date
+    // nor a Date fallback (issue #133) with AccessDenied. The signed request is built normally, then
+    // x-amz-date is stripped so no valid request timestamp can be resolved. (The signature still lists
+    // x-amz-date in SignedHeaders, but the absent-timestamp check runs before canonical-request
+    // construction, so AccessDenied — not SignatureDoesNotMatch — is returned.)
+    [Fact]
+    public async Task SigV4aHeaderAuthentication_WithNeitherXAmzDateNorDate_ReturnsAccessDenied()
+    {
+        const string accessKeyId = "sigv4a-header-nodate-access";
+        const string secretAccessKey = "sigv4a-header-nodate-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4aHeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey);
+        request.Headers.Remove("x-amz-date");
+        Assert.False(request.Headers.Contains("x-amz-date"));
+        Assert.False(request.Headers.Contains("date"));
+
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var errorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("AccessDenied", GetRequiredElementValue(errorDocument, "Code"));
+    }
+
     // ── Presigned-query SigV4a ──────────────────────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## Summary

Closes #113.

The primary (`Authorization`-header) SigV4 and SigV4a authentication paths are the only replay barrier for header-signed requests, yet the header-path freshness checks had **no** regression coverage:

- **Clock skew** (`IsOutsideAllowedClockSkew`, symmetric via `.Duration()`) → `RequestTimeTooSkewed`. The sole prior `RequestTimeTooSkewed` assertion drove the *presigned-query, future-only* path — not the header path, and not SigV4a at all.
- **Absent request timestamp** → `AccessDenied`. Only the SigV4 header case was covered; SigV4a was not.

A silent weakening of the header skew window (e.g. a refactor dropping `.Duration()`, inverting the comparison, or omitting the check) would have shipped with a green suite.

## What this adds

Conformance tests (no production changes), reusing the existing `signedAtUtc`-injecting signing helpers so each builds a real signed request:

**SigV4 header path** (`IntegratedS3SigV4ConformanceTests`)
- stale `x-amz-date` (too far in the past) → `RequestTimeTooSkewed`
- future `x-amz-date` (guards the `.Duration()` symmetry) → `RequestTimeTooSkewed`
- timestamp just inside the window → succeeds (proves it's a boundary, not a blanket reject)

**SigV4a header path** (`IntegratedS3SigV4aConformanceTests`)
- stale / future `x-amz-date` → `RequestTimeTooSkewed`
- within-window → succeeds
- neither `x-amz-date` nor `Date` fallback (per #133) → `AccessDenied`

Already-covered cases were intentionally not duplicated: SigV4 absent-date `AccessDenied`, the #133 `Date` fallback happy path, and the #132 presigned-expiry-not-extended-by-skew regression.

## Verification

- `dotnet build` clean; full `IntegratedS3.Tests` suite green (**1223 passed, 0 failed**).
- Non-vacuous check: temporarily mutating `IsOutsideAllowedClockSkew` to a future-only comparison makes both stale tests fail (`Expected: Forbidden, Actual: OK`), confirming they exercise the symmetric barrier. Mutation reverted; production code is untouched (`git diff` over `IntegratedS3.AspNetCore` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)