### PR TITLE
fix: persist and echo x-amz-storage-class on GET/HEAD/List (#155)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/MultipartUploadState.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/MultipartUploadState.cs
@@ -76,4 +76,9 @@ public class MultipartUploadState
     /// The checksum algorithm specified at upload initiation, or <see langword="null"/> if none was specified.
     /// </summary>
     public string? ChecksumAlgorithm { get; init; }
+
+    /// <summary>
+    /// The storage class specified at upload initiation, or <see langword="null"/> if none was specified.
+    /// </summary>
+    public string? StorageClass { get; init; }
 }

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/ObjectInfo.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/ObjectInfo.cs
@@ -122,4 +122,10 @@ public sealed class ObjectInfo
     /// Customer-provided encryption information for the object.
     /// </summary>
     public ObjectCustomerEncryptionInfo? CustomerEncryption { get; init; }
+
+    /// <summary>
+    /// The storage class of the object (e.g. <c>STANDARD</c>, <c>STANDARD_IA</c>, <c>GLACIER</c>), or
+    /// <see langword="null"/> when it was not persisted (treated as <c>STANDARD</c> by read paths).
+    /// </summary>
+    public string? StorageClass { get; init; }
 }

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/StorageClass.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/StorageClass.cs
@@ -1,0 +1,51 @@
+namespace IntegratedS3.Abstractions.Models;
+
+/// <summary>
+/// Helpers for the S3 <c>x-amz-storage-class</c> value: the canonical set of storage classes, the
+/// default (<c>STANDARD</c>), validation, and normalization for persistence and echo.
+/// </summary>
+public static class StorageClass
+{
+    /// <summary>The default storage class applied when a request does not specify one.</summary>
+    public const string Standard = "STANDARD";
+
+    /// <summary>
+    /// The set of storage-class values accepted on write. Mirrors the values AWS S3 accepts for the
+    /// <c>x-amz-storage-class</c> header.
+    /// </summary>
+    private static readonly HashSet<string> Known = new(StringComparer.Ordinal)
+    {
+        "STANDARD",
+        "REDUCED_REDUNDANCY",
+        "STANDARD_IA",
+        "ONEZONE_IA",
+        "INTELLIGENT_TIERING",
+        "GLACIER",
+        "DEEP_ARCHIVE",
+        "GLACIER_IR",
+        "SNOW",
+        "EXPRESS_ONEZONE",
+    };
+
+    /// <summary>
+    /// Determines whether <paramref name="value"/> is a recognized storage class. A null or
+    /// whitespace value is treated as valid because it means "unspecified" (defaults to STANDARD).
+    /// </summary>
+    public static bool IsKnown(string? value)
+        => string.IsNullOrWhiteSpace(value) || Known.Contains(value);
+
+    /// <summary>
+    /// Normalizes a stored/read storage-class value for echo: a null, whitespace, or unrecognized
+    /// value collapses to <see cref="Standard"/> so read paths always report a concrete class.
+    /// </summary>
+    public static string NormalizeForEcho(string? value)
+        => string.IsNullOrWhiteSpace(value) ? Standard : value;
+
+    /// <summary>
+    /// Returns <see langword="true"/> when the resolved storage class differs from <see cref="Standard"/>.
+    /// AWS omits the <c>x-amz-storage-class</c> response header on GET/HEAD for STANDARD objects and
+    /// emits it only for non-STANDARD classes.
+    /// </summary>
+    public static bool IsNonStandard(string? value)
+        => !string.Equals(NormalizeForEcho(value), Standard, StringComparison.Ordinal);
+}

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -1344,6 +1344,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                             return destinationCustomerEncryptionError;
                         }
 
+                        if (!TryReadStorageClassHeader(httpContext, bucketName, key, out var copyStorageClass, out var copyStorageClassError)) {
+                            return copyStorageClassError!;
+                        }
+
                         var copyResult = await storageService.CopyObjectAsync(new CopyObjectRequest
                         {
                             SourceBucketName = copySource!.BucketName,
@@ -1371,7 +1375,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                             DestinationServerSideEncryption = copyServerSideEncryption,
                             SourceCustomerEncryption = sourceCustomerEncryption,
                             DestinationCustomerEncryption = destinationCustomerEncryption,
-                            StorageClass = GetOptionalHeaderValue(request.Headers[StorageClassHeaderName].ToString())
+                            StorageClass = copyStorageClass
                         }, innerCancellationToken);
 
                         if (!copyResult.IsSuccess) {
@@ -1411,6 +1415,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                             BuildObjectResource(bucketName, key), bucketName, key);
                     }
 
