### PR TITLE
feat: implement OwnershipControls, GetBucketPolicyStatus, GetObjectTorrent subresources

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Errors/StorageErrorCode.cs
@@ -115,4 +115,7 @@ public enum StorageErrorCode
 
     /// <summary>The object is protected by an object-lock retention policy or legal hold.</summary>
     ObjectLocked,
+
+    /// <summary>No ownership controls configuration exists for the bucket.</summary>
+    OwnershipControlsNotFound,
 }

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Models/BucketOwnershipControlsConfiguration.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Models/BucketOwnershipControlsConfiguration.cs
@@ -1,0 +1,20 @@
+namespace IntegratedS3.Abstractions.Models;
+
+/// <summary>
+/// Ownership controls configuration for a bucket.
+/// Mirrors the S3 <c>OwnershipControls</c> element, which carries a single
+/// <c>Rule</c> with an <c>ObjectOwnership</c> value.
+/// </summary>
+public sealed class BucketOwnershipControlsConfiguration
+{
+    /// <summary>
+    /// The name of the bucket.
+    /// </summary>
+    public string BucketName { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The object ownership setting for the bucket. One of
+    /// <c>BucketOwnerPreferred</c>, <c>ObjectWriter</c>, or <c>BucketOwnerEnforced</c>.
+    /// </summary>
+    public string ObjectOwnership { get; init; } = string.Empty;
+}

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/DeleteBucketOwnershipControlsRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/DeleteBucketOwnershipControlsRequest.cs
@@ -1,0 +1,8 @@
+namespace IntegratedS3.Abstractions.Requests;
+
+/// <summary>Request parameters for the DeleteBucketOwnershipControls operation.</summary>
+public sealed class DeleteBucketOwnershipControlsRequest
+{
+    /// <summary>The name of the bucket.</summary>
+    public required string BucketName { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Requests/PutBucketOwnershipControlsRequest.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Requests/PutBucketOwnershipControlsRequest.cs
@@ -1,0 +1,14 @@
+namespace IntegratedS3.Abstractions.Requests;
+
+/// <summary>Request parameters for the PutBucketOwnershipControls operation.</summary>
+public sealed class PutBucketOwnershipControlsRequest
+{
+    /// <summary>The name of the bucket.</summary>
+    public required string BucketName { get; init; }
+
+    /// <summary>
+    /// The object ownership setting to apply. One of <c>BucketOwnerPreferred</c>,
+    /// <c>ObjectWriter</c>, or <c>BucketOwnerEnforced</c>.
+    /// </summary>
+    public required string ObjectOwnership { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageBackend.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageBackend.cs
@@ -214,6 +214,36 @@ public interface IStorageBackend
         => ValueTask.FromResult(StorageResult.Failure(StorageError.Unsupported("Bucket public access block is not implemented by this storage backend.", request.BucketName)));
 
     /// <summary>
+    /// Retrieves the ownership controls configuration for the specified bucket. The default implementation returns
+    /// <see cref="StorageErrorCode.UnsupportedCapability"/>.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the <see cref="BucketOwnershipControlsConfiguration"/> on success.</returns>
+    ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult<BucketOwnershipControlsConfiguration>.Failure(StorageError.Unsupported("Bucket ownership controls are not implemented by this storage backend.", bucketName)));
+
+    /// <summary>
+    /// Sets the ownership controls configuration for the specified bucket. The default implementation returns
+    /// <see cref="StorageErrorCode.UnsupportedCapability"/>.
+    /// </summary>
+    /// <param name="request">The ownership controls configuration to apply.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the applied <see cref="BucketOwnershipControlsConfiguration"/> on success.</returns>
+    ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult<BucketOwnershipControlsConfiguration>.Failure(StorageError.Unsupported("Bucket ownership controls are not implemented by this storage backend.", request.BucketName)));
+
+    /// <summary>
+    /// Deletes the ownership controls configuration from the specified bucket. The default implementation returns
+    /// <see cref="StorageErrorCode.UnsupportedCapability"/>.
+    /// </summary>
+    /// <param name="request">The delete ownership controls request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult"/> indicating success or failure.</returns>
+    ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult.Failure(StorageError.Unsupported("Bucket ownership controls are not implemented by this storage backend.", request.BucketName)));
+
+    /// <summary>
     /// Checks whether the specified bucket exists and is accessible.
     /// </summary>
     /// <param name="bucketName">The name of the bucket.</param>

--- a/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Services/IStorageService.cs
@@ -1,3 +1,4 @@
+using IntegratedS3.Abstractions.Errors;
 using IntegratedS3.Abstractions.Models;
 using IntegratedS3.Abstractions.Requests;
 using IntegratedS3.Abstractions.Responses;
@@ -126,6 +127,34 @@ public interface IStorageService
     /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A <see cref="StorageResult"/> indicating success or failure.</returns>
     ValueTask<StorageResult> DeleteBucketPublicAccessBlockAsync(DeleteBucketPublicAccessBlockRequest request, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Retrieves the ownership controls configuration for the specified bucket.
+    /// </summary>
+    /// <param name="bucketName">The name of the bucket.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the <see cref="BucketOwnershipControlsConfiguration"/> on success,
+    /// or a <see cref="Errors.StorageError"/> with <see cref="Errors.StorageErrorCode.OwnershipControlsNotFound"/> if none exists.</returns>
+    ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult<BucketOwnershipControlsConfiguration>.Failure(StorageError.Unsupported("Bucket ownership controls are not implemented by this storage service.", bucketName)));
+
+    /// <summary>
+    /// Sets the ownership controls configuration for the specified bucket.
+    /// </summary>
+    /// <param name="request">The ownership controls configuration to apply.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult{T}"/> containing the applied <see cref="BucketOwnershipControlsConfiguration"/> on success.</returns>
+    ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult<BucketOwnershipControlsConfiguration>.Failure(StorageError.Unsupported("Bucket ownership controls are not implemented by this storage service.", request.BucketName)));
+
+    /// <summary>
+    /// Deletes the ownership controls configuration from the specified bucket.
+    /// </summary>
+    /// <param name="request">The delete ownership controls request.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A <see cref="StorageResult"/> indicating success or failure.</returns>
+    ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(StorageResult.Failure(StorageError.Unsupported("Bucket ownership controls are not implemented by this storage service.", request.BucketName)));
 
     /// <summary>
     /// Checks whether the specified bucket exists and is accessible to the caller.

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -148,6 +148,9 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private const string InventoryQueryParameterName = "inventory";
     private const string IntelligentTieringQueryParameterName = "intelligent-tiering";
     private const string PublicAccessBlockQueryParameterName = "publicAccessBlock";
+    private const string OwnershipControlsQueryParameterName = "ownershipControls";
+    private const string PolicyStatusQueryParameterName = "policyStatus";
+    private const string TorrentQueryParameterName = "torrent";
     private const string IdQueryParameterName = "id";
     private const string RestoreQueryParameterName = "restore";
     private const string ResponseContentTypeQueryParameterName = "response-content-type";
@@ -203,10 +206,12 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static readonly HashSet<string> BucketInventoryQueryParameters = CreateQueryParameterSet(InventoryQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketIntelligentTieringQueryParameters = CreateQueryParameterSet(IntelligentTieringQueryParameterName, IdQueryParameterName);
     private static readonly HashSet<string> BucketPublicAccessBlockQueryParameters = CreateQueryParameterSet(PublicAccessBlockQueryParameterName);
+    private static readonly HashSet<string> BucketOwnershipControlsQueryParameters = CreateQueryParameterSet(OwnershipControlsQueryParameterName);
+    private static readonly HashSet<string> BucketPolicyStatusQueryParameters = CreateQueryParameterSet(PolicyStatusQueryParameterName);
     private static readonly HashSet<string> BucketVersionListingQueryParameters = CreateQueryParameterSet(VersionsQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MaxKeysQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, EncodingTypeQueryParameterName);
     private static readonly HashSet<string> BucketMultipartUploadsQueryParameters = CreateQueryParameterSet(UploadsQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MaxUploadsQueryParameterName, KeyMarkerQueryParameterName, UploadIdMarkerQueryParameterName, EncodingTypeQueryParameterName);
     private static readonly HashSet<string> BucketDeleteQueryParameters = CreateQueryParameterSet(DeleteQueryParameterName);
-    private static readonly HashSet<string> KnownBucketQueryParameters = CreateQueryParameterSet(ListTypeQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MarkerQueryParameterName, StartAfterQueryParameterName, MaxKeysQueryParameterName, MaxUploadsQueryParameterName, ContinuationTokenQueryParameterName, EncodingTypeQueryParameterName, FetchOwnerQueryParameterName, LocationQueryParameterName, AclQueryParameterName, CorsQueryParameterName, PolicyQueryParameterName, VersioningQueryParameterName, EncryptionQueryParameterName, TaggingQueryParameterName, LoggingQueryParameterName, WebsiteQueryParameterName, RequestPaymentQueryParameterName, AccelerateQueryParameterName, LifecycleQueryParameterName, ReplicationQueryParameterName, NotificationQueryParameterName, ObjectLockQueryParameterName, AnalyticsQueryParameterName, MetricsQueryParameterName, InventoryQueryParameterName, IntelligentTieringQueryParameterName, PublicAccessBlockQueryParameterName, IdQueryParameterName, VersionsQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, UploadIdMarkerQueryParameterName, UploadsQueryParameterName, DeleteQueryParameterName);
+    private static readonly HashSet<string> KnownBucketQueryParameters = CreateQueryParameterSet(ListTypeQueryParameterName, PrefixQueryParameterName, DelimiterQueryParameterName, MarkerQueryParameterName, StartAfterQueryParameterName, MaxKeysQueryParameterName, MaxUploadsQueryParameterName, ContinuationTokenQueryParameterName, EncodingTypeQueryParameterName, FetchOwnerQueryParameterName, LocationQueryParameterName, AclQueryParameterName, CorsQueryParameterName, PolicyQueryParameterName, VersioningQueryParameterName, EncryptionQueryParameterName, TaggingQueryParameterName, LoggingQueryParameterName, WebsiteQueryParameterName, RequestPaymentQueryParameterName, AccelerateQueryParameterName, LifecycleQueryParameterName, ReplicationQueryParameterName, NotificationQueryParameterName, ObjectLockQueryParameterName, AnalyticsQueryParameterName, MetricsQueryParameterName, InventoryQueryParameterName, IntelligentTieringQueryParameterName, PublicAccessBlockQueryParameterName, OwnershipControlsQueryParameterName, PolicyStatusQueryParameterName, IdQueryParameterName, VersionsQueryParameterName, KeyMarkerQueryParameterName, VersionIdMarkerQueryParameterName, UploadIdMarkerQueryParameterName, UploadsQueryParameterName, DeleteQueryParameterName);
     private static readonly HashSet<string> ObjectVersionQueryParameters = CreateQueryParameterSet(VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectAclQueryParameters = CreateQueryParameterSet(AclQueryParameterName);
     private static readonly HashSet<string> ObjectTaggingQueryParameters = CreateQueryParameterSet(TaggingQueryParameterName, VersionIdQueryParameterName);
@@ -215,6 +220,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static readonly HashSet<string> ObjectAttributesQueryParameters = CreateQueryParameterSet(AttributesQueryParameterName, VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectRestoreQueryParameters = CreateQueryParameterSet(RestoreQueryParameterName, VersionIdQueryParameterName);
     private static readonly HashSet<string> ObjectSelectQueryParameters = CreateQueryParameterSet(SelectQueryParameterName, SelectTypeQueryParameterName);
+    private static readonly HashSet<string> ObjectTorrentQueryParameters = CreateQueryParameterSet(TorrentQueryParameterName, VersionIdQueryParameterName);
     private static readonly HashSet<string> ResponseHeaderOverrideQueryParameters = CreateQueryParameterSet(
         ResponseContentTypeQueryParameterName,
         ResponseContentLanguageQueryParameterName,
@@ -226,7 +232,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     private static readonly HashSet<string> ObjectMultipartPartQueryParameters = CreateQueryParameterSet(UploadIdQueryParameterName, PartNumberQueryParameterName);
     private static readonly HashSet<string> ObjectMultipartUploadQueryParameters = CreateQueryParameterSet(UploadIdQueryParameterName);
     private static readonly HashSet<string> ObjectMultipartListPartsQueryParameters = CreateQueryParameterSet(UploadIdQueryParameterName, PartNumberMarkerQueryParameterName, MaxPartsQueryParameterName, EncodingTypeQueryParameterName);
-    private static readonly HashSet<string> KnownObjectQueryParameters = CreateQueryParameterSet(AclQueryParameterName, TaggingQueryParameterName, RetentionQueryParameterName, LegalHoldQueryParameterName, AttributesQueryParameterName, VersionIdQueryParameterName, RestoreQueryParameterName, SelectQueryParameterName, SelectTypeQueryParameterName, UploadsQueryParameterName, UploadIdQueryParameterName, PartNumberQueryParameterName, PartNumberMarkerQueryParameterName, MaxPartsQueryParameterName, EncodingTypeQueryParameterName, ResponseContentTypeQueryParameterName, ResponseContentLanguageQueryParameterName, ResponseExpiresQueryParameterName, ResponseCacheControlQueryParameterName, ResponseContentDispositionQueryParameterName, ResponseContentEncodingQueryParameterName);
+    private static readonly HashSet<string> KnownObjectQueryParameters = CreateQueryParameterSet(AclQueryParameterName, TaggingQueryParameterName, RetentionQueryParameterName, LegalHoldQueryParameterName, AttributesQueryParameterName, VersionIdQueryParameterName, RestoreQueryParameterName, SelectQueryParameterName, SelectTypeQueryParameterName, TorrentQueryParameterName, UploadsQueryParameterName, UploadIdQueryParameterName, PartNumberQueryParameterName, PartNumberMarkerQueryParameterName, MaxPartsQueryParameterName, EncodingTypeQueryParameterName, ResponseContentTypeQueryParameterName, ResponseContentLanguageQueryParameterName, ResponseExpiresQueryParameterName, ResponseCacheControlQueryParameterName, ResponseContentDispositionQueryParameterName, ResponseContentEncodingQueryParameterName);
     private static readonly HashSet<string> SupportedManagedServerSideEncryptionRequestHeaders = new(StringComparer.OrdinalIgnoreCase)
     {
         ServerSideEncryptionHeaderName,
@@ -1731,6 +1737,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "GET" when httpContext.Request.Query.ContainsKey(VersioningQueryParameterName) => await GetBucketVersioningAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(EncryptionQueryParameterName) => await GetBucketDefaultEncryptionAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(PublicAccessBlockQueryParameterName) => await GetBucketPublicAccessBlockAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "GET" when httpContext.Request.Query.ContainsKey(OwnershipControlsQueryParameterName) => await GetBucketOwnershipControlsAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "GET" when httpContext.Request.Query.ContainsKey(PolicyStatusQueryParameterName) => await GetBucketPolicyStatusAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await GetBucketTaggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(LoggingQueryParameterName) => await GetBucketLoggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(WebsiteQueryParameterName) => await GetBucketWebsiteAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -1774,6 +1782,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "PUT" when httpContext.Request.Query.ContainsKey(VersioningQueryParameterName) => await PutBucketVersioningAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(EncryptionQueryParameterName) => await PutBucketDefaultEncryptionAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(PublicAccessBlockQueryParameterName) => await PutBucketPublicAccessBlockAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "PUT" when httpContext.Request.Query.ContainsKey(OwnershipControlsQueryParameterName) => await PutBucketOwnershipControlsAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await PutBucketTaggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(LoggingQueryParameterName) => await PutBucketLoggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(WebsiteQueryParameterName) => await PutBucketWebsiteAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -1791,6 +1800,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "DELETE" when httpContext.Request.Query.ContainsKey(PolicyQueryParameterName) => await DeleteBucketPolicyAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(EncryptionQueryParameterName) => await DeleteBucketDefaultEncryptionAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(PublicAccessBlockQueryParameterName) => await DeleteBucketPublicAccessBlockAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "DELETE" when httpContext.Request.Query.ContainsKey(OwnershipControlsQueryParameterName) => await DeleteBucketOwnershipControlsAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await DeleteBucketTaggingAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(WebsiteQueryParameterName) => await DeleteBucketWebsiteAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "DELETE" when httpContext.Request.Query.ContainsKey(LifecycleQueryParameterName) => await DeleteBucketLifecycleAsync(resolvedRequest.BucketName, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -2502,6 +2512,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 "GET" when httpContext.Request.Query.ContainsKey(RetentionQueryParameterName) => await GetObjectRetentionAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(LegalHoldQueryParameterName) => await GetObjectLegalHoldAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "GET" when httpContext.Request.Query.ContainsKey(AttributesQueryParameterName) => await GetObjectAttributesAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
+                "GET" when httpContext.Request.Query.ContainsKey(TorrentQueryParameterName) => GetObjectTorrent(resolvedRequest.BucketName, key, httpContext),
                 "GET" when TryGetMultipartUploadId(httpContext.Request, out _, out _) => await ListMultipartPartsAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(AclQueryParameterName) => await PutObjectAclAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, cancellationToken),
                 "PUT" when httpContext.Request.Query.ContainsKey(TaggingQueryParameterName) => await PutObjectTaggingAsync(resolvedRequest.BucketName, key, httpContext, requestContextAccessor, storageService, cancellationToken),
@@ -4264,6 +4275,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.InventoryConfigurationNotFound => StatusCodes.Status404NotFound,
             StorageErrorCode.IntelligentTieringConfigurationNotFound => StatusCodes.Status404NotFound,
             StorageErrorCode.PublicAccessBlockConfigurationNotFound => StatusCodes.Status404NotFound,
+            StorageErrorCode.OwnershipControlsNotFound => StatusCodes.Status404NotFound,
             StorageErrorCode.AccessDenied => StatusCodes.Status403Forbidden,
             StorageErrorCode.InvalidTag => StatusCodes.Status400BadRequest,
             StorageErrorCode.InvalidChecksum => StatusCodes.Status400BadRequest,
@@ -4308,6 +4320,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             StorageErrorCode.InventoryConfigurationNotFound => "NoSuchConfiguration",
             StorageErrorCode.IntelligentTieringConfigurationNotFound => "NoSuchConfiguration",
             StorageErrorCode.PublicAccessBlockConfigurationNotFound => "NoSuchPublicAccessBlockConfiguration",
+            StorageErrorCode.OwnershipControlsNotFound => "OwnershipControlsNotFoundError",
             StorageErrorCode.AccessDenied => "AccessDenied",
             StorageErrorCode.InvalidTag => "InvalidTag",
             StorageErrorCode.InvalidChecksum => "BadDigest",
@@ -5037,6 +5050,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         var isBucketInventoryRequest = queryKeys.Contains(InventoryQueryParameterName) && queryKeys.IsSubsetOf(BucketInventoryQueryParameters);
         var isBucketIntelligentTieringRequest = queryKeys.Contains(IntelligentTieringQueryParameterName) && queryKeys.IsSubsetOf(BucketIntelligentTieringQueryParameters);
         var isBucketPublicAccessBlockRequest = queryKeys.SetEquals(BucketPublicAccessBlockQueryParameters);
+        var isBucketOwnershipControlsRequest = queryKeys.SetEquals(BucketOwnershipControlsQueryParameters);
+        var isBucketPolicyStatusRequest = queryKeys.SetEquals(BucketPolicyStatusQueryParameters);
         var isListObjectVersionsRequest = queryKeys.Contains(VersionsQueryParameterName) && queryKeys.IsSubsetOf(BucketVersionListingQueryParameters);
         var isListMultipartUploadsRequest = queryKeys.Contains(UploadsQueryParameterName) && queryKeys.IsSubsetOf(BucketMultipartUploadsQueryParameters);
         var isDeleteObjectsRequest = queryKeys.SetEquals(BucketDeleteQueryParameters);
@@ -5079,6 +5094,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketInventoryRequest
                     || isBucketIntelligentTieringRequest
                     || isBucketPublicAccessBlockRequest
+                    || isBucketOwnershipControlsRequest
+                    || isBucketPolicyStatusRequest
                     || isListObjectVersionsRequest
                     || isListMultipartUploadsRequest) {
                     break;
@@ -5123,7 +5140,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketMetricsRequest
                     || isBucketInventoryRequest
                     || isBucketIntelligentTieringRequest
-                    || isBucketPublicAccessBlockRequest) {
+                    || isBucketPublicAccessBlockRequest
+                    || isBucketOwnershipControlsRequest) {
                     break;
                 }
 
@@ -5142,7 +5160,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     || isBucketMetricsRequest
                     || isBucketInventoryRequest
                     || isBucketIntelligentTieringRequest
-                    || isBucketPublicAccessBlockRequest) {
+                    || isBucketPublicAccessBlockRequest
+                    || isBucketOwnershipControlsRequest) {
                     break;
                 }
 
@@ -5181,6 +5200,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         var isAttributesRequest = queryKeys.Contains(AttributesQueryParameterName) && queryKeys.IsSubsetOf(ObjectAttributesQueryParameters);
         var isRestoreRequest = queryKeys.Contains(RestoreQueryParameterName) && queryKeys.IsSubsetOf(ObjectRestoreQueryParameters);
         var isSelectRequest = queryKeys.Contains(SelectQueryParameterName) && queryKeys.IsSubsetOf(ObjectSelectQueryParameters);
+        var isTorrentRequest = queryKeys.Contains(TorrentQueryParameterName) && queryKeys.IsSubsetOf(ObjectTorrentQueryParameters);
         var isInitiateMultipartRequest = queryKeys.SetEquals(ObjectMultipartInitiateQueryParameters);
         var isUploadMultipartPartRequest = queryKeys.SetEquals(ObjectMultipartPartQueryParameters);
         var isListMultipartUploadPartsRequest = queryKeys.Contains(UploadIdQueryParameterName) && queryKeys.IsSubsetOf(ObjectMultipartListPartsQueryParameters);
@@ -5201,7 +5221,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
 
         switch (request.Method) {
-            case "GET" when isCurrentObjectRequest || isVersionedObjectRequest || isAclRequest || isTaggingRequest || isRetentionRequest || isLegalHoldRequest || isAttributesRequest || isListMultipartPartsRequest:
+            case "GET" when isCurrentObjectRequest || isVersionedObjectRequest || isAclRequest || isTaggingRequest || isRetentionRequest || isLegalHoldRequest || isAttributesRequest || isTorrentRequest || isListMultipartPartsRequest:
             case "PUT" when isCurrentObjectRequest || isAclRequest || isTaggingRequest || isRetentionRequest || isLegalHoldRequest || isUploadMultipartPartRequest:
             case "HEAD" when isCurrentObjectRequest || isVersionedObjectRequest:
             case "DELETE" when isCurrentObjectRequest || isVersionedObjectRequest || isTaggingRequest || isUploadScopedMultipartRequest:
@@ -10270,6 +10290,156 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
     }
 
+    // ── Bucket Ownership Controls ─────────────────────────────────────────────
+
+    private static async Task<IResult> GetBucketOwnershipControlsAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        IStorageService storageService,
+        CancellationToken cancellationToken)
+    {
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                var result = await storageService.GetBucketOwnershipControlsAsync(bucketName, innerCancellationToken);
+                if (!result.IsSuccess) {
+                    return ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+                }
+
+                var config = result.Value!;
+                return new XmlContentResult(
+                    S3XmlResponseWriter.WriteOwnershipControlsConfiguration(new S3OwnershipControlsConfiguration
+                    {
+                        ObjectOwnership = config.ObjectOwnership
+                    }),
+                    StatusCodes.Status200OK,
+                    XmlContentType);
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
+    private static async Task<IResult> PutBucketOwnershipControlsAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        IStorageService storageService,
+        CancellationToken cancellationToken)
+    {
+        S3OwnershipControlsConfiguration requestBody;
+        try {
+            requestBody = await S3XmlRequestReader.ReadOwnershipControlsConfigurationAsync(httpContext.Request.Body, cancellationToken);
+        }
+        catch (FormatException exception) {
+            return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "MalformedXML", exception.Message, BuildObjectResource(bucketName, null), bucketName);
+        }
+
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                var result = await storageService.PutBucketOwnershipControlsAsync(new PutBucketOwnershipControlsRequest
+                {
+                    BucketName = bucketName,
+                    ObjectOwnership = requestBody.ObjectOwnership
+                }, innerCancellationToken);
+
+                return result.IsSuccess
+                    ? TypedResults.Ok()
+                    : ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
+    private static async Task<IResult> DeleteBucketOwnershipControlsAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        IStorageService storageService,
+        CancellationToken cancellationToken)
+    {
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                var result = await storageService.DeleteBucketOwnershipControlsAsync(new DeleteBucketOwnershipControlsRequest
+                {
+                    BucketName = bucketName
+                }, innerCancellationToken);
+
+                return result.IsSuccess
+                    ? TypedResults.NoContent()
+                    : ToErrorResult(httpContext, result.Error, resourceOverride: BuildObjectResource(bucketName, null));
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
+    // ── Bucket Policy Status (GetBucketPolicyStatus) ──────────────────────────
+
+    private static async Task<IResult> GetBucketPolicyStatusAsync(
+        string bucketName,
+        HttpContext httpContext,
+        IIntegratedS3RequestContextAccessor requestContextAccessor,
+        CancellationToken cancellationToken)
+    {
+        var authorizationService = httpContext.RequestServices.GetRequiredService<IIntegratedS3AuthorizationService>();
+        var compatibilityService = httpContext.RequestServices.GetRequiredService<IStorageAuthorizationCompatibilityService>();
+
+        try {
+            return await ExecuteWithRequestContextAsync(httpContext, requestContextAccessor, async innerCancellationToken => {
+                await AuthorizeCompatibilityOperationAsync(
+                    httpContext,
+                    authorizationService,
+                    new StorageAuthorizationRequest
+                    {
+                        Operation = StorageOperationType.GetBucketPolicyStatus,
+                        BucketName = bucketName
+                    },
+                    innerCancellationToken);
+
+                // The bucket must exist; surface NoSuchBucket rather than a misleading IsPublic=false.
+                var policyResult = await compatibilityService.GetBucketPolicyAsync(bucketName, innerCancellationToken);
+                if (!policyResult.IsSuccess) {
+                    return ToErrorResult(httpContext, policyResult.Error, resourceOverride: BuildObjectResource(bucketName, null));
+                }
+
+                // IntegratedS3 does not grant anonymous public access via bucket policy, so the
+                // bucket is never considered public. If no policy is set, IsPublic is false by definition.
+                return new XmlContentResult(
+                    S3XmlResponseWriter.WritePolicyStatus(new S3PolicyStatus
+                    {
+                        IsPublic = false
+                    }),
+                    StatusCodes.Status200OK,
+                    XmlContentType);
+            }, cancellationToken);
+        }
+        catch (EndpointStorageAuthorizationException exception) {
+            return ToErrorResult(httpContext, exception.Error, resourceOverride: BuildObjectResource(bucketName, null));
+        }
+    }
+
+    // ── Object Torrent (GetObjectTorrent) ─────────────────────────────────────
+
+    private static IResult GetObjectTorrent(string bucketName, string key, HttpContext httpContext)
+    {
+        // AWS returns a BitTorrent file for this operation, but IntegratedS3 does not generate
+        // torrents. Return a clean, well-formed S3 NotImplemented error so the subresource is a
+        // KNOWN, correctly-erroring endpoint rather than a generic failure.
+        return ToErrorResult(
+            httpContext,
+            StatusCodes.Status501NotImplemented,
+            "NotImplemented",
+            "The requested functionality (GetObjectTorrent) is not implemented.",
+            BuildObjectResource(bucketName, key),
+            bucketName,
+            key);
+    }
+
     // ── Bucket Logging ──────────────────────────────────────────────────────
 
     private static async Task<IResult> GetBucketLoggingAsync(
@@ -12052,6 +12222,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         if (request.Query.ContainsKey(VersioningQueryParameterName)) return $"{method}BucketVersioning";
         if (request.Query.ContainsKey(EncryptionQueryParameterName)) return $"{method}BucketEncryption";
         if (request.Query.ContainsKey(PublicAccessBlockQueryParameterName)) return $"{method}BucketPublicAccessBlock";
+        if (request.Query.ContainsKey(OwnershipControlsQueryParameterName)) return $"{method}BucketOwnershipControls";
+        if (request.Query.ContainsKey(PolicyStatusQueryParameterName)) return "GetBucketPolicyStatus";
         if (request.Query.ContainsKey(TaggingQueryParameterName)) return $"{method}BucketTagging";
         if (request.Query.ContainsKey(LoggingQueryParameterName)) return $"{method}BucketLogging";
         if (request.Query.ContainsKey(WebsiteQueryParameterName)) return $"{method}BucketWebsite";
@@ -12090,6 +12262,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         if (request.Query.ContainsKey(AttributesQueryParameterName)) return "GetObjectAttributes";
         if (request.Query.ContainsKey(RestoreQueryParameterName)) return "RestoreObject";
         if (request.Query.ContainsKey(SelectQueryParameterName)) return "SelectObjectContent";
+        if (request.Query.ContainsKey(TorrentQueryParameterName)) return "GetObjectTorrent";
         if (request.Query.ContainsKey(UploadsQueryParameterName)) return "InitiateMultipartUpload";
         if (TryGetMultipartUploadId(request, out _, out _))
         {

--- a/src/IntegratedS3/IntegratedS3.Core/Models/StorageOperationType.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Models/StorageOperationType.cs
@@ -328,4 +328,19 @@ public enum StorageOperationType
 
     /// <summary>Delete the public access block configuration of a bucket.</summary>
     DeleteBucketPublicAccessBlock,
+
+    // ── Bucket ownership controls ───────────────────────────────────
+    // New members are appended so existing numeric values stay stable.
+
+    /// <summary>Retrieve the ownership controls configuration of a bucket.</summary>
+    GetBucketOwnershipControls,
+
+    /// <summary>Set the ownership controls configuration of a bucket.</summary>
+    PutBucketOwnershipControls,
+
+    /// <summary>Delete the ownership controls configuration of a bucket.</summary>
+    DeleteBucketOwnershipControls,
+
+    /// <summary>Retrieve the policy status (public/not) of a bucket.</summary>
+    GetBucketPolicyStatus,
 }

--- a/src/IntegratedS3/IntegratedS3.Core/Services/AuthorizingStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/AuthorizingStorageService.cs
@@ -145,6 +145,33 @@ internal sealed class AuthorizingStorageService(
         }, innerCancellationToken => inner.DeleteBucketPublicAccessBlockAsync(request, innerCancellationToken), cancellationToken);
     }
 
+    public ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAuthorizedAsync(new StorageAuthorizationRequest
+        {
+            Operation = StorageOperationType.GetBucketOwnershipControls,
+            BucketName = bucketName
+        }, innerCancellationToken => inner.GetBucketOwnershipControlsAsync(bucketName, innerCancellationToken), cancellationToken);
+    }
+
+    public ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAuthorizedAsync(new StorageAuthorizationRequest
+        {
+            Operation = StorageOperationType.PutBucketOwnershipControls,
+            BucketName = request.BucketName
+        }, innerCancellationToken => inner.PutBucketOwnershipControlsAsync(request, innerCancellationToken), cancellationToken);
+    }
+
+    public ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        return ExecuteAuthorizedAsync(new StorageAuthorizationRequest
+        {
+            Operation = StorageOperationType.DeleteBucketOwnershipControls,
+            BucketName = request.BucketName
+        }, innerCancellationToken => inner.DeleteBucketOwnershipControlsAsync(request, innerCancellationToken), cancellationToken);
+    }
+
     public ValueTask<StorageResult<BucketInfo>> HeadBucketAsync(string bucketName, CancellationToken cancellationToken = default)
     {
         return ExecuteAuthorizedAsync(new StorageAuthorizationRequest

--- a/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
@@ -814,6 +814,71 @@ internal sealed class OrchestratedStorageService(
         return result;
     }
 
+    // ── Bucket Ownership Controls ────────────────────────────────────────
+
+    public async ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        return await ExecuteReadAsync(
+            StorageOperationType.GetBucketOwnershipControls,
+            (backend, ct) => backend.GetBucketOwnershipControlsAsync(bucketName, ct),
+            onSuccess: null,
+            cancellationToken);
+    }
+
+    public async ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        var backend = GetPrimaryBackend();
+        var strictReplicationError = await GetStrictReplicaWritePreflightErrorAsync(backend, request.BucketName, objectKey: null, versionId: null, cancellationToken: cancellationToken);
+        if (strictReplicationError is not null) {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(strictReplicationError);
+        }
+
+        var result = await backend.PutBucketOwnershipControlsAsync(request, cancellationToken);
+        ObserveResult(backend, result);
+        if (result.IsSuccess && result.Value is not null) {
+            var replicationError = await ApplyReplicaWritePolicyAsync(
+                StorageOperationType.PutBucketOwnershipControls,
+                backend,
+                request.BucketName,
+                objectKey: null,
+                versionId: null,
+                writeThroughOperation: (replicaBackend, ct) => WriteReplicaPutBucketOwnershipControlsAsync(replicaBackend, request, ct),
+                cancellationToken: CancellationToken.None);
+            if (replicationError is not null) {
+                return StorageResult<BucketOwnershipControlsConfiguration>.Failure(replicationError);
+            }
+        }
+
+        return result;
+    }
+
+    public async ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        var backend = GetPrimaryBackend();
+        var strictReplicationError = await GetStrictReplicaWritePreflightErrorAsync(backend, request.BucketName, objectKey: null, versionId: null, cancellationToken: cancellationToken);
+        if (strictReplicationError is not null) {
+            return StorageResult.Failure(strictReplicationError);
+        }
+
+        var result = await backend.DeleteBucketOwnershipControlsAsync(request, cancellationToken);
+        ObserveResult(backend, result);
+        if (result.IsSuccess) {
+            var replicationError = await ApplyReplicaWritePolicyAsync(
+                StorageOperationType.DeleteBucketOwnershipControls,
+                backend,
+                request.BucketName,
+                objectKey: null,
+                versionId: null,
+                writeThroughOperation: (replicaBackend, ct) => WriteReplicaDeleteBucketOwnershipControlsAsync(replicaBackend, request, ct),
+                cancellationToken: CancellationToken.None);
+            if (replicationError is not null) {
+                return StorageResult.Failure(replicationError);
+            }
+        }
+
+        return result;
+    }
+
     // ── Bucket Logging ──────────────────────────────────────────────────
 
     public async ValueTask<StorageResult<BucketLoggingConfiguration>> GetBucketLoggingAsync(string bucketName, CancellationToken cancellationToken = default)
