### PR TITLE
fix: omit whole-object x-amz-checksum-* header on ranged 206 GET (#233)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.AspNetCore/Endpoints/IntegratedS3EndpointRouteBuilderExtensions.cs
@@ -1659,6 +1659,13 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
                                 $"bytes {normalizedRange.Start}-{normalizedRange.End}/{objectInfo.ContentLength}";
                             httpContext.Response.ContentLength =
                                 normalizedRange.End!.Value - normalizedRange.Start!.Value + 1;
+
+                            // Mirror GET: on a genuine partial 206 the whole-object x-amz-checksum-*
+                            // headers do not describe the ranged extent, so drop them (see issue #233).
+                            if (IsPartialRange(normalizedRange, objectInfo.ContentLength)) {
+                                RemoveChecksumValueHeaders(httpContext.Response);
+                            }
+
                             return TypedResults.StatusCode(StatusCodes.Status206PartialContent);
                         }
                     }
@@ -9422,9 +9429,26 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
     {
         httpResponse.Headers.Remove(ChecksumCrc32HeaderName);
         httpResponse.Headers.Remove(ChecksumCrc32cHeaderName);
+        httpResponse.Headers.Remove(ChecksumCrc64NvmeHeaderName);
         httpResponse.Headers.Remove(ChecksumSha1HeaderName);
         httpResponse.Headers.Remove(ChecksumSha256HeaderName);
         httpResponse.Headers.Remove(ChecksumTypeHeaderName);
+    }
+
+    /// <summary>
+    /// Determines whether a normalized response range covers only part of the object (a genuine
+    /// partial <c>206</c>) rather than the entire byte extent. The stored <c>x-amz-checksum-*</c>
+    /// values describe the whole object, so they are meaningless — and actively harmful — on a
+    /// partial response: an AWS SDK client that validates checksums recomputes over the returned
+    /// slice and fails when it does not match the whole-object digest (see issue #233). A range
+    /// that spans <c>[0, TotalContentLength - 1]</c> covers the whole object and is treated as a
+    /// full response, so the whole-object checksum still applies.
+    /// </summary>
+    private static bool IsPartialRange(ObjectRange range, long totalContentLength)
+    {
+        var start = range.Start ?? 0;
+        var end = range.End ?? totalContentLength - 1;
+        return start > 0 || end < totalContentLength - 1;
     }
 
     private static void ApplyServerSideEncryptionHeaders(HttpResponse httpResponse, ObjectServerSideEncryptionInfo? serverSideEncryption)
@@ -9889,6 +9913,15 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             if (response.Range is not null) {
                 httpContext.Response.StatusCode = StatusCodes.Status206PartialContent;
                 httpContext.Response.Headers.ContentRange = $"bytes {response.Range.Start}-{response.Range.End}/{response.TotalContentLength}";
+
+                // The x-amz-checksum-* headers applied above describe the whole object. On a genuine
+                // partial 206 the body is only a slice, so a validating client (e.g. AWS SDK for .NET
+                // v4, default) recomputes the checksum over the slice and fails the request. AWS omits
+                // the whole-object checksum on a partial 206; mirror that. A range covering the whole
+                // object is a full response and keeps the checksum. See issue #233.
+                if (IsPartialRange(response.Range, response.TotalContentLength)) {
+                    RemoveChecksumValueHeaders(httpContext.Response);
+                }
             }
             else {
                 httpContext.Response.StatusCode = StatusCodes.Status200OK;
@@ -9952,6 +9985,11 @@ public static class IntegratedS3EndpointRouteBuilderExtensions
             ApplyObjectHeaders(httpContext.Response, firstResponse.Object);
             ApplyObjectTaggingCountHeader(httpContext.Response, firstResponse.Object);
             httpContext.Response.Headers.AcceptRanges = "bytes";
+
+            // A multipart/byteranges response is always a partial 206. The whole-object
+            // x-amz-checksum-* headers do not describe the returned slices and break client-side
+            // checksum validation, so drop them (see issue #233).
+            RemoveChecksumValueHeaders(httpContext.Response);
 
             // Apply response-* overrides (Content-Disposition, Cache-Control, etc.) before the
             // multipart container Content-Type is set below, so the transport type still wins for

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3AwsSdkCompatibilityTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3AwsSdkCompatibilityTests.cs
@@ -109,6 +109,59 @@ public sealed class IntegratedS3AwsSdkCompatibilityTests : IClassFixture<WebUiAp
         Assert.Equal(System.Net.HttpStatusCode.NoContent, deleteObjectResponse.HttpStatusCode);
     }
 