+                    if (!TryReadStorageClassHeader(httpContext, bucketName, key, out var putStorageClass, out var putStorageClassError)) {
+                        return putStorageClassError!;
+                    }
+
                     var result = await storageService.PutObjectAsync(new PutObjectRequest
                     {
                         BucketName = bucketName,
@@ -1429,7 +1437,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         Checksums = requestedChecksums,
                         ServerSideEncryption = serverSideEncryption,
                         CustomerEncryption = customerEncryption,
-                        StorageClass = GetOptionalHeaderValue(request.Headers[StorageClassHeaderName].ToString()),
+                        StorageClass = putStorageClass,
                         IfMatchETag = GetOptionalHeaderValue(request.Headers.IfMatch.ToString()),
                         IfNoneMatchETag = GetOptionalHeaderValue(request.Headers.IfNoneMatch.ToString())
                     }, innerCancellationToken);
@@ -2960,6 +2968,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                         BuildObjectResource(bucketName, key), bucketName, key);
                 }
 
+                if (!TryReadStorageClassHeader(httpContext, bucketName, key, out var initiateStorageClass, out var initiateStorageClassError)) {
+                    return initiateStorageClassError!;
+                }
+
                 var result = await storageService.InitiateMultipartUploadAsync(new InitiateMultipartUploadRequest
                 {
                     BucketName = bucketName,
@@ -2976,7 +2988,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     ChecksumAlgorithm = checksumAlgorithm,
                     ServerSideEncryption = serverSideEncryption,
                     CustomerEncryption = customerEncryption,
-                    StorageClass = GetOptionalHeaderValue(httpContext.Request.Headers[StorageClassHeaderName].ToString())
+                    StorageClass = initiateStorageClass
                 }, innerCancellationToken);
 
                 if (!result.IsSuccess) {
@@ -4727,6 +4739,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     ETag = entry.Object.ETag,
                     Size = entry.Object.ContentLength,
                     LastModifiedUtc = entry.Object.LastModifiedUtc,
+                    StorageClass = StorageClass.NormalizeForEcho(entry.Object.StorageClass),
                     Owner = includeOwner ? owner : null
                 })
                 .ToArray(),
@@ -4818,6 +4831,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     ETag = entry.Version.ETag,
                     Size = entry.Version.ContentLength,
                     LastModifiedUtc = entry.Version.LastModifiedUtc,
+                    StorageClass = StorageClass.NormalizeForEcho(entry.Version.StorageClass),
                     Owner = owner
                 })
                 .ToArray(),
@@ -9017,6 +9031,35 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             : rawValue;
     }
 
+    /// <summary>
+    /// Validates the optional <c>x-amz-storage-class</c> request header. Returns the parsed value (or
+    /// null when absent) via <paramref name="storageClass"/>; when the supplied value is not a known
+    /// storage class, produces an <c>InvalidStorageClass</c> (400) error result and returns false.
+    /// </summary>
+    private static bool TryReadStorageClassHeader(
+        HttpContext httpContext,
+        string bucketName,
+        string key,
+        out string? storageClass,
+        out IResult? errorResult)
+    {
+        storageClass = GetOptionalHeaderValue(httpContext.Request.Headers[StorageClassHeaderName].ToString());
+        if (!StorageClass.IsKnown(storageClass)) {
+            errorResult = ToErrorResult(
+                httpContext,
+                StatusCodes.Status400BadRequest,
+                "InvalidStorageClass",
+                "The storage class you specified is not valid.",
+                BuildObjectResource(bucketName, key),
+                bucketName,
+                key);
+            return false;
+        }
+
+        errorResult = null;
+        return true;
+    }
+
     private static void ApplyDeleteObjectHeaders(HttpResponse httpResponse, DeleteObjectResult result)
     {
         ApplyVersionIdHeader(httpResponse, result.VersionId);
@@ -9220,6 +9263,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
         else if (objectInfo.ExpiresUtc is { } expiresUtc) {
             httpResponse.Headers.Expires = expiresUtc.ToString("R");
+        }
+
+        // AWS omits x-amz-storage-class on GET/HEAD for STANDARD objects and emits it only for
+        // non-STANDARD storage classes.
+        if (StorageClass.IsNonStandard(objectInfo.StorageClass)) {
+            httpResponse.Headers[StorageClassHeaderName] = StorageClass.NormalizeForEcho(objectInfo.StorageClass);
         }
     }
 

--- a/src/IntegratedS3/IntegratedS3.Core/Models/StoredObjectEntry.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Models/StoredObjectEntry.cs
@@ -73,6 +73,9 @@ public sealed class StoredObjectEntry
     /// <summary>Server-side encryption information for the object, or <see langword="null"/> if unencrypted.</summary>
     public ObjectServerSideEncryptionInfo? ServerSideEncryption { get; init; }
 
+    /// <summary>The S3 storage class of the object, or <see langword="null"/> when unset (treated as <c>STANDARD</c>).</summary>
+    public string? StorageClass { get; init; }
+
     /// <summary>The UTC date/time when this catalog entry was last synchronized from the provider.</summary>
     public DateTimeOffset LastSyncedAtUtc { get; init; }
 }