@@ -2543,6 +2608,28 @@ internal sealed class OrchestratedStorageService(
         ObserveResult(replicaBackend, replicaResult);
         if (!replicaResult.IsSuccess && replicaResult.Error?.Code is not (StorageErrorCode.PublicAccessBlockConfigurationNotFound or StorageErrorCode.BucketNotFound)) {
             return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket public access block delete did not succeed.");
+        }
+
+        return null;
+    }
+
+    private async ValueTask<StorageError?> WriteReplicaPutBucketOwnershipControlsAsync(IStorageBackend replicaBackend, PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken)
+    {
+        var replicaResult = await replicaBackend.PutBucketOwnershipControlsAsync(request, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket ownership controls update did not return configuration metadata.");
+        }
+
+        return null;
+    }
+
+    private async ValueTask<StorageError?> WriteReplicaDeleteBucketOwnershipControlsAsync(IStorageBackend replicaBackend, DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken)
+    {
+        var replicaResult = await replicaBackend.DeleteBucketOwnershipControlsAsync(request, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess && replicaResult.Error?.Code is not (StorageErrorCode.OwnershipControlsNotFound or StorageErrorCode.BucketNotFound)) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, objectKey: null, versionId: null, message: "Replica bucket ownership controls delete did not succeed.");
         }
 
         return null;

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3OwnershipControlsConfiguration.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3OwnershipControlsConfiguration.cs
@@ -1,0 +1,13 @@
+namespace IntegratedS3.Protocol;
+
+/// <summary>
+/// Represents the ownership controls configuration for an S3 bucket.
+/// </summary>
+public sealed class S3OwnershipControlsConfiguration
+{
+    /// <summary>
+    /// The object ownership setting. One of <c>BucketOwnerPreferred</c>,
+    /// <c>ObjectWriter</c>, or <c>BucketOwnerEnforced</c>.
+    /// </summary>
+    public string ObjectOwnership { get; init; } = string.Empty;
+}

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3PolicyStatus.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3PolicyStatus.cs
@@ -1,0 +1,10 @@
+namespace IntegratedS3.Protocol;
+
+/// <summary>
+/// Represents the policy status (GetBucketPolicyStatus) for an S3 bucket.
+/// </summary>
+public sealed class S3PolicyStatus
+{
+    /// <summary>Whether the bucket is public according to its policy and public-access state.</summary>
+    public bool IsPublic { get; init; }
+}

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlRequestReader.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlRequestReader.cs
@@ -126,6 +126,57 @@ public static class S3XmlRequestReader
         return parsed;
     }
 
