### PR TITLE
fix: order listing keys by UTF-8 bytes and honor whitespace delimiter/start-after (#167)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Abstractions/Comparers/Utf8OrdinalComparer.cs
+++ b/src/IntegratedS3/IntegratedS3.Abstractions/Comparers/Utf8OrdinalComparer.cs
@@ -1,0 +1,129 @@
+using System.Text;
+
+namespace IntegratedS3.Abstractions.Comparers;
+
+/// <summary>
+/// An ordinal string comparer that orders strings by their UTF-8 byte sequence, matching the
+/// lexicographic ordering AWS S3 applies to object keys, common prefixes, and version markers.
+/// </summary>
+/// <remarks>
+/// <para>
+/// .NET's <see cref="StringComparer.Ordinal"/> compares UTF-16 code units. For ASCII and the
+/// Basic Multilingual Plane the result matches UTF-8 byte order, but astral-plane characters
+/// (code points U+10000 and above, encoded in UTF-16 as surrogate pairs whose code units lie in
+/// U+D800..U+DFFF) sort <em>before</em> BMP characters such as U+E000..U+FFFF under code-unit
+/// ordering, whereas AWS &#8212; sorting raw UTF-8 bytes &#8212; sorts them <em>after</em>. This
+/// comparer reproduces the AWS ordering so listing pagination, marker filtering, and
+/// <c>CommonPrefixes</c> grouping stay consistent for keys containing emoji and other astral
+/// characters.
+/// </para>
+/// <para>
+/// UTF-8 byte order is equivalent to Unicode scalar-value (code point) order, so the comparison is
+/// performed by decoding each string into <see cref="Rune"/> values and comparing their scalar
+/// values. This avoids materializing intermediate byte buffers while producing exactly the same
+/// ordering as comparing <c>Encoding.UTF8.GetBytes(x)</c> against <c>Encoding.UTF8.GetBytes(y)</c>.
+/// </para>
+/// </remarks>
+public sealed class Utf8OrdinalComparer : IComparer<string?>, IEqualityComparer<string?>
+{
+    /// <summary>
+    /// Gets the shared, thread-safe <see cref="Utf8OrdinalComparer"/> instance.
+    /// </summary>
+    public static Utf8OrdinalComparer Instance { get; } = new();
+
+    private Utf8OrdinalComparer()
+    {
+    }
+
+    /// <summary>
+    /// Compares two strings by their UTF-8 byte sequence (equivalently, Unicode scalar-value order).
+    /// </summary>
+    /// <param name="x">The first string, or <c>null</c>.</param>
+    /// <param name="y">The second string, or <c>null</c>.</param>
+    /// <returns>
+    /// A negative value if <paramref name="x"/> sorts before <paramref name="y"/>, zero if they are
+    /// equal, and a positive value if <paramref name="x"/> sorts after <paramref name="y"/>.
+    /// <c>null</c> sorts before any non-<c>null</c> value.
+    /// </returns>
+    public int Compare(string? x, string? y)
+    {
+        if (ReferenceEquals(x, y)) {
+            return 0;
+        }
+
+        if (x is null) {
+            return -1;
+        }
+
+        if (y is null) {
+            return 1;
+        }
+
+        return Compare(x.AsSpan(), y.AsSpan());
+    }
+
+    /// <summary>
+    /// Compares two character spans by their UTF-8 byte sequence (equivalently, Unicode scalar-value order).
+    /// </summary>
+    /// <param name="x">The first span.</param>
+    /// <param name="y">The second span.</param>
+    /// <returns>
+    /// A negative value if <paramref name="x"/> sorts before <paramref name="y"/>, zero if they are
+    /// equal, and a positive value if <paramref name="x"/> sorts after <paramref name="y"/>.
+    /// </returns>
+    public static int Compare(ReadOnlySpan<char> x, ReadOnlySpan<char> y)
+    {
+        var xIndex = 0;
+        var yIndex = 0;
+
+        while (xIndex < x.Length && yIndex < y.Length) {
+            var xScalar = DecodeScalar(x, ref xIndex);
+            var yScalar = DecodeScalar(y, ref yIndex);
+
+            if (xScalar != yScalar) {
+                return xScalar < yScalar ? -1 : 1;
+            }
+        }
+
+        // Shared prefix consumed identically; the shorter (fully consumed) span sorts first.
+        return (x.Length - xIndex).CompareTo(y.Length - yIndex);
+    }
+
+    /// <summary>
+    /// Determines whether two strings are ordinally equal (identical UTF-16 content).
+    /// </summary>
+    /// <param name="x">The first string, or <c>null</c>.</param>
+    /// <param name="y">The second string, or <c>null</c>.</param>
+    /// <returns><c>true</c> if the strings are equal; otherwise <c>false</c>.</returns>
+    public bool Equals(string? x, string? y) => string.Equals(x, y, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Returns an ordinal hash code for the supplied string.
+    /// </summary>
+    /// <param name="obj">The string to hash.</param>
+    /// <returns>An ordinal hash code.</returns>
+    public int GetHashCode(string? obj) => obj is null ? 0 : string.GetHashCode(obj, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Decodes the Unicode scalar value at <paramref name="index"/>, advancing <paramref name="index"/>
+    /// past the consumed UTF-16 code unit(s). A lone or malformed surrogate is treated as the Unicode
+    /// replacement character (U+FFFD), matching how UTF-8 encoding would round-trip invalid input.
+    /// </summary>
+    private static int DecodeScalar(ReadOnlySpan<char> value, ref int index)
+    {
+        var current = value[index];
+
+        if (char.IsHighSurrogate(current)
+            && index + 1 < value.Length
+            && char.IsLowSurrogate(value[index + 1])) {
+            var scalar = char.ConvertToUtf32(current, value[index + 1]);
+            index += 2;
+            return scalar;
+        }
+
+        index += 1;
+
+        // Unpaired surrogate: substitute the replacement character so ordering stays deterministic.
+        return char.IsSurrogate(current) ? 0xFFFD : current;
+    }
+}

--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
 using IntegratedS3.Abstractions.Capabilities;
+using IntegratedS3.Abstractions.Comparers;
 using IntegratedS3.Abstractions.Errors;
 using IntegratedS3.Abstractions.Models;
 using IntegratedS3.Abstractions.Requests;
@@ -3493,10 +3494,10 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                     return ToErrorResult(httpContext, StatusCodes.Status400BadRequest, "InvalidArgument", "max-uploads must be between 1 and 1000.", BuildObjectResource(bucketName, null), bucketName);
                 }
 
-                var normalizedKeyMarker = string.IsNullOrWhiteSpace(keyMarker)
+                var normalizedKeyMarker = string.IsNullOrEmpty(keyMarker)
                     ? null
                     : keyMarker;
-                var normalizedUploadIdMarker = normalizedKeyMarker is null || string.IsNullOrWhiteSpace(uploadIdMarker)
+                var normalizedUploadIdMarker = normalizedKeyMarker is null || string.IsNullOrEmpty(uploadIdMarker)
                     ? null
                     : uploadIdMarker;
                 var requestedPageSize = parsedMaxUploads ?? 1000;
@@ -3569,7 +3570,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 try {
                     var normalizedPrefix = prefix ?? string.Empty;
                     var normalizedDelimiter = string.IsNullOrEmpty(delimiter) ? null : delimiter;
-                    var cursorKey = string.IsNullOrWhiteSpace(marker) ? null : marker;
+                    var cursorKey = string.IsNullOrEmpty(marker) ? null : marker;
 
                     var entries = await CollectListBucketEntriesAsync(
                         storageService.ListObjectsAsync(
@@ -3641,9 +3642,9 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 try {
                     var normalizedPrefix = prefix ?? string.Empty;
                     var normalizedDelimiter = string.IsNullOrEmpty(delimiter) ? null : delimiter;
-                    var cursorKey = !string.IsNullOrWhiteSpace(continuationToken)
+                    var cursorKey = !string.IsNullOrEmpty(continuationToken)
                         ? continuationToken
-                        : string.IsNullOrWhiteSpace(startAfter) ? null : startAfter;
+                        : string.IsNullOrEmpty(startAfter) ? null : startAfter;
 
                     var entries = await CollectListBucketEntriesAsync(
                         storageService.ListObjectsAsync(
@@ -4520,7 +4521,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
 
         var startAfter = values.ToString();
-        return string.IsNullOrWhiteSpace(startAfter)
+        return string.IsNullOrEmpty(startAfter)
             ? null
             : startAfter;
     }
@@ -4532,7 +4533,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
         }
 
         var marker = values.ToString();
-        return string.IsNullOrWhiteSpace(marker)
+        return string.IsNullOrEmpty(marker)
             ? null
             : marker;
     }
@@ -4685,8 +4686,8 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                 continue;
             }
 
-            if (!string.IsNullOrWhiteSpace(markerValue)
-                && StringComparer.Ordinal.Compare(key, markerValue) <= 0) {
+            if (!string.IsNullOrEmpty(markerValue)
+                && Utf8OrdinalComparer.Instance.Compare(key, markerValue) <= 0) {
                 continue;
             }
 
@@ -9725,11 +9726,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
 
     private static bool IsVersionAfterMarker(ObjectInfo version, string? keyMarker, string? versionIdMarker)
     {
-        if (string.IsNullOrWhiteSpace(keyMarker)) {
+        if (string.IsNullOrEmpty(keyMarker)) {
             return true;
         }
 
-        var keyComparison = StringComparer.Ordinal.Compare(version.Key, keyMarker);
+        var keyComparison = Utf8OrdinalComparer.Instance.Compare(version.Key, keyMarker);
         if (keyComparison > 0) {
             return true;
         }
@@ -9738,17 +9739,17 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             return false;
         }
 
-        return !string.IsNullOrWhiteSpace(versionIdMarker)
+        return !string.IsNullOrEmpty(versionIdMarker)
                && StringComparer.Ordinal.Compare(version.VersionId, versionIdMarker) < 0;
     }
 
     private static bool IsMultipartUploadAfterMarker(MultipartUploadInfo upload, string? keyMarker, string? uploadIdMarker)
     {
-        if (string.IsNullOrWhiteSpace(keyMarker)) {
+        if (string.IsNullOrEmpty(keyMarker)) {
             return true;
         }
 
-        var keyComparison = StringComparer.Ordinal.Compare(upload.Key, keyMarker);
+        var keyComparison = Utf8OrdinalComparer.Instance.Compare(upload.Key, keyMarker);
         if (keyComparison > 0) {
             return true;
         }
@@ -9757,7 +9758,7 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             return false;
         }
 
-        return !string.IsNullOrWhiteSpace(uploadIdMarker)
+        return !string.IsNullOrEmpty(uploadIdMarker)
                && StringComparer.Ordinal.Compare(upload.UploadId, uploadIdMarker) > 0;
     }
 

--- a/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
+++ b/src/IntegratedS3/IntegratedS3.Protocol/S3XmlResponseWriter.cs
@@ -428,19 +428,19 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteElementString("Prefix", EncodeS3ListValue(response.Prefix ?? string.Empty, response.EncodingType));
 
         if (response.IsV2) {
-            if (!string.IsNullOrWhiteSpace(response.Delimiter)) {
+            if (!string.IsNullOrEmpty(response.Delimiter)) {
                 xmlWriter.WriteElementString("Delimiter", EncodeS3ListValue(response.Delimiter, response.EncodingType));
             }
 
-            if (!string.IsNullOrWhiteSpace(response.StartAfter)) {
+            if (!string.IsNullOrEmpty(response.StartAfter)) {
                 xmlWriter.WriteElementString("StartAfter", EncodeS3ListValue(response.StartAfter, response.EncodingType));
             }
 
-            if (!string.IsNullOrWhiteSpace(response.ContinuationToken)) {
+            if (!string.IsNullOrEmpty(response.ContinuationToken)) {
                 xmlWriter.WriteElementString("ContinuationToken", response.ContinuationToken);
             }
 
-            if (!string.IsNullOrWhiteSpace(response.NextContinuationToken)) {
+            if (!string.IsNullOrEmpty(response.NextContinuationToken)) {
                 xmlWriter.WriteElementString("NextContinuationToken", response.NextContinuationToken);
             }
 
@@ -449,11 +449,11 @@ public static class S3XmlResponseWriter
         else {
             xmlWriter.WriteElementString("Marker", EncodeS3ListValue(response.Marker ?? string.Empty, response.EncodingType));
 
-            if (!string.IsNullOrWhiteSpace(response.Delimiter)) {
+            if (!string.IsNullOrEmpty(response.Delimiter)) {
                 xmlWriter.WriteElementString("Delimiter", EncodeS3ListValue(response.Delimiter, response.EncodingType));
             }
 
-            if (!string.IsNullOrWhiteSpace(response.NextMarker)) {
+            if (!string.IsNullOrEmpty(response.NextMarker)) {
                 xmlWriter.WriteElementString("NextMarker", EncodeS3ListValue(response.NextMarker, response.EncodingType));
             }
         }
@@ -509,7 +509,7 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteElementString("Name", response.Name);
         xmlWriter.WriteElementString("Prefix", EncodeS3ListValue(response.Prefix ?? string.Empty, response.EncodingType));
 
-        if (!string.IsNullOrWhiteSpace(response.Delimiter)) {
+        if (!string.IsNullOrEmpty(response.Delimiter)) {
             xmlWriter.WriteElementString("Delimiter", EncodeS3ListValue(response.Delimiter, response.EncodingType));
         }
 
@@ -518,11 +518,11 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteElementString("KeyMarker", EncodeS3ListValue(response.KeyMarker ?? string.Empty, response.EncodingType));
         xmlWriter.WriteElementString("VersionIdMarker", response.VersionIdMarker ?? string.Empty);
 
-        if (!string.IsNullOrWhiteSpace(response.NextKeyMarker)) {
+        if (!string.IsNullOrEmpty(response.NextKeyMarker)) {
             xmlWriter.WriteElementString("NextKeyMarker", EncodeS3ListValue(response.NextKeyMarker, response.EncodingType));
         }
 
-        if (!string.IsNullOrWhiteSpace(response.NextVersionIdMarker)) {
+        if (!string.IsNullOrEmpty(response.NextVersionIdMarker)) {
             xmlWriter.WriteElementString("NextVersionIdMarker", response.NextVersionIdMarker);
         }
 
@@ -584,15 +584,15 @@ public static class S3XmlResponseWriter
         xmlWriter.WriteElementString("UploadIdMarker", response.UploadIdMarker ?? string.Empty);
         xmlWriter.WriteElementString("Prefix", EncodeS3ListValue(response.Prefix ?? string.Empty, response.EncodingType));
 
-        if (!string.IsNullOrWhiteSpace(response.Delimiter)) {
+        if (!string.IsNullOrEmpty(response.Delimiter)) {
             xmlWriter.WriteElementString("Delimiter", EncodeS3ListValue(response.Delimiter, response.EncodingType));
         }
 
-        if (!string.IsNullOrWhiteSpace(response.NextKeyMarker)) {
+        if (!string.IsNullOrEmpty(response.NextKeyMarker)) {
             xmlWriter.WriteElementString("NextKeyMarker", EncodeS3ListValue(response.NextKeyMarker, response.EncodingType));
         }
 
-        if (!string.IsNullOrWhiteSpace(response.NextUploadIdMarker)) {
+        if (!string.IsNullOrEmpty(response.NextUploadIdMarker)) {
             xmlWriter.WriteElementString("NextUploadIdMarker", response.NextUploadIdMarker);
         }
 

--- a/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Provider.Disk/DiskStorageService.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using IntegratedS3.Abstractions.Capabilities;
+using IntegratedS3.Abstractions.Comparers;
 using IntegratedS3.Abstractions.Errors;
 using IntegratedS3.Abstractions.Models;
 using IntegratedS3.Abstractions.Requests;
@@ -2003,7 +2004,7 @@ internal sealed class DiskStorageService(
                 ObjectKey = GetObjectKey(bucketPath, filePath)
             })
             .Where(entry => string.IsNullOrEmpty(prefix) || entry.ObjectKey.StartsWith(prefix, StringComparison.Ordinal))
-            .OrderBy(entry => entry.ObjectKey, StringComparer.Ordinal);
+            .OrderBy(entry => entry.ObjectKey, Utf8OrdinalComparer.Instance);
 
         var yielded = 0;
 
@@ -2011,7 +2012,7 @@ internal sealed class DiskStorageService(
             cancellationToken.ThrowIfCancellationRequested();
 
             if (!string.IsNullOrEmpty(continuationToken)
-                && StringComparer.Ordinal.Compare(entry.ObjectKey, continuationToken) <= 0) {
+                && Utf8OrdinalComparer.Instance.Compare(entry.ObjectKey, continuationToken) <= 0) {
                 continue;
             }
 
@@ -4727,7 +4728,7 @@ internal sealed class DiskStorageService(
         }
 
         return versions
-            .OrderBy(version => version.Key, StringComparer.Ordinal)
+            .OrderBy(version => version.Key, Utf8OrdinalComparer.Instance)
             .ThenByDescending(version => version.IsLatest)
             .ThenByDescending(version => version.VersionId, StringComparer.Ordinal)
             .ToArray();
@@ -4742,7 +4743,7 @@ internal sealed class DiskStorageService(
             }
 
             return uploadsFromStateStore
-                .OrderBy(static upload => upload.Key, StringComparer.Ordinal)
+                .OrderBy(static upload => upload.Key, Utf8OrdinalComparer.Instance)
                 .ThenBy(upload => upload.InitiatedAtUtc)
                 .ThenBy(static upload => upload.UploadId, StringComparer.Ordinal)
                 .ToArray();
@@ -4779,7 +4780,7 @@ internal sealed class DiskStorageService(
         }
 
         return uploads
-            .OrderBy(static upload => upload.Key, StringComparer.Ordinal)
+            .OrderBy(static upload => upload.Key, Utf8OrdinalComparer.Instance)
             .ThenBy(upload => upload.InitiatedAtUtc)
             .ThenBy(static upload => upload.UploadId, StringComparer.Ordinal)
             .ToArray();
@@ -4988,7 +4989,7 @@ internal sealed class DiskStorageService(
     /// </summary>
     private static int FindVersionMarkerIndex(IReadOnlyList<ObjectInfo> versions, string? keyMarker, string? versionIdMarker)
     {
-        if (string.IsNullOrWhiteSpace(keyMarker)) {
+        if (string.IsNullOrEmpty(keyMarker)) {
             return -1;
         }
 
@@ -5003,9 +5004,9 @@ internal sealed class DiskStorageService(
         // Marker not found — fall back to comparison-based skip so pages
         // degrade gracefully when a version is removed between requests.
         for (var i = versions.Count - 1; i >= 0; i--) {
-            var keyComparison = StringComparer.Ordinal.Compare(versions[i].Key, normalizedKey);
+            var keyComparison = Utf8OrdinalComparer.Instance.Compare(versions[i].Key, normalizedKey);
             if (keyComparison < 0 || (keyComparison == 0
-                && !string.IsNullOrWhiteSpace(versionIdMarker)
+                && !string.IsNullOrEmpty(versionIdMarker)
                 && StringComparer.Ordinal.Compare(versions[i].VersionId, versionIdMarker) >= 0)) {
                 return i;
             }
@@ -5016,11 +5017,11 @@ internal sealed class DiskStorageService(
 
     private static bool IsMultipartUploadAfterMarker(MultipartUploadInfo upload, string? keyMarker, string? uploadIdMarker)
     {
-        if (string.IsNullOrWhiteSpace(keyMarker)) {
+        if (string.IsNullOrEmpty(keyMarker)) {
             return true;
         }
 
-        var keyComparison = StringComparer.Ordinal.Compare(upload.Key, NormalizeKey(keyMarker));
+        var keyComparison = Utf8OrdinalComparer.Instance.Compare(upload.Key, NormalizeKey(keyMarker));
         if (keyComparison > 0) {
             return true;
         }
@@ -5029,7 +5030,7 @@ internal sealed class DiskStorageService(
             return false;
         }
 
-        return !string.IsNullOrWhiteSpace(uploadIdMarker)
+        return !string.IsNullOrEmpty(uploadIdMarker)
                && StringComparer.Ordinal.Compare(upload.UploadId, uploadIdMarker) > 0;
     }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -4578,6 +4578,111 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
             static key => Assert.Equal("c.txt", key));
     }
 
+    // Regression tests for issue #167.
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_SortsAstralPlaneKeys_InUtf8ByteOrder()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        // "k\u{1F600}" (astral) and "k豈" (BMP) sort in OPPOSITE orders under UTF-16 ordinal vs
+        // UTF-8 bytes. AWS uses UTF-8 bytes: "k" then "k豈" (3-byte) then "k\u{1F600}" (4-byte).
+        const string astralKey = "k\U0001F600";
+        const string bmpKey = "k豈";
+
+        await client.PutAsync("/integrated-s3/buckets/utf8-sort-bucket", content: null);
+        foreach (var key in new[] { astralKey, bmpKey, "k" }) {
+            var putResponse = await client.PutAsync(
+                $"/integrated-s3/buckets/utf8-sort-bucket/objects/{Uri.EscapeDataString(key)}",
+                new StringContent("x", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+        }
+
+        var response = await client.GetAsync("/integrated-s3/utf8-sort-bucket?list-type=2");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync());
+        var keys = document.Root!.S3Elements("Contents")
+            .Select(static content => content.S3Element("Key")?.Value)
+            .ToArray();
+
+        // UTF-8 byte order — the BMP key precedes the astral key (the reverse of UTF-16 ordinal).
+        Assert.Collection(keys,
+            static key => Assert.Equal("k", key),
+            key => Assert.Equal(bmpKey, key),
+            key => Assert.Equal(astralKey, key));
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithSingleSpaceDelimiter_GroupsOnSpace()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/space-delimiter-bucket", content: null);
+        foreach (var key in new[] { "alpha beta", "alpha gamma", "solo" }) {
+            var putResponse = await client.PutAsync(
+                $"/integrated-s3/buckets/space-delimiter-bucket/objects/{Uri.EscapeDataString(key)}",
+                new StringContent("x", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+        }
+
+        // A single-space delimiter is a legitimate S3 value and must NOT be dropped as whitespace.
+        var response = await client.GetAsync($"/integrated-s3/space-delimiter-bucket?list-type=2&delimiter={Uri.EscapeDataString(" ")}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // PreserveWhitespace so the whitespace-only <Delimiter> element text is not normalized away.
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync(), LoadOptions.PreserveWhitespace);
+
+        // The space delimiter is echoed back verbatim rather than suppressed.
+        Assert.Equal(" ", GetRequiredElementValue(document, "Delimiter"));
+
+        // "alpha beta" and "alpha gamma" collapse into the common prefix "alpha " (up to the space).
+        var prefixes = document.Root!.S3Elements("CommonPrefixes")
+            .Select(static prefix => prefix.S3Element("Prefix")?.Value)
+            .ToArray();
+        Assert.Collection(prefixes, static prefix => Assert.Equal("alpha ", prefix));
+
+        // "solo" has no space, so it is returned as a plain object.
+        var keys = document.Root.S3Elements("Contents")
+            .Select(static content => content.S3Element("Key")?.Value)
+            .ToArray();
+        Assert.Collection(keys, static key => Assert.Equal("solo", key));
+    }
+
+    [Fact]
+    public async Task S3CompatibleBucketRoute_ListType2_WithWhitespaceStartAfter_IsHonored()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        await client.PutAsync("/integrated-s3/buckets/space-start-after-bucket", content: null);
+        // A single space sorts before every printable key, so a start-after of " " must keep every key.
+        foreach (var key in new[] { "!bang", "apple", "zebra" }) {
+            var putResponse = await client.PutAsync(
+                $"/integrated-s3/buckets/space-start-after-bucket/objects/{Uri.EscapeDataString(key)}",
+                new StringContent("x", Encoding.UTF8, "text/plain"));
+            Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+        }
+
+        // A whitespace-only start-after must be treated as the literal value " ", not dropped as absent.
+        var response = await client.GetAsync($"/integrated-s3/space-start-after-bucket?list-type=2&start-after={Uri.EscapeDataString(" ")}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // PreserveWhitespace so the whitespace-only <StartAfter> element text is not normalized away.
+        var document = XDocument.Parse(await response.Content.ReadAsStringAsync(), LoadOptions.PreserveWhitespace);
+
+        // The literal space is echoed back in StartAfter rather than suppressed.
+        Assert.Equal(" ", GetRequiredElementValue(document, "StartAfter"));
+
+        // "!bang" (0x21) sorts after " " (0x20), so all three keys survive the marker filter.
+        var keys = document.Root!.S3Elements("Contents")
+            .Select(static content => content.S3Element("Key")?.Value)
+            .ToArray();
+        Assert.Collection(keys,
+            static key => Assert.Equal("!bang", key),
+            static key => Assert.Equal("apple", key),
+            static key => Assert.Equal("zebra", key));
+    }
+
     [Fact]
     public async Task S3CompatibleDeleteMissingObjects_AreIdempotentAndVersionedDeletesCreateDeleteMarkers()
     {

--- a/src/IntegratedS3/IntegratedS3.Tests/Utf8OrdinalComparerTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/Utf8OrdinalComparerTests.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using IntegratedS3.Abstractions.Comparers;
+using Xunit;
+
+namespace IntegratedS3.Tests;
+
+/// <summary>
+/// Regression tests for issue #167: object-key sorting must match AWS S3, which orders keys by their
+/// raw UTF-8 byte sequence rather than by .NET's UTF-16 code-unit (<see cref="StringComparer.Ordinal"/>)
+/// ordering. The two orderings diverge for astral-plane (surrogate-pair) characters.
+/// </summary>
+public sealed class Utf8OrdinalComparerTests
+{
+    // "k" + U+1F600 (astral, encoded in UTF-16 as the surrogate pair D83D DE00).
+    private const string AstralKey = "k\U0001F600";
+
+    // "k" + U+F900 (BMP, single UTF-16 code unit F900).
+    private const string BmpKey = "k豈";
+
+    [Fact]
+    public void Ordinal_And_Utf8_DisagreeForAstralKeys_ProvingTheBugScenario()
+    {
+        // UTF-16 code-unit ordering (the previous behaviour) puts the astral key first because the
+        // high-surrogate code unit 0xD83D sorts before the BMP code unit 0xF900.
+        Assert.True(StringComparer.Ordinal.Compare(AstralKey, BmpKey) < 0);
+
+        // Raw UTF-8 byte ordering (what AWS does) puts the BMP key first because its three-byte
+        // sequence (EF A4 80) sorts before the astral key's four-byte sequence (F0 9F 98 80).
+        var astralBytes = Encoding.UTF8.GetBytes(AstralKey);
+        var bmpBytes = Encoding.UTF8.GetBytes(BmpKey);
+        Assert.True(astralBytes.AsSpan().SequenceCompareTo(bmpBytes) > 0);
+    }
+
+    [Fact]
+    public void Compare_OrdersAstralKeys_ByUtf8ByteOrder()
+    {
+        // The BMP key must sort BEFORE the astral key (opposite of StringComparer.Ordinal).
+        Assert.True(Utf8OrdinalComparer.Instance.Compare(BmpKey, AstralKey) < 0);
+        Assert.True(Utf8OrdinalComparer.Instance.Compare(AstralKey, BmpKey) > 0);
+    }
+
+    [Fact]
+    public void Compare_MatchesRawUtf8ByteComparison_AcrossMixedKeys()
+    {
+        string[] keys =
+        [
+            string.Empty,
+            "a",
+            "a/b",
+            "a豈",
+            "a\U0001F600",
+            "b",
+            "k豈",
+            "k\U0001F600",
+            "\U0001F600",
+            "豈",
+            "z",
+        ];
+
+        for (var i = 0; i < keys.Length; i++) {
+            for (var j = 0; j < keys.Length; j++) {
+                var expected = Math.Sign(Encoding.UTF8.GetBytes(keys[i]).AsSpan()
+                    .SequenceCompareTo(Encoding.UTF8.GetBytes(keys[j])));
+                var actual = Math.Sign(Utf8OrdinalComparer.Instance.Compare(keys[i], keys[j]));
+                Assert.Equal(expected, actual);
+            }
+        }
+    }
+
+    [Fact]
+    public void Sort_ProducesUtf8ByteOrder_ForAstralAndBmpKeys()
+    {
+        var keys = new List<string> { AstralKey, BmpKey, "k", "kz" };
+        keys.Sort(Utf8OrdinalComparer.Instance);
+
+        // UTF-8 byte order: "k" (6b), "kz" (6b 7a), "k豈" (6b ef a4 80), "k🙂" (6b f0 9f 98 80).
+        Assert.Equal(["k", "kz", BmpKey, AstralKey], keys);
+    }
+
+    [Fact]
+    public void Compare_TreatsNullAsSmallest_AndEqualReferencesAsEqual()
+    {
+        Assert.Equal(0, Utf8OrdinalComparer.Instance.Compare(null, null));
+        Assert.True(Utf8OrdinalComparer.Instance.Compare(null, "a") < 0);
+        Assert.True(Utf8OrdinalComparer.Instance.Compare("a", null) > 0);
+        Assert.Equal(0, Utf8OrdinalComparer.Instance.Compare("same", "same"));
+    }
+
+    [Fact]
+    public void Compare_ShorterPrefixSortsFirst()
+    {
+        Assert.True(Utf8OrdinalComparer.Instance.Compare("a", "ab") < 0);
+        Assert.True(Utf8OrdinalComparer.Instance.Compare("ab", "a") > 0);
+    }
+}


### PR DESCRIPTION
## Summary

Resolves two S3 listing correctness edge cases from #167.

### 1. Key sort order: UTF-8 byte order, not UTF-16 ordinal
Object-key sorting used `StringComparer.Ordinal` (UTF-16 **code-unit** order). AWS S3 orders keys by their raw **UTF-8 byte** sequence. These agree for ASCII and the Basic Multilingual Plane, but diverge for astral-plane (surrogate-pair) characters such as emoji: under UTF-16 ordinal a high surrogate (`0xD83D`) sorts *before* a BMP code unit like `0xF900`, whereas UTF-8 bytes sort the astral key *after* the BMP key. This mis-ordered `Contents`, `CommonPrefixes`, and marker/continuation filtering for such keys.

- Added `IntegratedS3.Abstractions.Comparers.Utf8OrdinalComparer` — UTF-8 byte order is equivalent to Unicode scalar-value order, so it compares by decoded scalar without allocating byte buffers, matching `Encoding.UTF8.GetBytes(x)` vs `...(y)` exactly.
- Applied it to every object-**key** sort and marker/continuation comparison across ListObjects V1/V2, `CommonPrefixes`, ListObjectVersions, and ListMultipartUploads (both the disk provider and the endpoint-layer marker filters), keeping sort order and marker filtering consistent. Opaque `VersionId`/`UploadId` tiebreaks remain ordinal.

### 2. Whitespace-only `delimiter` / `start-after` / `marker` dropped
A single space is a legitimate S3 delimiter/marker value, but the param parsers, cursor computations, marker filters, and the XML response writer gated on `IsNullOrWhiteSpace`, silently treating a space as absent and changing listing semantics. Switched those gates to `IsNullOrEmpty` so a literal space is honored (grouped/filtered on) and echoed back verbatim; only truly empty values are treated as absent.

## Tests (fail before / pass after)
- `Utf8OrdinalComparerTests` — proves astral vs BMP ordering differs from `StringComparer.Ordinal` and matches raw UTF-8 byte comparison across mixed keys.
- End-to-end HTTP listing tests: astral-plane keys sort in UTF-8 byte order (`k` < `k豈` < `k🙂`); a single-space `delimiter` groups on the space and is echoed; a whitespace `start-after` is honored and echoed.

Full suite: **1262 passed / 0 failed**, build clean with warnings-as-errors.

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)