--- a/src/IntegratedS3/IntegratedS3.Core/Services/CatalogStorageObjectStateStore.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/CatalogStorageObjectStateStore.cs
@@ -78,7 +78,8 @@ public sealed class CatalogStorageObjectStateStore(IStorageCatalogStore catalogS
             RetentionMode = entry.RetentionMode,
             RetainUntilDateUtc = entry.RetainUntilDateUtc,
             LegalHoldStatus = entry.LegalHoldStatus,
-            ServerSideEncryption = entry.ServerSideEncryption
+            ServerSideEncryption = entry.ServerSideEncryption,
+            StorageClass = entry.StorageClass
         };
     }
 }

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/IntegratedS3CatalogModelBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/IntegratedS3CatalogModelBuilderExtensions.cs
@@ -48,6 +48,7 @@ public static class IntegratedS3CatalogModelBuilderExtensions
             entity.Property(static @object => @object.TagsJson).HasMaxLength(32_768);
             entity.Property(static @object => @object.ChecksumsJson).HasMaxLength(4096);
             entity.Property(static @object => @object.ServerSideEncryptionKeyId).HasMaxLength(512);
+            entity.Property(static @object => @object.StorageClass).HasMaxLength(32);
             entity.Property(static @object => @object.Version).IsConcurrencyToken();
             entity.HasIndex(static @object => new { @object.ProviderName, @object.BucketName, @object.Key, @object.VersionId }).IsUnique();
             // Enforce the "at most one latest version per key" invariant as a hard database constraint so that
@@ -77,6 +78,7 @@ public static class IntegratedS3CatalogModelBuilderExtensions
             entity.Property(static upload => upload.MetadataJson).HasMaxLength(32_768);
             entity.Property(static upload => upload.TagsJson).HasMaxLength(32_768);
             entity.Property(static upload => upload.ChecksumAlgorithm).HasMaxLength(32);
+            entity.Property(static upload => upload.StorageClass).HasMaxLength(32);
             entity.HasIndex(static upload => new { upload.ProviderName, upload.BucketName, upload.Key, upload.UploadId }).IsUnique();
         });
 

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/MultipartUploadCatalogRecord.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/MultipartUploadCatalogRecord.cs
@@ -50,6 +50,9 @@ public sealed class MultipartUploadCatalogRecord
     /// <summary>Gets or sets the checksum algorithm used for part-level integrity verification.</summary>
     public string? ChecksumAlgorithm { get; set; }
 
+    /// <summary>Gets or sets the S3 storage class supplied at initiation, applied to the completed object.</summary>
+    public string? StorageClass { get; set; }
+
     /// <summary>Gets or sets the UTC timestamp of the last catalog synchronization for this upload.</summary>
     public DateTimeOffset LastSyncedAtUtc { get; set; }
 }

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/ObjectCatalogRecord.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/ObjectCatalogRecord.cs
@@ -79,6 +79,9 @@ public sealed class ObjectCatalogRecord
     /// <summary>Gets or sets the server-side encryption key identifier, if applicable.</summary>
     public string? ServerSideEncryptionKeyId { get; set; }
 