+    /// <summary>Reads a bucket ownership controls configuration from the XML request body.</summary>
+    /// <param name="content">The request body stream containing the XML payload.</param>
+    /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>
+    /// <returns>The deserialized <see cref="S3OwnershipControlsConfiguration"/>.</returns>
+    public static async Task<S3OwnershipControlsConfiguration> ReadOwnershipControlsConfigurationAsync(Stream content, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(content);
+
+        try {
+            var document = await HardenedXml.LoadAsync(content, cancellationToken);
+            var root = document.Root;
+            if (root is null || !string.Equals(root.Name.LocalName, "OwnershipControls", StringComparison.Ordinal)) {
+                throw new FormatException("The ownership controls request body must contain a root 'OwnershipControls' element.");
+            }
+
+            var rules = root.Elements()
+                .Where(static child => string.Equals(child.Name.LocalName, "Rule", StringComparison.Ordinal))
+                .ToArray();
+            if (rules.Length != 1) {
+                throw new FormatException("The ownership controls configuration must contain exactly one 'Rule' element.");
+            }
+
+            var objectOwnership = GetSingleOptionalChildValue(
+                rules[0],
+                "ObjectOwnership",
+                "The ownership controls rule must not contain multiple 'ObjectOwnership' elements.");
+            if (string.IsNullOrWhiteSpace(objectOwnership)) {
+                throw new FormatException("The ownership controls rule must contain a non-empty 'ObjectOwnership' element.");
+            }
+
+            if (!string.Equals(objectOwnership, "BucketOwnerPreferred", StringComparison.Ordinal)
+                && !string.Equals(objectOwnership, "ObjectWriter", StringComparison.Ordinal)
+                && !string.Equals(objectOwnership, "BucketOwnerEnforced", StringComparison.Ordinal)) {
+                throw new FormatException("The 'ObjectOwnership' element must be 'BucketOwnerPreferred', 'ObjectWriter', or 'BucketOwnerEnforced'.");
+            }
+
+            return new S3OwnershipControlsConfiguration
+            {
+                ObjectOwnership = objectOwnership
+            };
+        }
+        catch (FormatException ex) {
+            ProtocolTelemetry.RecordXmlParseError("ReadOwnershipControlsConfiguration", ex.Message);
+            throw;
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException) {
+            ProtocolTelemetry.RecordXmlParseError("ReadOwnershipControlsConfiguration", exception.Message);
+            throw new FormatException("The ownership controls request body is not valid XML.", exception);
+        }
+    }
+
     /// <summary>Reads a CORS configuration from the XML request body.</summary>
     /// <param name="content">The request body stream containing the XML payload.</param>
     /// <param name="cancellationToken">A token to cancel the asynchronous operation.</param>

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -128,6 +128,54 @@ public static class S3XmlResponseWriter
         return builder.ToString();
     }
 
