### PR TITLE
perf: route EF catalog/multipart JSON columns through a source-generated JsonSerializerContext

### DIFF
--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Serialization/EntityFrameworkCatalogJsonSerializerContext.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Serialization/EntityFrameworkCatalogJsonSerializerContext.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace IntegratedS3.EntityFramework.Serialization;
+
+/// <summary>
+/// Source-generated <see cref="JsonSerializerContext"/> for the JSON columns persisted by the EntityFramework
+/// catalog/multipart stores (the <c>MetadataJson</c>, <c>TagsJson</c> and <c>ChecksumsJson</c> string columns).
+/// Routing those (de)serialize calls through the generated <see cref="Default"/> instance keeps the stores off the
+/// reflection-based <see cref="System.Text.Json.JsonSerializer"/> resolver, matching the source-generated pattern
+/// used everywhere else in the solution (e.g. <c>DiskStorageJsonSerializerContext</c>).
+/// </summary>
+/// <remarks>
+/// The generator is configured with default options (no property-name policy, no custom converters) so the emitted
+/// JSON shape is byte-for-byte identical to the previous reflection-based path — existing stored rows still
+/// round-trip. The stored value type is <see cref="Dictionary{TKey,TValue}"/>: the write side materializes a
+/// concrete dictionary from the <c>IReadOnlyDictionary&lt;string, string&gt;</c> source properties, and the read
+/// side already deserializes into <see cref="Dictionary{TKey,TValue}"/>.
+/// </remarks>
+[JsonSourceGenerationOptions]
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal partial class EntityFrameworkCatalogJsonSerializerContext : JsonSerializerContext
+{
+}

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageCatalogStore.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageCatalogStore.cs
@@ -4,6 +4,7 @@ using IntegratedS3.Core.Models;
 using IntegratedS3.Core.Options;
 using IntegratedS3.Core.Persistence;
 using IntegratedS3.Core.Services;