+    /// <summary>Gets or sets the S3 storage class of the object, or <see langword="null"/> when unset.</summary>
+    public string? StorageClass { get; set; }
+
     /// <summary>Gets or sets the UTC timestamp of the last catalog synchronization for this object.</summary>
     public DateTimeOffset LastSyncedAtUtc { get; set; }
 

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageCatalogStore.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageCatalogStore.cs
@@ -263,6 +263,7 @@ internal sealed class EntityFrameworkStorageCatalogStore<TDbContext>(
             record.LegalHoldStatus = @object.LegalHoldStatus;
             record.ServerSideEncryptionAlgorithm = @object.ServerSideEncryption?.Algorithm;
             record.ServerSideEncryptionKeyId = @object.ServerSideEncryption?.KeyId;
+            record.StorageClass = @object.StorageClass;
             record.LastSyncedAtUtc = DateTimeOffset.UtcNow;
             // Advance the optimistic-concurrency token so a concurrent update to the same version is detected.
             record.Version = originalVersion + 1;
@@ -390,6 +391,7 @@ internal sealed class EntityFrameworkStorageCatalogStore<TDbContext>(
                         KeyId = @object.ServerSideEncryptionKeyId
                     }
                     : null,
+                StorageClass = @object.StorageClass,
                 LastSyncedAtUtc = @object.LastSyncedAtUtc
         };
 

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageMultipartStateStore.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageMultipartStateStore.cs
@@ -118,6 +118,7 @@ internal sealed class EntityFrameworkStorageMultipartStateStore<TDbContext>(
         record.ContentLanguage = state.ContentLanguage;
         record.ExpiresUtc = state.ExpiresUtc;
         record.ChecksumAlgorithm = state.ChecksumAlgorithm;
+        record.StorageClass = state.StorageClass;
         record.MetadataJson = SerializeDictionary(state.Metadata);
         record.TagsJson = SerializeDictionary(state.Tags);
         record.LastSyncedAtUtc = DateTimeOffset.UtcNow;
@@ -207,6 +208,7 @@ internal sealed class EntityFrameworkStorageMultipartStateStore<TDbContext>(
             ContentLanguage = record.ContentLanguage,
             ExpiresUtc = record.ExpiresUtc,
             ChecksumAlgorithm = record.ChecksumAlgorithm,
+            StorageClass = record.StorageClass,
             Metadata = DeserializeDictionary(record.MetadataJson),
             Tags = DeserializeDictionary(record.TagsJson)
         };

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -2391,7 +2391,10 @@ internal sealed class DiskStorageService(
                 contentEncoding: useReplacementMetadata ? request.ContentEncoding : sourceMetadata.ContentEncoding,
                 contentLanguage: useReplacementMetadata ? request.ContentLanguage : sourceMetadata.ContentLanguage,
                 expiresUtc: useReplacementMetadata ? request.ExpiresUtc : sourceMetadata.ExpiresUtc,
-                expires: useReplacementMetadata ? request.Expires : sourceMetadata.Expires);
+                expires: useReplacementMetadata ? request.Expires : sourceMetadata.Expires,
+                // AWS applies the request's storage class to the copy (defaulting to STANDARD); it does
+                // not preserve the source object's class unless the request repeats it.
+                storageClass: NormalizeStoredStorageClass(request.StorageClass));
         }
         finally {
             if (File.Exists(tempDestinationPath)) {
@@ -2523,7 +2526,8 @@ internal sealed class DiskStorageService(
                 contentEncoding: request.ContentEncoding,
                 contentLanguage: request.ContentLanguage,
                 expiresUtc: request.ExpiresUtc,
-                expires: request.Expires);
+                expires: request.Expires,
+                storageClass: NormalizeStoredStorageClass(request.StorageClass));
         }
         finally {
             if (File.Exists(tempFilePath)) {
@@ -3283,7 +3287,8 @@ internal sealed class DiskStorageService(
                 contentLanguage: uploadState.State.ContentLanguage,
                 expiresUtc: uploadState.State.ExpiresUtc,
                 expires: uploadState.State.Expires,
-                etag: multipartETag);
+                etag: multipartETag,
+                storageClass: NormalizeStoredStorageClass(uploadState.State.StorageClass));
 
             await DeleteStoredMultipartStateAsync(request.BucketName, request.Key, request.UploadId, uploadState.UploadDirectoryPath, cancellationToken);
             DeleteDirectoryIfExists(uploadState.UploadDirectoryPath);
@@ -3364,7 +3369,7 @@ internal sealed class DiskStorageService(
             LastModifiedUtc = obj.LastModifiedUtc,
             ETag = attrs.Any(a => string.Equals(a, "ETag", StringComparison.OrdinalIgnoreCase)) ? obj.ETag : null,
             ObjectSize = attrs.Any(a => string.Equals(a, "ObjectSize", StringComparison.OrdinalIgnoreCase)) ? obj.ContentLength : null,
-            StorageClass = attrs.Any(a => string.Equals(a, "StorageClass", StringComparison.OrdinalIgnoreCase)) ? "STANDARD" : null,
+            StorageClass = attrs.Any(a => string.Equals(a, "StorageClass", StringComparison.OrdinalIgnoreCase)) ? StorageClass.NormalizeForEcho(obj.StorageClass) : null,
             Checksums = attrs.Any(a => string.Equals(a, "Checksum", StringComparison.OrdinalIgnoreCase)) ? obj.Checksums : null,
             ObjectParts = objectParts,
         };
@@ -4048,7 +4053,8 @@ internal sealed class DiskStorageService(
             LastModifiedUtc = lastModifiedUtc,
             Metadata = metadata.Metadata,
             Tags = metadata.Tags,
-            Checksums = metadata.Checksums
+            Checksums = metadata.Checksums,
+            StorageClass = metadata.IsDeleteMarker ? null : StorageClass.NormalizeForEcho(metadata.StorageClass)
         };
     }
 
@@ -4202,7 +4208,8 @@ internal sealed class DiskStorageService(
         string? contentLanguage = null,
         DateTimeOffset? expiresUtc = null,
         string? expires = null,
-        string? etag = null)
+        string? etag = null,
+        string? storageClass = null)
     {
         // Persist the S3 content ETag so it never depends on filesystem mtime. Multipart callers
         // pass the composite "<md5>-<partCount>" form explicitly; every other write path stores a
@@ -4229,7 +4236,8 @@ internal sealed class DiskStorageService(
                 Expires = isDeleteMarker ? null : expires,
                 Metadata = metadata is null ? null : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
                 Tags = tags is null ? null : new Dictionary<string, string>(tags, StringComparer.Ordinal),
-                Checksums = checksums is null ? null : new Dictionary<string, string>(checksums, StringComparer.OrdinalIgnoreCase)
+                Checksums = checksums is null ? null : new Dictionary<string, string>(checksums, StringComparer.OrdinalIgnoreCase),
+                StorageClass = isDeleteMarker ? null : storageClass
             }, cancellationToken);
 
             return;