+    /// <summary>Writes an OwnershipControls configuration as an XML response body.</summary>
+    /// <param name="response">The <see cref="S3OwnershipControlsConfiguration"/> to serialize.</param>
+    /// <returns>The XML string.</returns>
+    public static string WriteOwnershipControlsConfiguration(S3OwnershipControlsConfiguration response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var builder = new StringBuilder(256);
+        using var stringWriter = new Utf8StringWriter(builder, CultureInfo.InvariantCulture);
+        using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
+
+        xmlWriter.WriteStartDocument();
+        WriteStartRootElement(xmlWriter, "OwnershipControls");
+
+        xmlWriter.WriteStartElement("Rule");
+        xmlWriter.WriteElementString("ObjectOwnership", response.ObjectOwnership);
+        xmlWriter.WriteEndElement();
+
+        xmlWriter.WriteEndElement();
+        xmlWriter.WriteEndDocument();
+        xmlWriter.Flush();
+
+        return builder.ToString();
+    }
+
+    /// <summary>Writes a PolicyStatus (GetBucketPolicyStatus) as an XML response body.</summary>
+    /// <param name="response">The <see cref="S3PolicyStatus"/> to serialize.</param>
+    /// <returns>The XML string.</returns>
+    public static string WritePolicyStatus(S3PolicyStatus response)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+
+        var builder = new StringBuilder(256);
+        using var stringWriter = new Utf8StringWriter(builder, CultureInfo.InvariantCulture);
+        using var xmlWriter = XmlWriter.Create(stringWriter, CreateSettings());
+
+        xmlWriter.WriteStartDocument();
+        WriteStartRootElement(xmlWriter, "PolicyStatus");
+
+        xmlWriter.WriteElementString("IsPublic", XmlConvert.ToString(response.IsPublic));
+
+        xmlWriter.WriteEndElement();
+        xmlWriter.WriteEndDocument();
+        xmlWriter.Flush();
+
+        return builder.ToString();
+    }
+
     /// <summary>Writes a CorsConfiguration as an XML response body.</summary>
     /// <param name="response">The <see cref="S3CorsConfiguration"/> to serialize.</param>
     /// <returns>The XML string.</returns>

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -268,6 +268,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         if (!ShouldPersistBucketMetadata(metadata)) {
@@ -334,6 +335,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         if (!ShouldPersistBucketMetadata(updatedMetadata)) {
@@ -376,6 +378,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         if (!ShouldPersistBucketMetadata(updatedMetadata)) {
@@ -448,6 +451,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -489,6 +493,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -561,6 +566,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = diskConfig,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -605,6 +611,116 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = null,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
+        };
+
+        await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
+        return StorageResult.Success();
+    }
+
+    // -------------------------------------------------------------------------
+    // Bucket Ownership Controls
+    // -------------------------------------------------------------------------
+
+    public async ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bucketPath = GetBucketPath(bucketName);
+        if (!Directory.Exists(bucketPath)) {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(BucketNotFound(bucketName));
+        }
+
+        var metadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
+        if (metadata.OwnershipControlsConfiguration is null) {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(ConfigurationNotFound(StorageErrorCode.OwnershipControlsNotFound, bucketName, "ownership controls"));
+        }
+
+        return StorageResult<BucketOwnershipControlsConfiguration>.Success(new BucketOwnershipControlsConfiguration
+        {
+            BucketName = bucketName,
+            ObjectOwnership = metadata.OwnershipControlsConfiguration.ObjectOwnership
+        });
+    }
+
+    public async ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bucketPath = GetBucketPath(request.BucketName);
+        if (!Directory.Exists(bucketPath)) {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(BucketNotFound(request.BucketName));
+        }
+
+        var diskConfig = new DiskBucketOwnershipControlsConfiguration
+        {
+            ObjectOwnership = request.ObjectOwnership
+        };
+
+        using var bucketMutationLock = await AcquireBucketMutationLockAsync(bucketPath, cancellationToken);
+        var existingMetadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
+        var updatedMetadata = new DiskBucketMetadata
+        {
+            VersioningStatus = existingMetadata.VersioningStatus,
+            CorsConfiguration = existingMetadata.CorsConfiguration,
+            TaggingConfiguration = existingMetadata.TaggingConfiguration,
+            LoggingConfiguration = existingMetadata.LoggingConfiguration,
+            WebsiteConfiguration = existingMetadata.WebsiteConfiguration,
+            RequestPaymentConfiguration = existingMetadata.RequestPaymentConfiguration,
+            AccelerateConfiguration = existingMetadata.AccelerateConfiguration,
+            LifecycleConfiguration = existingMetadata.LifecycleConfiguration,
+            ReplicationConfiguration = existingMetadata.ReplicationConfiguration,
+            NotificationConfiguration = existingMetadata.NotificationConfiguration,
+            ObjectLockConfiguration = existingMetadata.ObjectLockConfiguration,
+            AnalyticsConfigurations = existingMetadata.AnalyticsConfigurations,
+            MetricsConfigurations = existingMetadata.MetricsConfigurations,
+            InventoryConfigurations = existingMetadata.InventoryConfigurations,
+            IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = diskConfig,
+        };
+
+        await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
+
+        return StorageResult<BucketOwnershipControlsConfiguration>.Success(new BucketOwnershipControlsConfiguration
+        {
+            BucketName = request.BucketName,
+            ObjectOwnership = diskConfig.ObjectOwnership
+        });
+    }
+
+    public async ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var bucketPath = GetBucketPath(request.BucketName);
+        if (!Directory.Exists(bucketPath)) {
+            return StorageResult.Failure(BucketNotFound(request.BucketName));
+        }
+
+        using var bucketMutationLock = await AcquireBucketMutationLockAsync(bucketPath, cancellationToken);
+        var existingMetadata = await ReadBucketMetadataAsync(bucketPath, cancellationToken);
+        var updatedMetadata = new DiskBucketMetadata
+        {
+            VersioningStatus = existingMetadata.VersioningStatus,
+            CorsConfiguration = existingMetadata.CorsConfiguration,
+            TaggingConfiguration = existingMetadata.TaggingConfiguration,
+            LoggingConfiguration = existingMetadata.LoggingConfiguration,
+            WebsiteConfiguration = existingMetadata.WebsiteConfiguration,
+            RequestPaymentConfiguration = existingMetadata.RequestPaymentConfiguration,
+            AccelerateConfiguration = existingMetadata.AccelerateConfiguration,
+            LifecycleConfiguration = existingMetadata.LifecycleConfiguration,
+            ReplicationConfiguration = existingMetadata.ReplicationConfiguration,
+            NotificationConfiguration = existingMetadata.NotificationConfiguration,
+            ObjectLockConfiguration = existingMetadata.ObjectLockConfiguration,
+            AnalyticsConfigurations = existingMetadata.AnalyticsConfigurations,
+            MetricsConfigurations = existingMetadata.MetricsConfigurations,
+            InventoryConfigurations = existingMetadata.InventoryConfigurations,
+            IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
+            PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = null,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -669,6 +785,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -733,6 +850,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -770,6 +888,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -835,6 +954,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -905,6 +1025,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -968,6 +1089,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1005,6 +1127,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1063,6 +1186,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1100,6 +1224,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1157,6 +1282,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1229,6 +1355,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1292,6 +1419,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1334,6 +1462,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1417,6 +1546,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1459,6 +1589,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1542,6 +1673,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = updatedDict,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1584,6 +1716,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = updatedDict.Count > 0 ? updatedDict : null,
             IntelligentTieringConfigurations = existingMetadata.IntelligentTieringConfigurations,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1667,6 +1800,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = updatedDict,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -1709,6 +1843,7 @@ internal sealed class DiskStorageService(
             InventoryConfigurations = existingMetadata.InventoryConfigurations,
             IntelligentTieringConfigurations = updatedDict.Count > 0 ? updatedDict : null,
             PublicAccessBlockConfiguration = existingMetadata.PublicAccessBlockConfiguration,
+            OwnershipControlsConfiguration = existingMetadata.OwnershipControlsConfiguration,
         };
 
         await PersistBucketMetadataAsync(bucketPath, updatedMetadata, cancellationToken);
@@ -5012,7 +5147,8 @@ internal sealed class DiskStorageService(
             || metadata.MetricsConfigurations is { Count: > 0 }
             || metadata.InventoryConfigurations is { Count: > 0 }
             || metadata.IntelligentTieringConfigurations is { Count: > 0 }
-            || metadata.PublicAccessBlockConfiguration is not null;
+            || metadata.PublicAccessBlockConfiguration is not null
+            || metadata.OwnershipControlsConfiguration is not null;
     }
 
     private static BucketCorsConfiguration ToBucketCorsConfiguration(string bucketName, DiskBucketCorsConfiguration configuration)

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskBucketMetadata.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskBucketMetadata.cs
@@ -50,6 +50,9 @@ internal sealed class DiskBucketMetadata
 
     [JsonPropertyName("publicAccessBlockConfiguration")]
     public DiskBucketPublicAccessBlockConfiguration? PublicAccessBlockConfiguration { get; init; }
+
+    [JsonPropertyName("ownershipControlsConfiguration")]
+    public DiskBucketOwnershipControlsConfiguration? OwnershipControlsConfiguration { get; init; }
 }
 
 internal sealed class DiskBucketCorsConfiguration
