### PR TITLE
fix: clean up buffered temp file when write-through PutObject/CopyObject copy fails (#125)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
@@ -3482,10 +3482,20 @@ internal sealed class OrchestratedStorageService(
         ArgumentNullException.ThrowIfNull(content);
 
         var tempFilePath = Path.Combine(Path.GetTempPath(), $"integrateds3-orchestration-{Guid.NewGuid():N}.tmp");
-        await using var tempFileStream = new FileStream(tempFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
-        await content.CopyToAsync(tempFileStream, cancellationToken);
-        await tempFileStream.FlushAsync(cancellationToken);
-        return tempFilePath;
+        try {
+            await using var tempFileStream = new FileStream(tempFilePath, FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920, FileOptions.Asynchronous | FileOptions.SequentialScan);
+            await content.CopyToAsync(tempFileStream, cancellationToken);
+            await tempFileStream.FlushAsync(cancellationToken);
+            return tempFilePath;
+        }
+        catch {
+            // The file is created eagerly by the FileStream constructor. If creation, copy, or flush
+            // throws (client cancellation, request-body reset, replica read error), the callers never
+            // received the path and their try/finally cleanup never runs — delete it here so the
+            // buffered temp file is not orphaned on disk on any failure path.
+            DeleteTempFileIfPresent(tempFilePath);
+            throw;
+        }
     }
 
     private static Stream OpenBufferedReadStream(string tempFilePath)
@@ -3570,8 +3580,14 @@ internal sealed class OrchestratedStorageService(
 
     private static void DeleteTempFileIfPresent(string tempFilePath)
     {
-        if (File.Exists(tempFilePath)) {
+        try {
             File.Delete(tempFilePath);
+        }
+        catch (DirectoryNotFoundException) {
+            // Already gone — treat as success (idempotent).
+        }
+        catch (FileNotFoundException) {
+            // Already gone — treat as success (idempotent).
         }
     }
 

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
@@ -3350,6 +3350,126 @@ public sealed class IntegratedS3CoreOrchestrationTests
     }
 
     [Fact]
+    public async Task OrchestratedStorageService_WriteThroughAll_PutObject_DoesNotOrphanBufferedTempFile_WhenBodyCopyFails()
+    {
+        var primaryBackend = new InMemoryStorageBackend("primary-memory", isPrimary: true);
+        var replicaBackend = new InMemoryStorageBackend("replica-memory");
+
+        await using var fixture = new CoreStorageFixture(overrideCatalogStore: true, addDefaultDiskStorage: false, configureServices: services => {
+            services.Configure<IntegratedS3CoreOptions>(options => {
+                options.ConsistencyMode = StorageConsistencyMode.WriteThroughAll;
+            });
+            services.AddSingleton<IStorageBackend>(primaryBackend);
+            services.AddSingleton<IStorageBackend>(replicaBackend);
+        });
+
+        var storageService = fixture.Services.GetRequiredService<IStorageService>();
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = "leak-bucket"
+        })).IsSuccess);
+
+        var tempFilesBefore = SnapshotOrchestrationTempFiles();
+
+        // The write-through PutObject path buffers request.Content into a temp file before fanning it
+        // out to the replica. If that copy throws, the temp file must not be left behind.
+        await using var throwingContent = new ThrowOnReadStream(new IOException("simulated request-body reset"));
+        await Assert.ThrowsAsync<IOException>(async () => await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "leak-bucket",
+            Key = "docs/leak.txt",
+            Content = throwingContent,
+            ContentType = "text/plain"
+        }));
+
+        Assert.Empty(NewOrchestrationTempFiles(tempFilesBefore));
+    }
+
+    [Fact]
+    public async Task OrchestratedStorageService_WriteThroughAll_PutObject_DoesNotOrphanBufferedTempFile_WhenBodyCopyIsCancelled()
+    {
+        var primaryBackend = new InMemoryStorageBackend("primary-memory", isPrimary: true);
+        var replicaBackend = new InMemoryStorageBackend("replica-memory");
+
+        await using var fixture = new CoreStorageFixture(overrideCatalogStore: true, addDefaultDiskStorage: false, configureServices: services => {
+            services.Configure<IntegratedS3CoreOptions>(options => {
+                options.ConsistencyMode = StorageConsistencyMode.WriteThroughAll;
+            });
+            services.AddSingleton<IStorageBackend>(primaryBackend);
+            services.AddSingleton<IStorageBackend>(replicaBackend);
+        });
+
+        var storageService = fixture.Services.GetRequiredService<IStorageService>();
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = "cancel-bucket"
+        })).IsSuccess);
+
+        var tempFilesBefore = SnapshotOrchestrationTempFiles();
+
+        using var cancellation = new CancellationTokenSource();
+        await using var cancellingContent = new ThrowOnReadStream(new OperationCanceledException(cancellation.Token), cancellation);
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "cancel-bucket",
+            Key = "docs/cancel.txt",
+            Content = cancellingContent,
+            ContentType = "text/plain"
+        }, cancellation.Token));
+
+        Assert.Empty(NewOrchestrationTempFiles(tempFilesBefore));
+    }
+
+    private static HashSet<string> SnapshotOrchestrationTempFiles()
+    {
+        return new HashSet<string>(
+            Directory.EnumerateFiles(Path.GetTempPath(), "integrateds3-orchestration-*.tmp"),
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string[] NewOrchestrationTempFiles(HashSet<string> before)
+    {
+        return Directory.EnumerateFiles(Path.GetTempPath(), "integrateds3-orchestration-*.tmp")
+            .Where(path => !before.Contains(path))
+            .ToArray();
+    }
+
+    // A stream that throws on the first read attempt, simulating a client aborting the upload
+    // (cancellation) or the request body being reset mid-copy (IOException) while the write-through
+    // PutObject path is buffering request.Content into its temp file.
+    private sealed class ThrowOnReadStream(Exception failure, CancellationTokenSource? cancelBeforeThrow = null) : Stream
+    {
+        public override bool CanRead => true;
+        public override bool CanSeek => false;
+        public override bool CanWrite => false;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set => throw new NotSupportedException(); }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            cancelBeforeThrow?.Cancel();
+            throw failure;
+        }
+
+        public override ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            cancelBeforeThrow?.Cancel();
+            return ValueTask.FromException<int>(failure);
+        }
+
+        public override Task<int> ReadAsync(byte[] buffer, int offset, int count, CancellationToken cancellationToken)
+        {
+            cancelBeforeThrow?.Cancel();
+            return Task.FromException<int>(failure);
+        }
+
+        public override void Flush() { }
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
     public async Task StorageOperations_EmitActivitiesAndMetricsWithProviderAndCorrelationTags()
     {
         using var observability = new TestObservabilityCollector();


### PR DESCRIPTION
## Summary

Fixes a temp-file leak in the write-through replication path (`WriteThroughAll` consistency mode with at least one replica).

`BufferStreamToTempFileAsync` creates the temp file eagerly via the `FileStream` constructor and then copies the object body into it *before* returning the path. When the copy is cancelled (client aborts the upload) or fails (request-body network reset on `PutObject`, or a replica read error on write-through `CopyObject`), the exception propagated out of the helper **before** the path reached the caller. The two callers only start their `try { … } finally { DeleteTempFileIfPresent(…) }` cleanup after the `var tempFilePath = await …` assignment completes, so cleanup never ran and an `integrateds3-orchestration-<guid>.tmp` file (sized up to the object body) was orphaned in the system temp directory. Under abort-heavy load or replica flakiness these accumulate and can exhaust disk on the app host.

## Fix

- Make `BufferStreamToTempFileAsync` self-cleaning: wrap creation/copy/flush in a `try/catch` that deletes the temp file on any failure and rethrows, so cleanup no longer depends on the return value reaching either caller. This covers success, exception, and cancellation on both the `PutObject` and write-through `CopyObject` paths.
- Harden `DeleteTempFileIfPresent` to be idempotent (swallow `FileNotFoundException`/`DirectoryNotFoundException`) so it is safe to call from the catch path without masking the original exception.

## Tests

Adds two regression tests on the write-through `PutObject` path — a body copy that throws (`IOException`) and one that is cancelled (`OperationCanceledException`) — each asserting no orphaned `integrateds3-orchestration-*.tmp` file remains. Both **fail before** the fix and **pass after**. Full suite: 1264 passed.

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