+    // Regression for issue #233: a ranged GetObject returns 206 Partial Content. Previously the server
+    // attached the whole-object x-amz-checksum-* header to the partial body; the AWS SDK for .NET v4
+    // (checksum validation on by default) then recomputed the checksum over the returned slice and threw
+    // "Expected hash not equal to calculated hash". With the fix the partial 206 carries no whole-object
+    // checksum, so the ranged download succeeds without disabling checksum validation.
+    [Fact]
+    public async Task AmazonS3Client_RangedGetObject_SucceedsWithoutChecksumValidationFailure()
+    {
+        const string accessKeyId = "aws-sdk-range-checksum-access";
+        const string secretAccessKey = "aws-sdk-range-checksum-secret";
+
+        await using var isolatedClient = await CreateAuthenticatedLoopbackClientAsync(accessKeyId, secretAccessKey);
+        using var s3Client = CreateS3Client(isolatedClient.BaseAddress!, accessKeyId, secretAccessKey);
+
+        const string bucketName = "aws-sdk-range-checksum-bucket";
+        const string objectKey = "docs/ranged.bin";
+
+        // A payload large enough that a byte range is a genuine subset of the object.
+        var payloadBytes = new byte[300_000];
+        RandomNumberGenerator.Fill(payloadBytes);
+
+        Assert.Equal(HttpStatusCode.OK, (await s3Client.PutBucketAsync(new PutBucketRequest
+        {
+            BucketName = bucketName
+        })).HttpStatusCode);
+
+        using (var uploadStream = new MemoryStream(payloadBytes, writable: false)) {
+            var putResponse = await s3Client.PutObjectAsync(new PutObjectRequest
+            {
+                BucketName = bucketName,
+                Key = objectKey,
+                InputStream = uploadStream,
+                ContentType = "application/octet-stream",
+                UseChunkEncoding = false
+            });
+            Assert.Equal(HttpStatusCode.OK, putResponse.HttpStatusCode);
+        }
+
+        // The SDK validates the response checksum against the received bytes by default. Before the fix
+        // this call threw AmazonClientException: "Expected hash not equal to calculated hash".
+        var rangedGetResponse = await s3Client.GetObjectAsync(new GetObjectRequest
+        {
+            BucketName = bucketName,
+            Key = objectKey,
+            ByteRange = new ByteRange(100, 199)
+        });
+        Assert.Equal(HttpStatusCode.PartialContent, rangedGetResponse.HttpStatusCode);
+
+        using var rangedBuffer = new MemoryStream();
+        await rangedGetResponse.ResponseStream.CopyToAsync(rangedBuffer);
+        Assert.Equal(payloadBytes.AsSpan(100, 100).ToArray(), rangedBuffer.ToArray());
+    }
+
     [Fact]
     public async Task AmazonS3Client_PathStyleAwsChunkedPutObject_WorksAgainstIntegratedS3()
     {

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3HttpEndpointsTests.cs
@@ -3483,6 +3483,76 @@ public sealed class IntegratedS3HttpEndpointsTests : IClassFixture<WebUiApplicat
         Assert.Equal("integrated", await response.Content.ReadAsStringAsync());
     }
 