@@ -4258,7 +4266,8 @@ internal sealed class DiskStorageService(
             LastModifiedUtc = lastModifiedUtc ?? fileInfo?.LastWriteTimeUtc ?? DateTimeOffset.UtcNow,
             Metadata = metadata is null ? null : new Dictionary<string, string>(metadata, StringComparer.Ordinal),
             Tags = tags is null ? null : new Dictionary<string, string>(tags, StringComparer.Ordinal),
-            Checksums = checksums is null ? null : new Dictionary<string, string>(checksums, StringComparer.OrdinalIgnoreCase)
+            Checksums = checksums is null ? null : new Dictionary<string, string>(checksums, StringComparer.OrdinalIgnoreCase),
+            StorageClass = isDeleteMarker ? null : storageClass
         }, cancellationToken);
 
         DeleteMetadataFileIfPresent(objectPath);
@@ -4918,7 +4927,8 @@ internal sealed class DiskStorageService(
             Expires = diskState.Expires,
             Metadata = diskState.Metadata,
             Tags = NormalizeTags(diskState.Tags),
-            ChecksumAlgorithm = diskState.ChecksumAlgorithm
+            ChecksumAlgorithm = diskState.ChecksumAlgorithm,
+            StorageClass = diskState.StorageClass
         };
     }
 
@@ -4939,7 +4949,8 @@ internal sealed class DiskStorageService(
             Expires = state.Expires,
             Metadata = state.Metadata is null ? null : new Dictionary<string, string>(state.Metadata, StringComparer.Ordinal),
             Tags = NormalizeTags(state.Tags) is { } tags ? new Dictionary<string, string>(tags, StringComparer.Ordinal) : null,
-            ChecksumAlgorithm = state.ChecksumAlgorithm
+            ChecksumAlgorithm = state.ChecksumAlgorithm,
+            StorageClass = state.StorageClass
         };
     }
 
@@ -4966,6 +4977,14 @@ internal sealed class DiskStorageService(
         }
     }
 
+    /// <summary>
+    /// Normalizes a request storage class for persistence: an unspecified or <c>STANDARD</c> value is
+    /// stored as <see langword="null"/> (read paths report <c>STANDARD</c>), and any other recognized
+    /// value is stored verbatim. Validation of unknown values happens at the HTTP boundary.
+    /// </summary>
+    private static string? NormalizeStoredStorageClass(string? storageClass)
+        => IntegratedS3.Abstractions.Models.StorageClass.IsNonStandard(storageClass) ? storageClass : null;
+
     private static DiskObjectMetadata ToDiskObjectMetadata(ObjectInfo? objectInfo)
     {
         return objectInfo is null
@@ -4986,7 +5005,8 @@ internal sealed class DiskStorageService(
                 Expires = objectInfo.Expires,
                 Metadata = objectInfo.Metadata is null ? null : new Dictionary<string, string>(objectInfo.Metadata, StringComparer.Ordinal),
                 Tags = objectInfo.Tags is null ? null : new Dictionary<string, string>(objectInfo.Tags, StringComparer.Ordinal),
-                Checksums = objectInfo.Checksums is null ? null : new Dictionary<string, string>(objectInfo.Checksums, StringComparer.OrdinalIgnoreCase)
+                Checksums = objectInfo.Checksums is null ? null : new Dictionary<string, string>(objectInfo.Checksums, StringComparer.OrdinalIgnoreCase),
+                StorageClass = objectInfo.StorageClass
             };
     }
 
@@ -5700,7 +5720,8 @@ internal sealed class DiskStorageService(
             Expires = request.Expires,
             Metadata = request.Metadata is null ? null : new Dictionary<string, string>(request.Metadata),
             Tags = NormalizeTags(request.Tags),
-            ChecksumAlgorithm = uploadInfo.ChecksumAlgorithm
+            ChecksumAlgorithm = uploadInfo.ChecksumAlgorithm,
+            StorageClass = NormalizeStoredStorageClass(request.StorageClass)
         };
 
         var statePath = GetMultipartStatePath(uploadDirectoryPath);

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskMultipartUploadState.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskMultipartUploadState.cs
@@ -33,4 +33,10 @@ internal sealed class DiskMultipartUploadState
     public Dictionary<string, string>? Tags { get; init; }
 
     public string? ChecksumAlgorithm { get; init; }