@@ -95,6 +98,14 @@ internal sealed class DiskBucketPublicAccessBlockConfiguration
 
     [JsonPropertyName("restrictPublicBuckets")]
     public bool RestrictPublicBuckets { get; init; }
+}
+
+// --- Ownership Controls ---
+
+internal sealed class DiskBucketOwnershipControlsConfiguration
+{
+    [JsonPropertyName("objectOwnership")]
+    public string ObjectOwnership { get; init; } = string.Empty;
 }
 
 // --- Logging ---

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskStorageJsonSerializerContext.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/Internal/DiskStorageJsonSerializerContext.cs
@@ -9,6 +9,7 @@ namespace IntegratedS3.Provider.Disk.Internal;
 [JsonSerializable(typeof(DiskMultipartUploadState))]
 [JsonSerializable(typeof(DiskBucketTaggingConfiguration))]
 [JsonSerializable(typeof(DiskBucketPublicAccessBlockConfiguration))]
+[JsonSerializable(typeof(DiskBucketOwnershipControlsConfiguration))]
 [JsonSerializable(typeof(DiskBucketLoggingConfiguration))]
 [JsonSerializable(typeof(DiskBucketWebsiteConfiguration))]
 [JsonSerializable(typeof(DiskBucketWebsiteRedirectAllRequestsTo))]

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/AwsS3StorageClient.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/AwsS3StorageClient.cs
@@ -11,6 +11,7 @@ using PutBucketDefaultEncryptionStorageRequest = IntegratedS3.Abstractions.Reque
 using UploadPartCopyStorageRequest = IntegratedS3.Abstractions.Requests.UploadPartCopyRequest;
 using PutBucketTaggingStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketTaggingRequest;
 using PutBucketPublicAccessBlockStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketPublicAccessBlockRequest;
+using PutBucketOwnershipControlsStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketOwnershipControlsRequest;
 using PutBucketLoggingStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketLoggingRequest;
 using PutBucketWebsiteStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketWebsiteRequest;
 using PutBucketRequestPaymentStorageRequest = IntegratedS3.Abstractions.Requests.PutBucketRequestPaymentRequest;
@@ -387,6 +388,63 @@ internal sealed class AwsS3StorageClient : IS3StorageClient
         };
 
         await _s3.DeletePublicAccessBlockAsync(request, cancellationToken).ConfigureAwait(false);
+    }
+
+    // -------------------------------------------------------------------------
+    // Bucket Ownership Controls
+    // -------------------------------------------------------------------------
+
+    public async Task<BucketOwnershipControlsConfiguration> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        var request = new GetBucketOwnershipControlsRequest
+        {
+            BucketName = bucketName
+        };
+
+        var response = await _s3.GetBucketOwnershipControlsAsync(request, cancellationToken).ConfigureAwait(false);
+        var rule = response.OwnershipControls?.Rules?.FirstOrDefault();
+        return new BucketOwnershipControlsConfiguration
+        {
+            BucketName = bucketName,
+            ObjectOwnership = rule?.ObjectOwnership?.Value ?? string.Empty
+        };
+    }
+
+    public async Task<BucketOwnershipControlsConfiguration> SetBucketOwnershipControlsAsync(PutBucketOwnershipControlsStorageRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var putRequest = new PutBucketOwnershipControlsRequest
+        {
+            BucketName = request.BucketName,
+            OwnershipControls = new Amazon.S3.Model.OwnershipControls
+            {
+                Rules =
+                [
+                    new OwnershipControlsRule
+                    {
+                        ObjectOwnership = ObjectOwnership.FindValue(request.ObjectOwnership)
+                    }
+                ]
+            }
+        };
+
+        await _s3.PutBucketOwnershipControlsAsync(putRequest, cancellationToken).ConfigureAwait(false);
+        return new BucketOwnershipControlsConfiguration
+        {
+            BucketName = request.BucketName,
+            ObjectOwnership = request.ObjectOwnership
+        };
+    }
+
+    public async Task DeleteBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        var request = new DeleteBucketOwnershipControlsRequest
+        {
+            BucketName = bucketName
+        };
+
+        await _s3.DeleteBucketOwnershipControlsAsync(request, cancellationToken).ConfigureAwait(false);
     }
 
     // -------------------------------------------------------------------------

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/IS3StorageClient.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/Internal/IS3StorageClient.cs
@@ -41,6 +41,14 @@ internal interface IS3StorageClient : IDisposable
     Task DeleteBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
         => Task.FromException(new NotSupportedException("Bucket public access block is not implemented by this S3 storage client."));
 