+    // Regression for issue #233: a whole-object x-amz-checksum-* header must not accompany a partial
+    // 206 body. The stored checksum covers the full object, so a validating client (AWS SDK for .NET
+    // v4, default) recomputes it over the returned slice and fails. A full 200 (and a range covering
+    // the whole object) must still carry the checksum.
+    [Fact]
+    public async Task GetObject_PartialRange_OmitsWholeObjectChecksumHeader_ButFullResponseKeepsIt()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        const string payload = "hello integrated s3"; // 19 bytes
+        var expectedChecksumCrc32c = ChecksumTestAlgorithms.ComputeCrc32cBase64(payload);
+
+        await client.PutAsync("/integrated-s3/buckets/range-checksum-bucket", content: null);
+        await client.PutAsync(
+            "/integrated-s3/buckets/range-checksum-bucket/objects/docs/range.txt",
+            new StringContent(payload, Encoding.UTF8, "text/plain"));
+
+        // Full GET (200): the whole-object checksum is present, as before.
+        var fullResponse = await client.GetAsync("/integrated-s3/buckets/range-checksum-bucket/objects/docs/range.txt");
+        Assert.Equal(HttpStatusCode.OK, fullResponse.StatusCode);
+        Assert.Equal(expectedChecksumCrc32c, Assert.Single(fullResponse.Headers.GetValues("x-amz-checksum-crc32c")));
+
+        // Partial GET (206): no whole-object checksum header of any algorithm.
+        using var partialRequest = new HttpRequestMessage(HttpMethod.Get, "/integrated-s3/buckets/range-checksum-bucket/objects/docs/range.txt");
+        partialRequest.Headers.Range = new RangeHeaderValue(6, 15);
+        var partialResponse = await client.SendAsync(partialRequest);
+        Assert.Equal(HttpStatusCode.PartialContent, partialResponse.StatusCode);
+        Assert.False(partialResponse.Headers.Contains("x-amz-checksum-crc32"));
+        Assert.False(partialResponse.Headers.Contains("x-amz-checksum-crc32c"));
+        Assert.False(partialResponse.Headers.Contains("x-amz-checksum-crc64nvme"));
+        Assert.False(partialResponse.Headers.Contains("x-amz-checksum-sha1"));
+        Assert.False(partialResponse.Headers.Contains("x-amz-checksum-sha256"));
+        Assert.False(partialResponse.Headers.Contains("x-amz-checksum-type"));
+
+        // A range covering the whole object [0, size) is a full response and keeps the checksum.
+        using var fullRangeRequest = new HttpRequestMessage(HttpMethod.Get, "/integrated-s3/buckets/range-checksum-bucket/objects/docs/range.txt");
+        fullRangeRequest.Headers.Range = new RangeHeaderValue(0, 18);
+        var fullRangeResponse = await client.SendAsync(fullRangeRequest);
+        Assert.Equal(HttpStatusCode.PartialContent, fullRangeResponse.StatusCode);
+        Assert.Equal(expectedChecksumCrc32c, Assert.Single(fullRangeResponse.Headers.GetValues("x-amz-checksum-crc32c")));
+    }
+
+    // Regression for issue #233: HEAD mirrors GET — a partial 206 must not carry the whole-object
+    // checksum, but a full HEAD (200) still does.
+    [Fact]
+    public async Task HeadObject_PartialRange_OmitsWholeObjectChecksumHeader_ButFullResponseKeepsIt()
+    {
+        using var client = await _factory.CreateClientAsync();
+
+        const string payload = "hello integrated s3"; // 19 bytes
+        var expectedChecksumCrc32c = ChecksumTestAlgorithms.ComputeCrc32cBase64(payload);
+
+        await client.PutAsync("/integrated-s3/buckets/head-range-checksum-bucket", content: null);
+        await client.PutAsync(
+            "/integrated-s3/buckets/head-range-checksum-bucket/objects/docs/range.txt",
+            new StringContent(payload, Encoding.UTF8, "text/plain"));
+
+        using var fullHeadRequest = new HttpRequestMessage(HttpMethod.Head, "/integrated-s3/buckets/head-range-checksum-bucket/objects/docs/range.txt");
+        var fullHeadResponse = await client.SendAsync(fullHeadRequest);
+        Assert.Equal(HttpStatusCode.OK, fullHeadResponse.StatusCode);
+        Assert.Equal(expectedChecksumCrc32c, Assert.Single(fullHeadResponse.Headers.GetValues("x-amz-checksum-crc32c")));
+
+        using var partialHeadRequest = new HttpRequestMessage(HttpMethod.Head, "/integrated-s3/buckets/head-range-checksum-bucket/objects/docs/range.txt");
+        partialHeadRequest.Headers.Range = new RangeHeaderValue(6, 15);
+        var partialHeadResponse = await client.SendAsync(partialHeadRequest);
+        Assert.Equal(HttpStatusCode.PartialContent, partialHeadResponse.StatusCode);
+        Assert.False(partialHeadResponse.Headers.Contains("x-amz-checksum-crc32c"));
+        Assert.False(partialHeadResponse.Headers.Contains("x-amz-checksum-type"));
+    }
+
     [Fact]
     public async Task GetObject_WithUnsatisfiableRange_Returns416WithContentRange()
     {


### PR DESCRIPTION
## Problem

A ranged `GetObject` returns `206 Partial Content` but the server attached the **whole-object** `x-amz-checksum-*` header (crc32/crc32c/crc64nvme/sha1/sha256, plus `x-amz-checksum-type`) to the partial body. AWS SDK for .NET v4 validates response checksums by default: it recomputes the checksum over the returned slice, gets a different value than the whole-object digest, and throws `AmazonClientException: Expected hash not equal to calculated hash`. Every default-configured ranged download failed.

## Fix

When a GET/HEAD response is a **genuine partial 206** (the range does not cover `[0, size)`), suppress the whole-object `x-amz-checksum-*` headers — matching AWS, which only attaches the whole-object checksum to a full `200`. A full GET (200), and a range that spans the entire object, still return the checksum unchanged.

- `StreamObjectResult` (single-range GET): drop checksum headers when `IsPartialRange`.
- `MultiRangeStreamObjectResult` (multipart/byteranges GET): always partial → always drop.
- HEAD range 206 path: mirror GET.
- `RemoveChecksumValueHeaders` now also removes the previously-missed `x-amz-checksum-crc64nvme` header.

## Tests

- `AmazonS3Client_RangedGetObject_SucceedsWithoutChecksumValidationFailure` — real loopback host + AWS SDK v4 with default checksum validation; reproduces the exact issue exception before the fix, passes after.
- `GetObject_PartialRange_OmitsWholeObjectChecksumHeader_ButFullResponseKeepsIt` and the HEAD counterpart — assert no `x-amz-checksum-*` on a partial 206, checksum retained on a full 200 and on a whole-object-covering range.

Verified fails-before / passes-after. Full suite: 1264 passed, 0 failed.

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)