+
+    /// <summary>
+    /// The storage class supplied at upload initiation, applied to the completed object. Null for
+    /// legacy state written before this field existed.
+    /// </summary>
+    public string? StorageClass { get; init; }
 }

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskObjectMetadata.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskObjectMetadata.cs
@@ -43,4 +43,10 @@ internal sealed class DiskObjectMetadata
     public Dictionary<string, string>? Tags { get; init; }
 
     public Dictionary<string, string>? Checksums { get; init; }
+
+    /// <summary>
+    /// The S3 storage class persisted at write time. Null for delete markers and for legacy metadata
+    /// written before this field existed (read paths treat null as <c>STANDARD</c>).
+    /// </summary>
+    public string? StorageClass { get; init; }
 }

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/AwsS3StorageClient.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/AwsS3StorageClient.cs
@@ -426,7 +426,8 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
                     ETag: o.ETag,
                     LastModifiedUtc: ToDateTimeOffset(o.LastModified),
                     Metadata: null,
-                    VersionId: null))
+                    VersionId: null,
+                    StorageClass: o.StorageClass?.Value))
                 .ToList();
 
             var result = new S3ObjectListPage(
@@ -496,7 +497,8 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
                     Metadata: null,
                     VersionId: v.VersionId,
                     IsLatest: v.IsLatest == true,
-                    IsDeleteMarker: v.IsDeleteMarker == true))
+                    IsDeleteMarker: v.IsDeleteMarker == true,
+                    StorageClass: v.StorageClass?.Value))
                 .ToList();
 
             var result = new S3ObjectVersionListPage(
@@ -577,7 +579,8 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
                 LegalHoldStatus: S3ObjectLockMapper.ToLegalHoldStatus(response.ObjectLockLegalHoldStatus),
                 CustomerEncryption: S3ServerSideEncryptionMapper.ToCustomerEncryptionInfo(
                     response.ServerSideEncryptionCustomerMethod,
-                    response.ServerSideEncryptionCustomerProvidedKeyMD5));
+                    response.ServerSideEncryptionCustomerProvidedKeyMD5),
+                StorageClass: response.StorageClass?.Value);
 
             sw.Stop();
             S3StorageTelemetry.RecordSuccess("HeadObject", sw.Elapsed);
@@ -796,7 +799,8 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
                 LegalHoldStatus: S3ObjectLockMapper.ToLegalHoldStatus(response.ObjectLockLegalHoldStatus),
                 CustomerEncryption: S3ServerSideEncryptionMapper.ToCustomerEncryptionInfo(
                     response.ServerSideEncryptionCustomerMethod,
-                    response.ServerSideEncryptionCustomerProvidedKeyMD5));
+                    response.ServerSideEncryptionCustomerProvidedKeyMD5),
+                StorageClass: response.StorageClass?.Value);
 
             long totalContentLength = TryParseContentRangeTotal(response.ContentRange)
                 ?? response.ContentLength;
@@ -1025,7 +1029,8 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
                     response.BucketKeyEnabled),
                 CustomerEncryption: S3ServerSideEncryptionMapper.ToCustomerEncryptionInfo(
                     response.ServerSideEncryptionCustomerMethod,
-                    response.ServerSideEncryptionCustomerProvidedKeyMD5));
+                    response.ServerSideEncryptionCustomerProvidedKeyMD5),
+                StorageClass: storageClass);
 
             sw.Stop();
             S3StorageTelemetry.RecordSuccess("PutObject", sw.Elapsed);
@@ -1218,7 +1223,8 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
                     response.BucketKeyEnabled),
                 CustomerEncryption: S3ServerSideEncryptionMapper.ToCustomerEncryptionInfo(
                     response.ServerSideEncryptionCustomerMethod,
-                    response.ServerSideEncryptionCustomerProvidedKeyMD5));
+                    response.ServerSideEncryptionCustomerProvidedKeyMD5),
+                StorageClass: storageClass);
 
             sw.Stop();
             S3StorageTelemetry.RecordSuccess("CopyObject", sw.Elapsed);

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ObjectEntry.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/S3ObjectEntry.cs
@@ -26,4 +26,5 @@ internal sealed record S3ObjectEntry(
     ObjectRetentionMode? RetentionMode = null,
     DateTimeOffset? RetainUntilDateUtc = null,
     ObjectLegalHoldStatus? LegalHoldStatus = null,
-    ObjectCustomerEncryptionInfo? CustomerEncryption = null);
+    ObjectCustomerEncryptionInfo? CustomerEncryption = null,
+    string? StorageClass = null);

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
@@ -2109,7 +2109,8 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
         RetainUntilDateUtc = entry.RetainUntilDateUtc,
         LegalHoldStatus = entry.LegalHoldStatus,
         ServerSideEncryption = entry.ServerSideEncryption,