+    // Bucket Ownership Controls
+    Task<BucketOwnershipControlsConfiguration> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+        => Task.FromException<BucketOwnershipControlsConfiguration>(new NotSupportedException("Bucket ownership controls are not implemented by this S3 storage client."));
+    Task<BucketOwnershipControlsConfiguration> SetBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        => Task.FromException<BucketOwnershipControlsConfiguration>(new NotSupportedException("Bucket ownership controls are not implemented by this S3 storage client."));
+    Task DeleteBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+        => Task.FromException(new NotSupportedException("Bucket ownership controls are not implemented by this S3 storage client."));
+
     // Object listing
     Task<S3ObjectListPage> ListObjectsAsync(
         string bucketName,

--- a/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.S3/S3StorageService.cs
@@ -411,6 +411,61 @@ internal sealed class S3StorageService(S3StorageOptions options, IS3StorageClien
     }
 
     // -------------------------------------------------------------------------
+    // Bucket Ownership Controls
+    // -------------------------------------------------------------------------
+
+    public async ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _client.GetBucketOwnershipControlsAsync(bucketName, cancellationToken).ConfigureAwait(false);
+            return StorageResult<BucketOwnershipControlsConfiguration>.Success(config);
+        }
+        catch (AmazonServiceException ex)
+        {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, bucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, bucketName));
+        }
+    }
+
+    public async ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var config = await _client.SetBucketOwnershipControlsAsync(request, cancellationToken).ConfigureAwait(false);
+            return StorageResult<BucketOwnershipControlsConfiguration>.Success(config);
+        }
+        catch (AmazonServiceException ex)
+        {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult<BucketOwnershipControlsConfiguration>.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
+        }
+    }
+
+    public async ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            await _client.DeleteBucketOwnershipControlsAsync(request.BucketName, cancellationToken).ConfigureAwait(false);
+            return StorageResult.Success();
+        }
+        catch (AmazonServiceException ex)
+        {
+            return StorageResult.Failure(S3ErrorTranslator.Translate(ex, Name, request.BucketName));
+        }
+        catch (Exception ex) when (S3ErrorTranslator.IsTransportFailure(ex, cancellationToken))
+        {
+            return StorageResult.Failure(S3ErrorTranslator.TranslateTransport(ex, Name, request.BucketName));
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Bucket Tagging
     // -------------------------------------------------------------------------
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -1867,6 +1867,7 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     // so the (existing) handler was unreachable. It must now route through and surface the mapped 404.
     [InlineData("?intelligent-tiering&id=report", "NoSuchConfiguration")]
     [InlineData("?publicAccessBlock", "NoSuchPublicAccessBlockConfiguration")]
+    [InlineData("?ownershipControls", "OwnershipControlsNotFoundError")]
     public async Task S3CompatibleBucketSubresource_WhenConfigAbsent_ReturnsNoSuchCodeWithNotFoundStatus(string query, string expectedCode)
     {
         // Regression test for #152: absent bucket subresource configs must surface the specific
@@ -1877,6 +1878,139 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         var response = await client.GetAsync($"/integrated-s3/absent-config-bucket{query}");
 
         await AssertErrorResponseAsync(response, HttpStatusCode.NotFound, expectedCode);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketOwnershipControls_RoundTripsXmlPayload()
+    {
+        var storageService = new RecordingStorageService();
+        await using var isolatedClient = await CreateStorageServiceIsolatedClientAsync(storageService);
+        using var client = isolatedClient.Client;
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/ownership-controls-bucket?ownershipControls")
+        {
+            Content = new StringContent("""
+<OwnershipControls>
+  <Rule>
+    <ObjectOwnership>BucketOwnerEnforced</ObjectOwnership>
+  </Rule>
+</OwnershipControls>
+""", Encoding.UTF8, "application/xml")
+        };
+
+        var putResponse = await client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        var putOwnershipControls = storageService.LastPutBucketOwnershipControlsRequest
+            ?? throw new Xunit.Sdk.XunitException("Expected bucket ownership controls request to reach the storage service.");
+        Assert.Equal("BucketOwnerEnforced", putOwnershipControls.ObjectOwnership);
+
+        var getResponse = await client.GetAsync("/integrated-s3/ownership-controls-bucket?ownershipControls");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        Assert.Equal("application/xml", getResponse.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await getResponse.Content.ReadAsStringAsync());
+        Assert.Equal("OwnershipControls", document.Root?.Name.LocalName);
+        var rule = document.Root!.Element(S3Ns + "Rule");
+        Assert.NotNull(rule);
+        Assert.Equal("BucketOwnerEnforced", rule!.Element(S3Ns + "ObjectOwnership")?.Value);
+
+        var deleteResponse = await client.DeleteAsync("/integrated-s3/ownership-controls-bucket?ownershipControls");
+        Assert.Equal(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+
+        var missingResponse = await client.GetAsync("/integrated-s3/ownership-controls-bucket?ownershipControls");
+        await AssertErrorResponseAsync(missingResponse, HttpStatusCode.NotFound, "OwnershipControlsNotFoundError");
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketOwnershipControls_PersistsThroughDiskProvider()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "ownership-controls-disk-bucket";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        // GET before any config is set surfaces the specific NotFound error.
+        var missingBefore = await client.GetAsync($"/integrated-s3/{bucketName}?ownershipControls");
+        await AssertErrorResponseAsync(missingBefore, HttpStatusCode.NotFound, "OwnershipControlsNotFoundError");
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, $"/integrated-s3/{bucketName}?ownershipControls")
+        {
+            Content = new StringContent("""
+<OwnershipControls>
+  <Rule>
+    <ObjectOwnership>BucketOwnerPreferred</ObjectOwnership>
+  </Rule>
+</OwnershipControls>
+""", Encoding.UTF8, "application/xml")
+        };
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(putRequest)).StatusCode);
+
+        var getResponse = await client.GetAsync($"/integrated-s3/{bucketName}?ownershipControls");
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+        var document = XDocument.Parse(await getResponse.Content.ReadAsStringAsync());
+        Assert.Equal("OwnershipControls", document.Root?.Name.LocalName);
+        Assert.Equal("BucketOwnerPreferred", document.Root!.Element(S3Ns + "Rule")?.Element(S3Ns + "ObjectOwnership")?.Value);
+
+        Assert.Equal(HttpStatusCode.NoContent, (await client.DeleteAsync($"/integrated-s3/{bucketName}?ownershipControls")).StatusCode);
+
+        var missingAfter = await client.GetAsync($"/integrated-s3/{bucketName}?ownershipControls");
+        await AssertErrorResponseAsync(missingAfter, HttpStatusCode.NotFound, "OwnershipControlsNotFoundError");
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketOwnershipControls_WithInvalidObjectOwnership_ReturnsMalformedXml()
+    {
+        var storageService = new RecordingStorageService();
+        await using var isolatedClient = await CreateStorageServiceIsolatedClientAsync(storageService);
+        using var client = isolatedClient.Client;
+
+        using var putRequest = new HttpRequestMessage(HttpMethod.Put, "/integrated-s3/ownership-controls-invalid-bucket?ownershipControls")
+        {
+            Content = new StringContent("""
+<OwnershipControls>
+  <Rule>
+    <ObjectOwnership>NotAValidValue</ObjectOwnership>
+  </Rule>
+</OwnershipControls>
+""", Encoding.UTF8, "application/xml")
+        };
+
+        var response = await client.SendAsync(putRequest);
+        await AssertErrorResponseAsync(response, HttpStatusCode.BadRequest, "MalformedXML");
+        Assert.Null(storageService.LastPutBucketOwnershipControlsRequest);
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketPolicyStatus_WhenNoPolicy_ReturnsIsPublicFalse()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "policy-status-bucket";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+
+        var response = await client.GetAsync($"/integrated-s3/{bucketName}?policyStatus");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("application/xml", response.Content.Headers.ContentType?.MediaType);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.Equal("PolicyStatus", document.Root?.Name.LocalName);
+        Assert.Equal("false", document.Root!.Element(S3Ns + "IsPublic")?.Value);
+    }
+
+    [Fact]
+    public async Task S3CompatibleObjectTorrent_ReturnsNotImplemented()
+    {
+        using var client = await _factory.CreateClientAsync();
+        const string bucketName = "torrent-bucket";
+        const string objectKey = "torrent-object.txt";
+
+        Assert.Equal(HttpStatusCode.Created, (await client.PutAsync($"/integrated-s3/buckets/{bucketName}", content: null)).StatusCode);
+        Assert.Equal(HttpStatusCode.OK, (await client.PutAsync($"/integrated-s3/{bucketName}/{objectKey}", new StringContent("payload", Encoding.UTF8, "text/plain"))).StatusCode);
+
+        var response = await client.GetAsync($"/integrated-s3/{bucketName}/{objectKey}?torrent");
+
+        await AssertNotImplementedResponseAsync(response);
     }
 
     [Fact]
@@ -5575,7 +5709,7 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
     }
 
     [Theory]