+using IntegratedS3.EntityFramework.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -254,9 +255,9 @@ internal sealed class EntityFrameworkStorageCatalogStore<TDbContext>(
             record.ExpiresUtc = @object.ExpiresUtc;
             record.ETag = @object.ETag;
             record.LastModifiedUtc = @object.LastModifiedUtc;
-            record.MetadataJson = @object.Metadata is null ? null : JsonSerializer.Serialize(@object.Metadata);
-            record.TagsJson = @object.Tags is null ? null : JsonSerializer.Serialize(@object.Tags);
-            record.ChecksumsJson = @object.Checksums is null ? null : JsonSerializer.Serialize(@object.Checksums);
+            record.MetadataJson = SerializeDictionary(@object.Metadata);
+            record.TagsJson = SerializeDictionary(@object.Tags);
+            record.ChecksumsJson = SerializeDictionary(@object.Checksums);
             record.RetentionMode = @object.RetentionMode;
             record.RetainUntilDateUtc = @object.RetainUntilDateUtc;
             record.LegalHoldStatus = @object.LegalHoldStatus;
@@ -376,15 +377,9 @@ internal sealed class EntityFrameworkStorageCatalogStore<TDbContext>(
                 ExpiresUtc = @object.ExpiresUtc,
                 ETag = @object.ETag,
                 LastModifiedUtc = @object.LastModifiedUtc,
-                Metadata = string.IsNullOrWhiteSpace(@object.MetadataJson)
-                    ? null
-                    : JsonSerializer.Deserialize<Dictionary<string, string>>(@object.MetadataJson),
-                Tags = string.IsNullOrWhiteSpace(@object.TagsJson)
-                    ? null
-                    : JsonSerializer.Deserialize<Dictionary<string, string>>(@object.TagsJson),
-                Checksums = string.IsNullOrWhiteSpace(@object.ChecksumsJson)
-                    ? null
-                    : JsonSerializer.Deserialize<Dictionary<string, string>>(@object.ChecksumsJson),
+                Metadata = DeserializeDictionary(@object.MetadataJson),
+                Tags = DeserializeDictionary(@object.TagsJson),
+                Checksums = DeserializeDictionary(@object.ChecksumsJson),
                 RetentionMode = @object.RetentionMode,
                 RetainUntilDateUtc = @object.RetainUntilDateUtc,
                 LegalHoldStatus = @object.LegalHoldStatus,
@@ -397,6 +392,32 @@ internal sealed class EntityFrameworkStorageCatalogStore<TDbContext>(
                     : null,
                 LastSyncedAtUtc = @object.LastSyncedAtUtc
         };
+
+    /// <summary>
+    /// Serializes a metadata/tags/checksums dictionary to its JSON-column representation via the source-generated
+    /// <see cref="EntityFrameworkCatalogJsonSerializerContext"/>, returning <see langword="null"/> for a null source
+    /// so the column stays NULL. The source is materialized into a concrete <see cref="Dictionary{TKey,TValue}"/>
+    /// (when it is not already one) so the generated <see cref="Dictionary{TKey,TValue}"/> type info applies; with
+    /// default options this yields the same JSON shape as the previous reflection-based path.
+    /// </summary>
+    private static string? SerializeDictionary(IReadOnlyDictionary<string, string>? source)
+    {
+        if (source is null) {
+            return null;
+        }
+
+        var dictionary = source as Dictionary<string, string> ?? new Dictionary<string, string>(source);
+        return JsonSerializer.Serialize(dictionary, EntityFrameworkCatalogJsonSerializerContext.Default.DictionaryStringString);
+    }
+
+    /// <summary>
+    /// Deserializes a JSON-column value back into a dictionary via the source-generated
+    /// <see cref="EntityFrameworkCatalogJsonSerializerContext"/>, treating null/blank input as "no value".
+    /// </summary>
+    private static Dictionary<string, string>? DeserializeDictionary(string? json)
+        => string.IsNullOrWhiteSpace(json)
+            ? null
+            : JsonSerializer.Deserialize(json, EntityFrameworkCatalogJsonSerializerContext.Default.DictionaryStringString);
 
     private async Task EnsureInitializedAsync(CancellationToken cancellationToken)
     {

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageMultipartStateStore.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageMultipartStateStore.cs
@@ -5,6 +5,7 @@ using IntegratedS3.Abstractions.Models;
 using IntegratedS3.Abstractions.Services;
 using IntegratedS3.Core.Options;
 using IntegratedS3.Core.Persistence;
+using IntegratedS3.EntityFramework.Serialization;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
@@ -117,8 +118,8 @@ internal sealed class EntityFrameworkStorageMultipartStateStore<TDbContext>(
         record.ContentLanguage = state.ContentLanguage;
         record.ExpiresUtc = state.ExpiresUtc;
         record.ChecksumAlgorithm = state.ChecksumAlgorithm;
-        record.MetadataJson = state.Metadata is null ? null : JsonSerializer.Serialize(state.Metadata);
-        record.TagsJson = state.Tags is null ? null : JsonSerializer.Serialize(state.Tags);
+        record.MetadataJson = SerializeDictionary(state.Metadata);
+        record.TagsJson = SerializeDictionary(state.Tags);
         record.LastSyncedAtUtc = DateTimeOffset.UtcNow;
 
         if (isNew)
@@ -206,12 +207,34 @@ internal sealed class EntityFrameworkStorageMultipartStateStore<TDbContext>(
             ContentLanguage = record.ContentLanguage,
             ExpiresUtc = record.ExpiresUtc,
             ChecksumAlgorithm = record.ChecksumAlgorithm,
-            Metadata = string.IsNullOrWhiteSpace(record.MetadataJson)
-                ? null
-                : JsonSerializer.Deserialize<Dictionary<string, string>>(record.MetadataJson),
-            Tags = string.IsNullOrWhiteSpace(record.TagsJson)
-                ? null
-                : JsonSerializer.Deserialize<Dictionary<string, string>>(record.TagsJson)
+            Metadata = DeserializeDictionary(record.MetadataJson),
+            Tags = DeserializeDictionary(record.TagsJson)
         };
     }
+
+    /// <summary>
+    /// Serializes a metadata/tags dictionary to its JSON-column representation via the source-generated
+    /// <see cref="EntityFrameworkCatalogJsonSerializerContext"/>, returning <see langword="null"/> for a null source
+    /// so the column stays NULL. The source is materialized into a concrete <see cref="Dictionary{TKey,TValue}"/>
+    /// (when it is not already one) so the generated type info applies; with default options this yields the same
+    /// JSON shape as the previous reflection-based path.
+    /// </summary>
+    private static string? SerializeDictionary(IReadOnlyDictionary<string, string>? source)
+    {
+        if (source is null) {
+            return null;
+        }
+
+        var dictionary = source as Dictionary<string, string> ?? new Dictionary<string, string>(source);
+        return JsonSerializer.Serialize(dictionary, EntityFrameworkCatalogJsonSerializerContext.Default.DictionaryStringString);
+    }
+
+    /// <summary>
+    /// Deserializes a JSON-column value back into a dictionary via the source-generated
+    /// <see cref="EntityFrameworkCatalogJsonSerializerContext"/>, treating null/blank input as "no value".
+    /// </summary>
+    private static Dictionary<string, string>? DeserializeDictionary(string? json)
+        => string.IsNullOrWhiteSpace(json)
+            ? null
+            : JsonSerializer.Deserialize(json, EntityFrameworkCatalogJsonSerializerContext.Default.DictionaryStringString);
 }

--- a/src/IntegratedS3/IntegratedS3.Tests/EntityFrameworkCatalogAtomicityTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/EntityFrameworkCatalogAtomicityTests.cs
@@ -244,6 +244,140 @@ public sealed class EntityFrameworkCatalogAtomicityTests : IDisposable
         Assert.Contains("LIMIT", objectSelect, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task UpsertObjectAsync_RoundTripsMetadataTagsChecksums_ThroughSourceGeneratedJsonColumns()
+    {
+        // Issue #140: the Metadata/Tags/Checksums JSON columns are now (de)serialized through the
+        // source-generated EntityFrameworkCatalogJsonSerializerContext. Persisting an object with all three
+        // dictionaries populated and reading it back on a fresh scope/DbContext must return them intact, proving
+        // the generated serialize AND deserialize paths agree with each other end-to-end.
+        const string key = "docs/meta.txt";
+        var metadata = new Dictionary<string, string> { ["x-amz-meta-owner"] = "alice", ["x-amz-meta-team"] = "storage" };
+        var tags = new Dictionary<string, string> { ["env"] = "prod", ["tier"] = "hot" };
+        var checksums = new Dictionary<string, string> { ["CRC32"] = "AAAAAA==", ["SHA256"] = "deadbeef" };
+
+        await using (var seedProvider = BuildProvider()) {
+            var seedStore = seedProvider.GetRequiredService<IStorageCatalogStore>();
+            var @object = new ObjectInfo
+            {
+                BucketName = "catalog-bucket",
+                Key = key,
+                VersionId = "version-001",
+                IsLatest = true,
+                ContentLength = 16,
+                LastModifiedUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z"),
+                Metadata = metadata,
+                Tags = tags,
+                Checksums = checksums
+            };
+            await seedStore.UpsertObjectAsync("catalog-disk", @object);
+        }
+
+        // Read back on a brand-new provider so nothing is served from an in-memory cache.
+        await using var verifyProvider = BuildProvider();
+        var verifyStore = verifyProvider.GetRequiredService<IStorageCatalogStore>();
+        var stored = Assert.Single(await verifyStore.ListObjectsAsync("catalog-disk", "catalog-bucket"), o => o.Key == key);
+
+        Assert.NotNull(stored.Metadata);
+        Assert.NotNull(stored.Tags);
+        Assert.NotNull(stored.Checksums);
+        Assert.Equal(metadata, stored.Metadata!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+        Assert.Equal(tags, stored.Tags!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+        Assert.Equal(checksums, stored.Checksums!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+    }
+
+    [Fact]
+    public async Task UpsertObjectAsync_NullDictionaries_PersistAsNullColumns_AndReadBackAsNull()
+    {
+        // The write side must keep the JSON columns NULL when the source dictionaries are null (the source-gen
+        // helper returns null for a null source), and the read side must surface them as null rather than empty.
+        const string key = "docs/nometa.txt";
+
+        await using (var seedProvider = BuildProvider()) {
+            var seedStore = seedProvider.GetRequiredService<IStorageCatalogStore>();
+            await seedStore.UpsertObjectAsync("catalog-disk", NewObject(key, "version-001", isLatest: true));
+        }
+
+        await using var verifyProvider = BuildProvider();
+        var verifyStore = verifyProvider.GetRequiredService<IStorageCatalogStore>();
+        var stored = Assert.Single(await verifyStore.ListObjectsAsync("catalog-disk", "catalog-bucket"), o => o.Key == key);
+
+        Assert.Null(stored.Metadata);
+        Assert.Null(stored.Tags);
+        Assert.Null(stored.Checksums);
+    }
+
+    [Fact]
+    public async Task UpsertObjectAsync_PersistsMetadataJson_ByteIdenticalToReflectionBaseline()
+    {
+        // Issue #140 compat guarantee: routing through the source-generated context must not change the stored
+        // JSON shape. Read the raw MetadataJson column straight out of SQLite and assert it matches what the
+        // previous reflection-based System.Text.Json path (default options) would have produced for the same
+        // dictionary, so existing persisted rows keep round-tripping.
+        const string key = "docs/shape.txt";
+        var metadata = new Dictionary<string, string> { ["x-amz-meta-owner"] = "alice", ["x-amz-meta-team"] = "storage" };
+        var reflectionBaseline = System.Text.Json.JsonSerializer.Serialize(metadata);
+
+        await using var provider = BuildProvider();
+        var store = provider.GetRequiredService<IStorageCatalogStore>();
+        await store.UpsertObjectAsync("catalog-disk", new ObjectInfo
+        {
+            BucketName = "catalog-bucket",
+            Key = key,
+            VersionId = "version-001",
+            IsLatest = true,
+            ContentLength = 16,
+            LastModifiedUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z"),
+            Metadata = metadata
+        });
+
+        await using var scope = provider.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TestCatalogDbContext>();
+        await using var connection = dbContext.Database.GetDbConnection();
+        await connection.OpenAsync();
+        await using var command = connection.CreateCommand();
+        command.CommandText = "SELECT MetadataJson FROM IntegratedS3Objects WHERE Key = $key";
+        var keyParameter = command.CreateParameter();
+        keyParameter.ParameterName = "$key";
+        keyParameter.Value = key;
+        command.Parameters.Add(keyParameter);
+        var persistedJson = (string?)await command.ExecuteScalarAsync();
+
+        Assert.Equal(reflectionBaseline, persistedJson);
+    }
+
+    [Fact]
+    public async Task MultipartUploadState_RoundTripsMetadataAndTags_ThroughSourceGeneratedJsonColumns()
+    {
+        // Issue #140: the multipart-state store's Metadata/Tags JSON columns route through the same source-generated
+        // context. Persist a state with both populated and read it back on a fresh scope to prove the round-trip.
+        var metadata = new Dictionary<string, string> { ["x-amz-meta-source"] = "upload" };
+        var tags = new Dictionary<string, string> { ["stage"] = "in-progress" };
+
+        await using (var seedProvider = BuildProvider()) {
+            var seedStore = seedProvider.GetRequiredService<IStorageMultipartStateStore>();
+            await seedStore.UpsertMultipartUploadStateAsync("catalog-disk", new MultipartUploadState
+            {
+                BucketName = "catalog-bucket",
+                Key = "docs/big.bin",
+                UploadId = "upload-001",
+                InitiatedAtUtc = DateTimeOffset.Parse("2026-03-01T00:00:00Z"),
+                Metadata = metadata,
+                Tags = tags
+            });
+        }
+
+        await using var verifyProvider = BuildProvider();
+        var verifyStore = verifyProvider.GetRequiredService<IStorageMultipartStateStore>();
+        var stored = await verifyStore.GetMultipartUploadStateAsync("catalog-disk", "catalog-bucket", "docs/big.bin", "upload-001");
+
+        Assert.NotNull(stored);
+        Assert.NotNull(stored!.Metadata);
+        Assert.NotNull(stored.Tags);
+        Assert.Equal(metadata, stored.Metadata!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+        Assert.Equal(tags, stored.Tags!.ToDictionary(kvp => kvp.Key, kvp => kvp.Value));
+    }
+
     private sealed class TestCatalogDbContext(DbContextOptions<TestCatalogDbContext> options) : DbContext(options)
     {
         protected override void OnModelCreating(ModelBuilder modelBuilder)


### PR DESCRIPTION
## Summary

Closes #140.

The EntityFramework catalog and multipart-state stores were the last JSON call sites in the solution still using the reflection-based `JsonSerializer.Serialize`/`Deserialize<T>` overloads for their `Metadata`/`Tags`/`Checksums` string columns, deviating from the source-generated pattern used everywhere else (`DiskStorageJsonSerializerContext`, client/AspNetCore/benchmark contexts) and violating the project's own guidelines in `.github/copilot-instructions.md` ("Use source-generated serialization … Do not introduce reflection-heavy JSON approaches").

## Changes

- **New** `IntegratedS3.EntityFramework/Serialization/EntityFrameworkCatalogJsonSerializerContext.cs` — a partial `JsonSerializerContext` registering `Dictionary<string, string>` with a default `[JsonSourceGenerationOptions]` (no name policy / converters), so the emitted JSON shape is byte-for-byte identical to the previous reflection path.
- **`EntityFrameworkStorageCatalogStore`** — the three serialize sites (`UpsertObjectAsync`) and three deserialize sites (`ProjectEntry`) now route through `Context.Default.DictionaryStringString` via `SerializeDictionary`/`DeserializeDictionary` helpers.
- **`EntityFrameworkStorageMultipartStateStore`** — the two serialize sites (`UpsertMultipartUploadStateAsync`) and two deserialize sites (`ToMultipartUploadState`) routed the same way.
- The serialize helper materializes a concrete `Dictionary<string, string>` from the `IReadOnlyDictionary<string, string>?` source properties so the generated type info applies; a null source keeps the column NULL (unchanged behavior).

## Compatibility

Same property names, casing, and (default) options ⇒ the persisted JSON is unchanged. Existing stored rows still deserialize.

## Tests

Four regression tests added to `EntityFrameworkCatalogAtomicityTests` (real file-backed SQLite):
- round-trip of `Metadata`/`Tags`/`Checksums` through the catalog store,
- null dictionaries persist as NULL columns and read back as null,
- the persisted `MetadataJson` column is byte-identical to the reflection baseline (`JsonSerializer.Serialize(dict)`),
- round-trip of multipart `Metadata`/`Tags`.

`dotnet build src/IntegratedS3/IntegratedS3.slnx -c Debug` — 0 warnings, 0 errors (no source-generator warnings).
`dotnet test IntegratedS3.Tests` — **1220 passed**, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)