-        CustomerEncryption = entry.CustomerEncryption
+        CustomerEncryption = entry.CustomerEncryption,
+        StorageClass = StorageClass.NormalizeForEcho(entry.StorageClass)
     };
 
     private async Task<S3ObjectEntry> EnrichObjectEntryAsync(

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -159,6 +159,181 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Fact]
+    public async Task PutObject_WithNonStandardStorageClass_PersistsAndEchoesOnGetHeadAndList()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "storage-class-bucket";
+        const string objectKey = "docs/cold.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("cold payload", Encoding.UTF8, "text/plain")
+        }) {
+            putRequest.Headers.TryAddWithoutValidation("x-amz-storage-class", "STANDARD_IA");
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        // AWS emits x-amz-storage-class on GET/HEAD only for non-STANDARD classes.
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal("STANDARD_IA", Assert.Single(getResponse.Headers.GetValues("x-amz-storage-class")));
+
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}");
+        var headResponse = await client.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.Equal("STANDARD_IA", Assert.Single(headResponse.Headers.GetValues("x-amz-storage-class")));
+
+        // ListObjects V2 always reports <StorageClass> for each entry.
+        var listResponse = await client.GetAsync($"/integrated-s3/{bucketName}?list-type=2");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var listDocument = XDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+        var listedObject = Assert.Single(listDocument.Root!.S3Elements("Contents"));
+        Assert.Equal("STANDARD_IA", listedObject.S3Element("StorageClass")?.Value);
+
+        // ListObjects V1 too.
+        var listV1Response = await client.GetAsync($"/integrated-s3/{bucketName}");
+        Assert.Equal(HttpStatusCode.OK, listV1Response.StatusCode);
+        var listV1Document = XDocument.Parse(await listV1Response.Content.ReadAsStringAsync());
+        Assert.Equal("STANDARD_IA", Assert.Single(listV1Document.Root!.S3Elements("Contents")).S3Element("StorageClass")?.Value);
+
+        // GetObjectAttributes reports the persisted storage class rather than a hard-coded STANDARD.
+        using var attributesRequest = new HttpRequestMessage(HttpMethod.Get, $"/integrated-s3/{bucketName}/{objectKey}?attributes");
+        attributesRequest.Headers.TryAddWithoutValidation("x-amz-object-attributes", "StorageClass");
+        var attributesResponse = await client.SendAsync(attributesRequest);
+        Assert.Equal(HttpStatusCode.OK, attributesResponse.StatusCode);
+        var attributesDocument = XDocument.Parse(await attributesResponse.Content.ReadAsStringAsync());
+        Assert.Equal("STANDARD_IA", attributesDocument.Root!.S3Element("StorageClass")?.Value);
+    }
+
+    [Fact]
+    public async Task PutObject_WithStandardStorageClass_OmitsHeaderOnGetAndListsStandard()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "storage-class-standard-bucket";
+        const string objectKey = "docs/warm.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // PUT with no storage-class header at all -> defaults to STANDARD.
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("warm payload", Encoding.UTF8, "text/plain")
+        }) {
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        // AWS omits the header entirely for STANDARD objects.
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.False(getResponse.Headers.Contains("x-amz-storage-class"));
+
+        using var headRequest = new HttpRequestMessage(HttpMethod.Head, $"/integrated-s3/{bucketName}/{objectKey}");
+        var headResponse = await client.SendAsync(headRequest);
+        Assert.Equal(HttpStatusCode.OK, headResponse.StatusCode);
+        Assert.False(headResponse.Headers.Contains("x-amz-storage-class"));
+
+        // List entries still report STANDARD explicitly (AWS always includes <StorageClass>).
+        var listResponse = await client.GetAsync($"/integrated-s3/{bucketName}?list-type=2");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var listDocument = XDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+        Assert.Equal("STANDARD", Assert.Single(listDocument.Root!.S3Elements("Contents")).S3Element("StorageClass")?.Value);
+    }
+
+    [Fact]
+    public async Task PutObject_WithUnknownStorageClass_ReturnsInvalidStorageClass()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "storage-class-invalid-bucket";
+        const string objectKey = "docs/bogus.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("bogus payload", Encoding.UTF8, "text/plain")
+        };
+        putRequest.Headers.TryAddWithoutValidation("x-amz-storage-class", "TOTALLY_BOGUS");
+
+        var response = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal("InvalidStorageClass", GetRequiredElementValue(XDocument.Parse(await response.Content.ReadAsStringAsync()), "Code"));
+    }
+
+    [Fact]
+    public async Task ListObjectVersions_ReportsPersistedStorageClass()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "storage-class-versions-bucket";
+        const string objectKey = "docs/versioned.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using (var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}")
+        {
+            Content = new StringContent("glacier payload", Encoding.UTF8, "text/plain")
+        }) {
+            putRequest.Headers.TryAddWithoutValidation("x-amz-storage-class", "GLACIER");
+            Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+        }
+
+        var response = await client.GetAsync($"/integrated-s3/{bucketName}?versions");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        var version = Assert.Single(document.Root!.S3Elements("Version"));
+        Assert.Equal("GLACIER", version.S3Element("StorageClass")?.Value);
+    }
+
+    [Fact]
+    public async Task MultipartUpload_WithNonStandardStorageClass_EchoesOnGetAndList()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "storage-class-multipart-bucket";
+        const string objectKey = "docs/multipart-cold.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        using var initiateRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploads")
+        {
+            Content = new ByteArrayContent([])
+        };
+        initiateRequest.Headers.TryAddWithoutValidation("x-amz-storage-class", "ONEZONE_IA");
+        initiateRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("text/plain");
+        var initiateResponse = await client.SendAsync(initiateRequest);
+        Assert.Equal(HttpStatusCode.OK, initiateResponse.StatusCode);
+        var uploadId = GetRequiredElementValue(XDocument.Parse(await initiateResponse.Content.ReadAsStringAsync()), "UploadId");
+
+        string partETag;
+        using (var partRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}/{objectKey}?partNumber=1&uploadId={Uri.EscapeDataString(uploadId)}")
+        {
+            Content = new StringContent("multipart cold body", Encoding.UTF8, "text/plain")
+        }) {
+            var partResponse = await client.SendAsync(partRequest);
+            Assert.Equal(HttpStatusCode.OK, partResponse.StatusCode);
+            partETag = partResponse.Headers.ETag?.Tag ?? throw new Xunit.Sdk.XunitException("Expected multipart part ETag header.");
+        }
+
+        var completeBody = $"<CompleteMultipartUpload><Part><PartNumber>1</PartNumber><ETag>{partETag}</ETag></Part></CompleteMultipartUpload>";
+        using (var completeRequest = new HttpRequestMessage(HttpMethod.Post, $"/integrated-s3/{bucketName}/{objectKey}?uploadId={Uri.EscapeDataString(uploadId)}")
+        {
+            Content = new StringContent(completeBody, Encoding.UTF8, "application/xml")
+        }) {
+            var completeResponse = await client.SendAsync(completeRequest);
+            Assert.Equal(HttpStatusCode.OK, completeResponse.StatusCode);
+        }
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal("ONEZONE_IA", Assert.Single(getResponse.Headers.GetValues("x-amz-storage-class")));
+
+        var listResponse = await client.GetAsync($"/integrated-s3/{bucketName}?list-type=2");
+        Assert.Equal(HttpStatusCode.OK, listResponse.StatusCode);
+        var listDocument = XDocument.Parse(await listResponse.Content.ReadAsStringAsync());
+        Assert.Equal("ONEZONE_IA", Assert.Single(listDocument.Root!.S3Elements("Contents")).S3Element("StorageClass")?.Value);
+    }
+
+    [Fact]
     public async Task PutObject_WithoutContentType_DefaultsToBinaryOctetStreamOnGetAndHead()
     {
         using var client = await _factory.CreateClientAsync();


### PR DESCRIPTION
## Summary
`x-amz-storage-class` was parsed on PUT / InitiateMultipartUpload / CopyObject but discarded: `ObjectInfo` had no storage-class field, no store persisted it, and no read path echoed it. This threads the storage class end-to-end and echoes it to match AWS.

## Changes
**Persist** (all write paths + all stores):
- Added `StorageClass` to `ObjectInfo`, `MultipartUploadState`.
- Disk provider: `DiskObjectMetadata` + `DiskMultipartUploadState` sidecars now carry it; PutObject, CopyObject, and multipart Complete persist the requested class (default `STANDARD`).
- Catalog path: `StoredObjectEntry`, both EF entities (`ObjectCatalogRecord`, `MultipartUploadCatalogRecord`) + upsert/projection/column mapping.
- S3 backing provider maps storage class through its read entries (list/head/get).

**Echo** (matches AWS):
- GET/HEAD emit `x-amz-storage-class` only for **non-STANDARD** classes (STANDARD omitted).
- ListObjects V1/V2 and ListObjectVersions **always** include `<StorageClass>`.
- GetObjectAttributes returns the persisted class instead of a hard-coded `STANDARD`.

**Validate**: unknown storage-class values are rejected at the HTTP boundary with `InvalidStorageClass` (400).

## Tests
Added regression tests (fail-before / pass-after):
- `PutObject_WithNonStandardStorageClass_PersistsAndEchoesOnGetHeadAndList` (STANDARD_IA → GET/HEAD header + list + attributes)
- `PutObject_WithStandardStorageClass_OmitsHeaderOnGetAndListsStandard`
- `PutObject_WithUnknownStorageClass_ReturnsInvalidStorageClass`
- `ListObjectVersions_ReportsPersistedStorageClass`
- `MultipartUpload_WithNonStandardStorageClass_EchoesOnGetAndList`

Full suite green: 1238 passed / 0 failed.

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)