-    [InlineData("ownershipControls")]
+    [InlineData("notarealsubresource")]
     [InlineData("versioning&list-type=2")]
     [InlineData("cors&versioning")]
     public async Task S3CompatibleBucketRoute_UnsupportedSubresource_ReturnsNotImplemented(string query)
@@ -10810,6 +10944,9 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         public ValueTask<StorageResult<BucketPublicAccessBlockConfiguration>> GetBucketPublicAccessBlockAsync(string bucketName, CancellationToken cancellationToken = default)
             => ValueTask.FromResult(StorageResult<BucketPublicAccessBlockConfiguration>.Failure(NotFound(StorageErrorCode.PublicAccessBlockConfigurationNotFound, bucketName)));
 
+        public ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(StorageResult<BucketOwnershipControlsConfiguration>.Failure(NotFound(StorageErrorCode.OwnershipControlsNotFound, bucketName)));
+
         public ValueTask<StorageResult<BucketWebsiteConfiguration>> GetBucketWebsiteAsync(string bucketName, CancellationToken cancellationToken = default)
             => ValueTask.FromResult(StorageResult<BucketWebsiteConfiguration>.Failure(NotFound(StorageErrorCode.WebsiteConfigurationNotFound, bucketName)));
 
@@ -11113,6 +11250,10 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
 
         public DeleteBucketPublicAccessBlockRequest? LastDeleteBucketPublicAccessBlockRequest { get; private set; }
 
+        public PutBucketOwnershipControlsRequest? LastPutBucketOwnershipControlsRequest { get; private set; }
+
+        public DeleteBucketOwnershipControlsRequest? LastDeleteBucketOwnershipControlsRequest { get; private set; }
+
         public ObjectInfo? PutObjectResult { get; set; }
 
         public ObjectInfo? CopyObjectResult { get; set; }
@@ -11143,6 +11284,8 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         private readonly Dictionary<string, BucketDefaultEncryptionConfiguration> _bucketDefaultEncryptions = new(StringComparer.Ordinal);
 
         private readonly Dictionary<string, BucketPublicAccessBlockConfiguration> _bucketPublicAccessBlocks = new(StringComparer.Ordinal);
+
+        private readonly Dictionary<string, BucketOwnershipControlsConfiguration> _bucketOwnershipControls = new(StringComparer.Ordinal);
 
         public IAsyncEnumerable<BucketInfo> ListBucketsAsync(CancellationToken cancellationToken = default) => throw new NotSupportedException();
 
@@ -11220,6 +11363,36 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         {
             LastDeleteBucketPublicAccessBlockRequest = request;
             _bucketPublicAccessBlocks.Remove(request.BucketName);
+            return ValueTask.FromResult(StorageResult.Success());
+        }
+
+        public ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> GetBucketOwnershipControlsAsync(string bucketName, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return ValueTask.FromResult(_bucketOwnershipControls.TryGetValue(bucketName, out var configuration)
+                ? StorageResult<BucketOwnershipControlsConfiguration>.Success(CloneOwnershipControls(bucketName, configuration))
+                : StorageResult<BucketOwnershipControlsConfiguration>.Failure(CreateOwnershipControlsNotFound(bucketName)));
+        }
+
+        public ValueTask<StorageResult<BucketOwnershipControlsConfiguration>> PutBucketOwnershipControlsAsync(PutBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        {
+            LastPutBucketOwnershipControlsRequest = request;
+
+            var configuration = new BucketOwnershipControlsConfiguration
+            {
+                BucketName = request.BucketName,
+                ObjectOwnership = request.ObjectOwnership
+            };
+
+            _bucketOwnershipControls[request.BucketName] = configuration;
+            return ValueTask.FromResult(StorageResult<BucketOwnershipControlsConfiguration>.Success(CloneOwnershipControls(request.BucketName, configuration)));
+        }
+
+        public ValueTask<StorageResult> DeleteBucketOwnershipControlsAsync(DeleteBucketOwnershipControlsRequest request, CancellationToken cancellationToken = default)
+        {
+            LastDeleteBucketOwnershipControlsRequest = request;
+            _bucketOwnershipControls.Remove(request.BucketName);
             return ValueTask.FromResult(StorageResult.Success());
         }
 
@@ -11538,6 +11711,26 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
             {
                 Code = StorageErrorCode.PublicAccessBlockConfigurationNotFound,
                 Message = $"Bucket '{bucketName}' does not have a public access block configuration.",
+                BucketName = bucketName,
+                SuggestedHttpStatusCode = 404
+            };
+        }
+
+        private static BucketOwnershipControlsConfiguration CloneOwnershipControls(string bucketName, BucketOwnershipControlsConfiguration configuration)
+        {
+            return new BucketOwnershipControlsConfiguration
+            {
+                BucketName = bucketName,
+                ObjectOwnership = configuration.ObjectOwnership
+            };
+        }
+
+        private static StorageError CreateOwnershipControlsNotFound(string bucketName)
+        {
+            return new StorageError
+            {
+                Code = StorageErrorCode.OwnershipControlsNotFound,
+                Message = $"Bucket '{bucketName}' does not have an ownership controls configuration.",
                 BucketName = bucketName,
                 SuggestedHttpStatusCode = 404
             };


### PR DESCRIPTION
Closes #166.

Implements the three previously-missing S3 subresources — all of which used to fall through to a generic `501 NotImplemented` — following the existing bucket-config subresource pattern (`PublicAccessBlock`) end-to-end.

## `?ownershipControls` (GET / PUT / DELETE)
Persisted bucket **OwnershipControls** configuration (`ObjectOwnership`: `BucketOwnerPreferred` / `ObjectWriter` / `BucketOwnerEnforced`).
- **PUT** persists; **GET** returns the config, or `404 OwnershipControlsNotFoundError` when unset; **DELETE** removes it.
- Wired through the full stack, matching `PublicAccessBlock`:
  - `IStorageService` / `IStorageBackend` (new methods, default-unsupported so no test-double churn)
  - `AuthorizingStorageService` (per-op authorization) + `OrchestratedStorageService` (replica write-through + strict-replica preflight)
  - **Disk provider**: persisted in bucket metadata (`ownershipControlsConfiguration`), added to the JSON serializer context and to every metadata round-trip so other subresource writes don't drop it
  - **S3 provider**: forwards to the AWS SDK (`GetBucketOwnershipControls` / `PutBucketOwnershipControls` / `DeleteBucketOwnershipControls`)
- Hardened XML read (DTD-prohibited, entity-expansion capped) with `ObjectOwnership` value validation; xmlns-namespaced XML write.

## `?policyStatus` (GET — GetBucketPolicyStatus)
Returns `<PolicyStatus><IsPublic>false</IsPublic></PolicyStatus>`. Verifies the bucket exists (surfaces `NoSuchBucket` otherwise rather than a misleading `IsPublic=false`). IsPublic is `false` because IntegratedS3 does not grant anonymous public access via bucket policy, and is `false` by definition when no policy is set.

## `?torrent` (GET — GetObjectTorrent)
Returns a clean, well-formed `501 NotImplemented` S3 XML error, making it a KNOWN, correctly-erroring subresource rather than a generic failure (AWS's real BitTorrent-file behavior is out of scope — the issue asks only that it be acknowledged).

## Validators
All three are added to the request-validator known-subresource sets (`KnownBucketQueryParameters` / `KnownObjectQueryParameters`) and the per-method validation switches so they dispatch instead of being rejected pre-dispatch.

## Tests
- `ownershipControls` PUT/GET/DELETE round-trip + not-found — via recording storage service **and** the real Disk provider
- invalid `ObjectOwnership` → `MalformedXML` (400), storage untouched
- `policyStatus` GET → `IsPublic=false`
- `torrent` GET → `NotImplemented` (501)
- Updated the stale `UnsupportedSubresource` test that asserted `ownershipControls` returned 501; added `?ownershipControls` to the absent-config not-found theory

Full suite: **1239 passed, 0 failed**. Build clean (0 warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)