### PR TITLE
fix: align SigV4 defaults with AWS — 15-min skew, 604800s presigned-expiry cap

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/IntegratedS3Options.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/IntegratedS3Options.cs
@@ -48,9 +48,10 @@ public sealed class IntegratedS3Options
     public string SignatureAuthenticationService { get; set; } = "s3";
 
     /// <summary>
-    /// Maximum clock skew tolerance in minutes for SigV4 authentication. Defaults to <c>5</c>.
+    /// Maximum clock skew tolerance in minutes for SigV4 authentication. Defaults to <c>15</c>,
+    /// matching the AWS S3 <c>RequestTimeTooSkewed</c> tolerance of ±15 minutes.
     /// </summary>
-    public int AllowedSignatureClockSkewMinutes { get; set; } = 5;
+    public int AllowedSignatureClockSkewMinutes { get; set; } = 15;
 
     /// <summary>
     /// Maximum allowed expiry for presigned URLs in seconds. Defaults to <c>3600</c> (1 hour).

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsSignatureV4RequestAuthenticator.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Services/AwsSignatureV4RequestAuthenticator.cs
@@ -31,6 +31,14 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
     private const string StreamingSigV4aPayloadTrailer = "STREAMING-AWS4-ECDSA-P256-SHA256-PAYLOAD-TRAILER";
     private const string StreamingUnsignedPayloadTrailer = "STREAMING-UNSIGNED-PAYLOAD-TRAILER";
 
+    /// <summary>
+    /// AWS-parity hard ceiling for the presigned-URL <c>X-Amz-Expires</c> value: 604800 seconds
+    /// (7 days). AWS S3 rejects any larger value with <c>AuthorizationQueryParametersError</c>
+    /// regardless of server configuration, so this bound is enforced independently of the
+    /// configurable <see cref="IntegratedS3Options.MaximumPresignedUrlExpirySeconds"/>.
+    /// </summary>
+    private const int MaximumPresignedUrlExpiryHardCapSeconds = 604800;
+
     public async ValueTask<IntegratedS3RequestAuthenticationResult> AuthenticateAsync(HttpContext httpContext, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(httpContext);
@@ -196,6 +204,10 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
 
         if (!TryValidateCredentialScope(presignedRequest.CredentialScope, settings, out var scopeError, out var statusCode)) {
             return IntegratedS3RequestAuthenticationResult.Failure("AuthorizationQueryParametersError", scopeError!, statusCode);
+        }
+
+        if (presignedRequest.ExpiresSeconds > MaximumPresignedUrlExpiryHardCapSeconds) {
+            return IntegratedS3RequestAuthenticationResult.Failure("AuthorizationQueryParametersError", $"X-Amz-Expires must be less than or equal to {MaximumPresignedUrlExpiryHardCapSeconds} seconds.", statusCode: 400);
         }
 
         if (presignedRequest.ExpiresSeconds > settings.MaximumPresignedUrlExpirySeconds) {
@@ -444,6 +456,10 @@ internal sealed class AwsSignatureV4RequestAuthenticator(
 
         if (!TryValidateSigV4aRegionSet(presignedRequest.RegionSet, settings, out var regionError, out statusCode)) {
             return IntegratedS3RequestAuthenticationResult.Failure("AuthorizationQueryParametersError", regionError!, statusCode);
+        }
+
+        if (presignedRequest.ExpiresSeconds > MaximumPresignedUrlExpiryHardCapSeconds) {
+            return IntegratedS3RequestAuthenticationResult.Failure("AuthorizationQueryParametersError", $"X-Amz-Expires must be less than or equal to {MaximumPresignedUrlExpiryHardCapSeconds} seconds.", statusCode: 400);
         }
 
         if (presignedRequest.ExpiresSeconds > settings.MaximumPresignedUrlExpirySeconds) {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4ConformanceTests.cs
@@ -1943,6 +1943,96 @@ public sealed class IntegratedS3SigV4ConformanceTests : IClassFixture<WebUiAppli
         Assert.Contains("60", GetRequiredElementValue(errorDocument, "Message"), StringComparison.Ordinal);
     }
 
+    // Regression for #161: AWS S3 caps X-Amz-Expires at 604800 seconds (7 days) and rejects any
+    // larger value with AuthorizationQueryParametersError regardless of server configuration. The
+    // hard cap must apply even when the operator raises MaximumPresignedUrlExpirySeconds above it.
+    [Fact]
+    public async Task SigV4PresignedQueryAuthentication_ExpiryBeyondAwsHardCap_ReturnsXmlError()
+    {
+        const string accessKeyId = "sigv4-hardcap-access";
+        const string secretAccessKey = "sigv4-hardcap-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(
+            accessKeyId,
+            secretAccessKey,
+            // Configure a maximum well above the AWS hard cap so only the hard cap can reject.
+            options => options.MaximumPresignedUrlExpirySeconds = 604800 * 4);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4PresignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/buckets/hardcap-bucket/objects/docs/hardcap.txt",
+            accessKeyId,
+            secretAccessKey,
+            expiresSeconds: 604801);
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+        var hardCapErrorDocument = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("AuthorizationQueryParametersError", GetRequiredElementValue(hardCapErrorDocument, "Code"));
+        Assert.Contains("604800", GetRequiredElementValue(hardCapErrorDocument, "Message"), StringComparison.Ordinal);
+    }
+
+    // Regression for #161: X-Amz-Expires exactly at the AWS hard cap (604800) must be accepted; the
+    // ceiling is inclusive. This guards the boundary against an off-by-one that would reject 7-day URLs.
+    [Fact]
+    public async Task SigV4PresignedQueryAuthentication_ExpiryExactlyAtAwsHardCap_IsAccepted()
+    {
+        const string accessKeyId = "sigv4-hardcap-boundary-access";
+        const string secretAccessKey = "sigv4-hardcap-boundary-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(
+            accessKeyId,
+            secretAccessKey,
+            options => options.MaximumPresignedUrlExpirySeconds = 604800 * 4);
+        using var client = isolatedClient.Client;
+
+        await CreateBucketAsync(client, accessKeyId, secretAccessKey, "hardcap-boundary-bucket");
+
+        using var request = CreateSigV4PresignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/buckets/hardcap-boundary-bucket/objects/docs/missing.txt",
+            accessKeyId,
+            secretAccessKey,
+            expiresSeconds: 604800);
+        var response = await client.SendAsync(request);
+
+        // A 604800s expiry passes the auth cap; the request reaches storage and 404s on the missing
+        // object rather than being rejected at authorization with a 400 AuthorizationQueryParametersError.
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task SigV4HeaderAuthentication_TimestampWithinDefaultFifteenMinuteSkew_Succeeds()
+    {
+        // Regression for #161: the default AllowedSignatureClockSkewMinutes is 15 (AWS parity), not 5.
+        // A request signed ~10 minutes ago — which the old 5-minute default rejected — must now pass
+        // WITHOUT any explicit skew override on the options.
+        const string accessKeyId = "sigv4-default-skew-access";
+        const string secretAccessKey = "sigv4-default-skew-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedClientAsync(accessKeyId, secretAccessKey);
+        using var client = isolatedClient.Client;
+
+        using var request = CreateSigV4HeaderSignedRequest(
+            HttpMethod.Get,
+            "/integrated-s3/",
+            accessKeyId,
+            secretAccessKey,
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-10));
+        var response = await client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public void IntegratedS3Options_AllowedSignatureClockSkewMinutes_DefaultsToAwsFifteenMinutes()
+    {
+        // Regression for #161: default clock-skew tolerance matches the AWS S3 ±15-minute window.
+        Assert.Equal(15, new IntegratedS3Options().AllowedSignatureClockSkewMinutes);
+    }
+
     [Fact]
     public async Task SigV4PresignedQueryAuthentication_FutureTimestampOutsideClockSkew_ReturnsXmlError()
     {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4aConformanceTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3SigV4aConformanceTests.cs
@@ -152,7 +152,8 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
     // Regression for #113: the SigV4a header path shares the same symmetric clock-skew barrier as
     // SigV4 (IsOutsideAllowedClockSkew) but had zero coverage. A request whose x-amz-date is too far
     // in the PAST — a captured, replayed request — must be rejected with RequestTimeTooSkewed.
-    // Default AllowedSignatureClockSkewMinutes is 5, so a 6-minute-stale timestamp is outside it.
+    // Default AllowedSignatureClockSkewMinutes is 15 (AWS parity), so a 20-minute-stale timestamp is
+    // outside it.
     [Fact]
     public async Task SigV4aHeaderAuthentication_StaleTimestampOutsideClockSkew_ReturnsRequestTimeTooSkewed()
     {
@@ -167,7 +168,7 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
             "/integrated-s3/",
             accessKeyId,
             secretAccessKey,
-            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-6));
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(-20));
         var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
@@ -192,7 +193,7 @@ public sealed class IntegratedS3SigV4aConformanceTests : IClassFixture<WebUiAppl
             "/integrated-s3/",
             accessKeyId,
             secretAccessKey,
-            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(6));
+            signedAtUtc: DateTimeOffset.UtcNow.AddMinutes(20));
         var response = await client.SendAsync(request);
 
         Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);


### PR DESCRIPTION
Closes #161

## What
Two SigV4 auth defaults diverged from AWS S3; this aligns both while keeping the skew configurable.

### 1. Clock-skew default 5 → 15 min
`IntegratedS3Options.AllowedSignatureClockSkewMinutes` defaulted to `5`. AWS S3 uses a ±15-minute window before `RequestTimeTooSkewed`, so a client with 6–14 min of drift that AWS accepts was rejected. Default is now `15` (still operator-configurable).

### 2. `604800`s hard cap on presigned `X-Amz-Expires`
Previously only the configurable `MaximumPresignedUrlExpirySeconds` bounded presigned expiry. AWS rejects `X-Amz-Expires > 604800` (7 days) with `AuthorizationQueryParametersError` **regardless of server config**. A config-independent hard cap (`604800`) is now enforced on both the SigV4 and SigV4a presigned paths, evaluated before the configurable-max check.

The #132 invariant (clock-skew tolerance must not extend the presigned URL's stated lifetime) is preserved — the cap is a pure upper bound on the declared `X-Amz-Expires`.

## Tests
- `IntegratedS3Options_AllowedSignatureClockSkewMinutes_DefaultsToAwsFifteenMinutes` — asserts the option default.
- `SigV4HeaderAuthentication_TimestampWithinDefaultFifteenMinuteSkew_Succeeds` — a ~10-min-skewed request (rejected under the old 5-min default) now authenticates with no override.
- `SigV4PresignedQueryAuthentication_ExpiryBeyondAwsHardCap_ReturnsXmlError` — `X-Amz-Expires=604801` rejected with `AuthorizationQueryParametersError` even when the configured max is set well above the cap.
- `SigV4PresignedQueryAuthentication_ExpiryExactlyAtAwsHardCap_IsAccepted` — `604800` (inclusive boundary) passes auth and reaches storage.
- Two pre-existing SigV4a skew tests that used ±6-min timestamps against the old 5-min default were bumped to ±20 min so they still exercise the out-of-window rejection.

Full suite: **1237 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)