### PR TITLE
fix: translate primary→replica version for object tag ops via recorded version mapping (#126)

### DIFF
--- a/src/IntegratedS3/IntegratedS3.Core/Services/IStorageCatalogStore.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/IStorageCatalogStore.cs
@@ -66,6 +66,34 @@ public interface IStorageCatalogStore
     ValueTask<StoredObjectEntry?> GetObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Records, for a replica row, which PRIMARY version id the replica's own <paramref name="replicaVersionId"/>
+    /// mirrors, so that version-specific operations (e.g. tagging a historical version) can later be translated
+    /// from a primary version id to the corresponding replica version id. This is a no-op when the matching replica
+    /// row does not exist. Callers should only invoke it for versioned objects where a concrete primary version id
+    /// is known; unversioned/null versions need no mapping.
+    /// </summary>
+    /// <param name="replicaProviderName">The replica storage provider that owns the row.</param>
+    /// <param name="bucketName">The bucket containing the object.</param>
+    /// <param name="key">The object key.</param>
+    /// <param name="primaryVersionId">The primary version id that the replica version mirrors.</param>
+    /// <param name="replicaVersionId">The replica's own version id for the mirrored object.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    ValueTask RecordReplicaVersionMappingAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, string replicaVersionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Resolves the replica's own version id that mirrors the supplied <paramref name="primaryVersionId"/> for the
+    /// given replica provider, bucket, and key, or <see langword="null"/> when no mapping has been recorded (e.g. a
+    /// legacy replica row, or one not yet replicated). Never returns the primary version id verbatim.
+    /// </summary>
+    /// <param name="replicaProviderName">The replica storage provider to resolve against.</param>
+    /// <param name="bucketName">The bucket containing the object.</param>
+    /// <param name="key">The object key.</param>
+    /// <param name="primaryVersionId">The primary version id to translate.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The corresponding replica version id, or <see langword="null"/> when unmapped.</returns>
+    ValueTask<string?> GetReplicaVersionIdForPrimaryAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Lists object entries in the catalog, optionally filtered by provider, bucket, and key prefix.
     /// </summary>
     /// <param name="providerName">If specified, limits results to this provider.</param>

--- a/src/IntegratedS3/IntegratedS3.Core/Services/NullStorageCatalogStore.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/NullStorageCatalogStore.cs
@@ -30,6 +30,16 @@ internal sealed class NullStorageCatalogStore : IStorageCatalogStore
         return ValueTask.CompletedTask;
     }
 
+    public ValueTask RecordReplicaVersionMappingAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, string replicaVersionId, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    public ValueTask<string?> GetReplicaVersionIdForPrimaryAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, CancellationToken cancellationToken = default)
+    {
+        return ValueTask.FromResult<string?>(null);
+    }
+
     public ValueTask<StoredObjectEntry?> GetObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default)
     {
         return ValueTask.FromResult<StoredObjectEntry?>(null);

--- a/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/OrchestratedStorageService.cs
@@ -453,7 +453,7 @@ internal sealed class OrchestratedStorageService(
                     request.BucketName,
                     request.Key,
                     result.Value.VersionId,
-                    writeThroughOperation: (replicaBackend, ct) => WriteReplicaBufferedObjectAsync(replicaBackend, request, tempFilePath, ct),
+                    writeThroughOperation: (replicaBackend, ct) => WriteReplicaBufferedObjectAsync(replicaBackend, request, tempFilePath, result.Value.VersionId, ct),
                     CancellationToken.None);
                 if (replicationError is not null) {
                     return StorageResult<ObjectInfo>.Failure(replicationError);
@@ -508,13 +508,13 @@ internal sealed class OrchestratedStorageService(
                 request.BucketName,
                 request.Key,
                 request.VersionId,
-                writeThroughOperation: (replicaBackend, ct) => WriteReplicaPutObjectTagsAsync(replicaBackend, new PutObjectTagsRequest
-                {
-                    BucketName = request.BucketName,
-                    Key = request.Key,
-                    VersionId = request.VersionId,
-                    Tags = CloneTags(request.Tags) ?? new Dictionary<string, string>(StringComparer.Ordinal)
-                }, ct),
+                writeThroughOperation: (replicaBackend, ct) => WriteReplicaPutObjectTagsAsync(
+                    replicaBackend,
+                    request.BucketName,
+                    request.Key,
+                    request.VersionId,
+                    CloneTags(request.Tags) ?? new Dictionary<string, string>(StringComparer.Ordinal),
+                    ct),
                 CancellationToken.None);
             if (replicationError is not null) {
                 return StorageResult<ObjectTagSet>.Failure(replicationError);
@@ -544,12 +544,12 @@ internal sealed class OrchestratedStorageService(
                 request.BucketName,
                 request.Key,
                 request.VersionId,
-                writeThroughOperation: (replicaBackend, ct) => WriteReplicaDeleteObjectTagsAsync(replicaBackend, new DeleteObjectTagsRequest
-                {
-                    BucketName = request.BucketName,
-                    Key = request.Key,
-                    VersionId = request.VersionId
-                }, ct),
+                writeThroughOperation: (replicaBackend, ct) => WriteReplicaDeleteObjectTagsAsync(
+                    replicaBackend,
+                    request.BucketName,
+                    request.Key,
+                    request.VersionId,
+                    ct),
                 CancellationToken.None);
             if (replicationError is not null) {
                 return StorageResult<ObjectTagSet>.Failure(replicationError);
@@ -2120,6 +2120,7 @@ internal sealed class OrchestratedStorageService(
                     sourceResponse.Object.Tags,
                     sourceResponse.Object.Checksums,
                     request.OverwriteIfExists,
+                    versionId,
                     ct),
                 cancellationToken);
         }
@@ -2359,7 +2360,7 @@ internal sealed class OrchestratedStorageService(
         return primaryEncryptionResult.Error ?? CreatePrimaryReplicationSourceError(primaryBackend, bucketName, objectKey: null, versionId: null, message: "Primary bucket default encryption configuration could not be resolved for replica repair.");
     }
 
-    private ValueTask<StorageError?> WriteReplicaBufferedObjectAsync(IStorageBackend replicaBackend, PutObjectRequest request, string tempFilePath, CancellationToken cancellationToken)
+    private ValueTask<StorageError?> WriteReplicaBufferedObjectAsync(IStorageBackend replicaBackend, PutObjectRequest request, string tempFilePath, string? primaryVersionId, CancellationToken cancellationToken)
     {
         return WriteReplicaBufferedObjectAsync(
             replicaBackend,
@@ -2372,6 +2373,7 @@ internal sealed class OrchestratedStorageService(
             request.Tags,
             request.Checksums,
             request.OverwriteIfExists,
+            primaryVersionId,
             cancellationToken);
     }
 
@@ -2386,6 +2388,7 @@ internal sealed class OrchestratedStorageService(
         IReadOnlyDictionary<string, string>? tags,
         IReadOnlyDictionary<string, string>? checksums,
         bool overwriteIfExists,
+        string? primaryVersionId,
         CancellationToken cancellationToken)
     {
         var replicaResult = await PutBufferedObjectAsync(
@@ -2406,6 +2409,7 @@ internal sealed class OrchestratedStorageService(
         }
 
         await catalogStore.UpsertObjectAsync(replicaBackend.Name, replicaResult.Value, cancellationToken);
+        await RecordReplicaVersionMappingAsync(replicaBackend, bucketName, key, primaryVersionId, replicaResult.Value.VersionId, cancellationToken);
         return null;
     }
 
@@ -2449,31 +2453,86 @@ internal sealed class OrchestratedStorageService(
         }
 
         await catalogStore.UpsertObjectAsync(replicaBackend.Name, replicaResult.Value, cancellationToken);
+        await RecordReplicaVersionMappingAsync(replicaBackend, bucketName, key, versionId, replicaResult.Value.VersionId, cancellationToken);
         return null;
     }
 
-    private async ValueTask<StorageError?> WriteReplicaPutObjectTagsAsync(IStorageBackend replicaBackend, PutObjectTagsRequest request, CancellationToken cancellationToken)
+    private async ValueTask<StorageError?> WriteReplicaPutObjectTagsAsync(
+        IStorageBackend replicaBackend,
+        string bucketName,
+        string key,
+        string? requestedVersionId,
+        IReadOnlyDictionary<string, string> tags,
+        CancellationToken cancellationToken)
     {
-        var replicaResult = await replicaBackend.PutObjectTagsAsync(request, cancellationToken);
-        ObserveResult(replicaBackend, replicaResult);
-        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
-            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, request.Key, request.VersionId, "Replica object tag update did not return tag metadata.");
+        // #126: translate the PRIMARY version id to this replica's own version. Null passes through (latest); an
+        // explicit-but-unmapped version is skipped so the primary op still succeeds and no wrong version is tagged.
+        var translation = await TranslateReplicaTagVersionAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+        if (!translation.HasMapping) {
+            LogSkippedUnmappedReplicaTagWrite(StorageOperationType.PutObjectTags, replicaBackend, bucketName, key, requestedVersionId);
+            return null;
         }
 
-        await RefreshCatalogObjectAsync(replicaBackend, request.BucketName, request.Key, request.VersionId, cancellationToken);
+        var replicaVersionId = translation.ReplicaVersionId;
+        var replicaResult = await replicaBackend.PutObjectTagsAsync(new PutObjectTagsRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = replicaVersionId,
+            Tags = CloneTags(tags) ?? new Dictionary<string, string>(StringComparer.Ordinal)
+        }, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, bucketName, key, replicaVersionId, "Replica object tag update did not return tag metadata.");
+        }
+
+        await RefreshCatalogObjectAsync(replicaBackend, bucketName, key, replicaVersionId, cancellationToken);
         return null;
     }
 
-    private async ValueTask<StorageError?> WriteReplicaDeleteObjectTagsAsync(IStorageBackend replicaBackend, DeleteObjectTagsRequest request, CancellationToken cancellationToken)
+    private async ValueTask<StorageError?> WriteReplicaDeleteObjectTagsAsync(
+        IStorageBackend replicaBackend,
+        string bucketName,
+        string key,
+        string? requestedVersionId,
+        CancellationToken cancellationToken)
     {
-        var replicaResult = await replicaBackend.DeleteObjectTagsAsync(request, cancellationToken);
-        ObserveResult(replicaBackend, replicaResult);
-        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
-            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, request.BucketName, request.Key, request.VersionId, "Replica object tag delete did not return tag metadata.");
+        // #126: translate the PRIMARY version id to this replica's own version (see WriteReplicaPutObjectTagsAsync).
+        var translation = await TranslateReplicaTagVersionAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+        if (!translation.HasMapping) {
+            LogSkippedUnmappedReplicaTagWrite(StorageOperationType.DeleteObjectTags, replicaBackend, bucketName, key, requestedVersionId);
+            return null;
         }
 
-        await RefreshCatalogObjectAsync(replicaBackend, request.BucketName, request.Key, request.VersionId, cancellationToken);
+        var replicaVersionId = translation.ReplicaVersionId;
+        var replicaResult = await replicaBackend.DeleteObjectTagsAsync(new DeleteObjectTagsRequest
+        {
+            BucketName = bucketName,
+            Key = key,
+            VersionId = replicaVersionId
+        }, cancellationToken);
+        ObserveResult(replicaBackend, replicaResult);
+        if (!replicaResult.IsSuccess || replicaResult.Value is null) {
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, bucketName, key, replicaVersionId, "Replica object tag delete did not return tag metadata.");
+        }
+
+        await RefreshCatalogObjectAsync(replicaBackend, bucketName, key, replicaVersionId, cancellationToken);
         return null;
+    }
+
+    /// <summary>
+    /// Logs that a synchronous replica tag write was skipped because no primary→replica version mapping exists for
+    /// an explicit version (#126). The primary operation still succeeds; the async repair backlog reconciles later.
+    /// </summary>
+    private void LogSkippedUnmappedReplicaTagWrite(StorageOperationType operation, IStorageBackend replicaBackend, string bucketName, string key, string? requestedVersionId)
+    {
+        logger.LogInformation(
+            "Skipping synchronous {StorageOperation} on replica {ReplicaProvider} for bucket {Bucket} key {Key} version {Version}: no primary->replica version mapping recorded. The async repair backlog will reconcile the replica.",
+            operation,
+            replicaBackend.Name,
+            bucketName,
+            key,
+            requestedVersionId);
     }
 
     private async ValueTask<StorageError?> RepairReplicaObjectTagsFromPrimaryAsync(
@@ -3556,6 +3615,105 @@ internal sealed class OrchestratedStorageService(
         return string.IsNullOrWhiteSpace(resolvedVersionId)
             ? requestedVersionId
             : resolvedVersionId;
+    }
+
+    /// <summary>
+    /// Records a primary→replica version mapping (#126) when both the primary version id and the replica's freshly
+    /// minted version id are concrete (versioned buckets). For unversioned/suspended writes — where either side is
+    /// null/blank — no mapping is meaningful and this is a no-op. Failures to record the mapping are swallowed and
+    /// logged so a mapping bookkeeping problem can never fail the object write it accompanies; the async repair path
+    /// will re-establish the mapping on the next pass.
+    /// </summary>
+    private async ValueTask RecordReplicaVersionMappingAsync(
+        IStorageBackend replicaBackend,
+        string bucketName,
+        string key,
+        string? primaryVersionId,
+        string? replicaVersionId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(primaryVersionId) || string.IsNullOrWhiteSpace(replicaVersionId)) {
+            return;
+        }
+
+        try {
+            await catalogStore.RecordReplicaVersionMappingAsync(
+                replicaBackend.Name,
+                bucketName,
+                key,
+                primaryVersionId,
+                replicaVersionId,
+                cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested) {
+            throw;
+        }
+        catch (Exception ex) {
+            logger.LogWarning(
+                ex,
+                "Failed to record primary->replica version mapping for {ReplicaProvider} bucket {Bucket} key {Key} (primary {PrimaryVersion} -> replica {ReplicaVersion}). Version-specific tag replication may fall back to async repair.",
+                replicaBackend.Name,
+                bucketName,
+                key,
+                primaryVersionId,
+                replicaVersionId);
+        }
+    }
+
+    /// <summary>
+    /// Translates a PRIMARY version id to the replica's own version id for a version-specific tag operation (#126).
+    /// A null/blank <paramref name="requestedVersionId"/> means "operate on the latest version" and is passed through
+    /// unchanged so the replica tags its own latest version. An explicit primary version is looked up via the recorded
+    /// mapping; when no mapping exists (legacy or not-yet-replicated replica) the result is a sentinel indicating the
+    /// synchronous replica tag write must be skipped so the primary operation still succeeds and no wrong version is
+    /// tagged — the async repair backlog reconciles the replica later.
+    /// </summary>
+    private async ValueTask<ReplicaVersionTranslation> TranslateReplicaTagVersionAsync(
+        IStorageBackend replicaBackend,
+        string bucketName,
+        string key,
+        string? requestedVersionId,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(requestedVersionId)) {
+            // Latest-version tag/delete: the replica must operate on ITS OWN latest version, so pass null through.
+            return ReplicaVersionTranslation.Mapped(null);
+        }
+
+        var replicaVersionId = await catalogStore.GetReplicaVersionIdForPrimaryAsync(
+            replicaBackend.Name,
+            bucketName,
+            key,
+            requestedVersionId,
+            cancellationToken);
+
+        return string.IsNullOrWhiteSpace(replicaVersionId)
+            ? ReplicaVersionTranslation.Unmapped
+            : ReplicaVersionTranslation.Mapped(replicaVersionId);
+    }
+
+    /// <summary>
+    /// Outcome of translating a primary version id to a replica version id for a version-specific replica tag write.
+    /// </summary>
+    private readonly struct ReplicaVersionTranslation
+    {
+        private ReplicaVersionTranslation(bool hasMapping, string? replicaVersionId)
+        {
+            HasMapping = hasMapping;
+            ReplicaVersionId = replicaVersionId;
+        }
+
+        /// <summary>Whether a usable target version was resolved (true also for the latest/null-passthrough case).</summary>
+        public bool HasMapping { get; }
+
+        /// <summary>The replica version id to write (null means "latest" when <see cref="HasMapping"/> is true).</summary>
+        public string? ReplicaVersionId { get; }
+
+        /// <summary>A resolved translation, targeting <paramref name="replicaVersionId"/> (null = replica's latest).</summary>
+        public static ReplicaVersionTranslation Mapped(string? replicaVersionId) => new(hasMapping: true, replicaVersionId);
+
+        /// <summary>No mapping exists for the requested explicit primary version; the replica write must be skipped.</summary>
+        public static ReplicaVersionTranslation Unmapped { get; } = new(hasMapping: false, replicaVersionId: null);
     }
 
     private async ValueTask RefreshCatalogObjectAsync(IStorageBackend backend, string bucketName, string key, CancellationToken cancellationToken)

--- a/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
+++ b/src/IntegratedS3/IntegratedS3.Core/Services/StorageReplicaRepairService.cs
@@ -298,6 +298,12 @@ internal sealed class StorageReplicaRepairService(
         }
 
         await catalogStore.UpsertObjectAsync(replicaBackend.Name, replicaResult.Value, cancellationToken);
+        // #126: record the primary->replica version mapping so a later version-specific tag repair can translate.
+        // Only meaningful when both sides carry a concrete (versioned) version id.
+        if (!string.IsNullOrWhiteSpace(versionId) && !string.IsNullOrWhiteSpace(replicaResult.Value.VersionId)) {
+            await catalogStore.RecordReplicaVersionMappingAsync(replicaBackend.Name, bucketName, key, versionId, replicaResult.Value.VersionId, cancellationToken);
+        }
+
         return null;
     }
 
@@ -309,6 +315,19 @@ internal sealed class StorageReplicaRepairService(
         string? requestedVersionId,
         CancellationToken cancellationToken)
     {
+        // #126: translate the PRIMARY version id (as recorded on the repair entry) to this replica's own version.
+        // A null request means "latest" and passes through. An explicit-but-unmapped version means the replica has
+        // no corresponding version yet (the object repair that records the mapping has not run / completed): skip so
+        // we never tag the wrong replica version. A subsequent object repair records the mapping and a re-queued tag
+        // repair then reconciles.
+        string? replicaVersionId = null;
+        if (!string.IsNullOrWhiteSpace(requestedVersionId)) {
+            replicaVersionId = await catalogStore.GetReplicaVersionIdForPrimaryAsync(replicaBackend.Name, bucketName, key, requestedVersionId, cancellationToken);
+            if (string.IsNullOrWhiteSpace(replicaVersionId)) {
+                return null;
+            }
+        }
+
         var primaryTagResult = await primaryBackend.GetObjectTagsAsync(new GetObjectTagsRequest
         {
             BucketName = bucketName,
@@ -318,7 +337,7 @@ internal sealed class StorageReplicaRepairService(
         ObserveResult(primaryBackend, primaryTagResult);
         if (!primaryTagResult.IsSuccess || primaryTagResult.Value is null) {
             if (primaryTagResult.Error?.Code is StorageErrorCode.ObjectNotFound or StorageErrorCode.BucketNotFound) {
-                return await ReconcileReplicaObjectDeletionAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+                return await ReconcileReplicaObjectDeletionAsync(replicaBackend, bucketName, key, replicaVersionId, cancellationToken);
             }
 
             return primaryTagResult.Error ?? CreatePrimaryReplicationSourceError(primaryBackend, bucketName, key, requestedVersionId, "Primary object tags could not be resolved for replica repair.");
@@ -330,7 +349,7 @@ internal sealed class StorageReplicaRepairService(
             {
                 BucketName = bucketName,
                 Key = key,
-                VersionId = requestedVersionId
+                VersionId = replicaVersionId
             }, cancellationToken);
         }
         else {
@@ -338,17 +357,17 @@ internal sealed class StorageReplicaRepairService(
             {
                 BucketName = bucketName,
                 Key = key,
-                VersionId = requestedVersionId,
+                VersionId = replicaVersionId,
                 Tags = CloneTags(primaryTagResult.Value.Tags) ?? new Dictionary<string, string>(StringComparer.Ordinal)
             }, cancellationToken);
         }
 
         ObserveResult(replicaBackend, replicaResult);
         if (!replicaResult.IsSuccess || replicaResult.Value is null) {
-            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, bucketName, key, requestedVersionId, "Replica tag repair did not return tag metadata.");
+            return replicaResult.Error ?? CreateReplicaOperationError(replicaBackend, bucketName, key, replicaVersionId, "Replica tag repair did not return tag metadata.");
         }
 
-        await RefreshCatalogObjectAsync(replicaBackend, bucketName, key, requestedVersionId, cancellationToken);
+        await RefreshCatalogObjectAsync(replicaBackend, bucketName, key, replicaVersionId, cancellationToken);
         return null;
     }
 

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/IntegratedS3CatalogModelBuilderExtensions.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/IntegratedS3CatalogModelBuilderExtensions.cs
@@ -38,6 +38,7 @@ public static class IntegratedS3CatalogModelBuilderExtensions
             entity.Property(static @object => @object.BucketName).IsRequired().HasMaxLength(63);
             entity.Property(static @object => @object.Key).IsRequired().HasMaxLength(1024);
             entity.Property(static @object => @object.VersionId).HasMaxLength(128);
+            entity.Property(static @object => @object.PrimaryVersionId).HasMaxLength(128);
             entity.Property(static @object => @object.ContentType).HasMaxLength(256);
             entity.Property(static @object => @object.CacheControl).HasMaxLength(256);
             entity.Property(static @object => @object.ContentDisposition).HasMaxLength(512);
@@ -61,6 +62,11 @@ public static class IntegratedS3CatalogModelBuilderExtensions
                 .HasFilter("\"IsLatest\" = 1")
                 .HasDatabaseName("IX_IntegratedS3Objects_SingleLatestPerKey");
             entity.HasIndex(static @object => new { @object.ProviderName, @object.BucketName, @object.Key, @object.IsLatest });
+            // Supports the primary→replica version translation lookup (#126): resolve a replica row from the
+            // primary version id it mirrors. Non-unique because a primary version could, in principle, be mapped
+            // after a re-repair; the lookup takes the latest match. Rows with a null PrimaryVersionId (primary rows,
+            // unversioned objects, legacy replica rows) do not participate meaningfully but are harmless.
+            entity.HasIndex(static @object => new { @object.ProviderName, @object.BucketName, @object.Key, @object.PrimaryVersionId });
         });
 
         modelBuilder.Entity<MultipartUploadCatalogRecord>(entity => {

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/ObjectCatalogRecord.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Persistence/ObjectCatalogRecord.cs
@@ -22,6 +22,14 @@ public sealed class ObjectCatalogRecord
     /// <summary>Gets or sets the version identifier, or <see langword="null"/> for unversioned objects.</summary>
     public string? VersionId { get; set; }
 
+    /// <summary>
+    /// For a REPLICA row, gets or sets the PRIMARY version id that this replica version mirrors, enabling a
+    /// primary→replica version translation for version-specific operations (e.g. tagging a historical version).
+    /// It is <see langword="null"/> for primary rows, for unversioned objects, and for legacy replica rows written
+    /// before this mapping existed. Reads tolerate its absence so an unmapped lookup simply returns no match.
+    /// </summary>
+    public string? PrimaryVersionId { get; set; }
+
     /// <summary>Gets or sets a value indicating whether this is the latest version of the object.</summary>
     public bool IsLatest { get; set; }
 

--- a/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageCatalogStore.cs
+++ b/src/IntegratedS3/IntegratedS3.EntityFramework/Services/EntityFrameworkStorageCatalogStore.cs
@@ -301,6 +301,55 @@ internal sealed class EntityFrameworkStorageCatalogStore<TDbContext>(
         await query.ExecuteDeleteAsync(cancellationToken);
     }
 
+    public async ValueTask RecordReplicaVersionMappingAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, string replicaVersionId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(replicaVersionId) || string.IsNullOrWhiteSpace(primaryVersionId)) {
+            return;
+        }
+
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var scope = serviceProvider.CreateAsyncScope();
+        var dbContext = ResolveDbContext(scope);
+
+        // Stamp the primary version id onto the already-persisted replica row (identified by its own version id).
+        // A set-based update avoids touching the concurrency token / other columns; if the replica row does not
+        // exist yet (upsert not committed), this is a harmless no-op and the mapping is (re)recorded on the next
+        // repair pass.
+        await dbContext.Set<ObjectCatalogRecord>()
+            .Where(existing => existing.ProviderName == replicaProviderName
+                && existing.BucketName == bucketName
+                && existing.Key == key
+                && existing.VersionId == replicaVersionId)
+            .ExecuteUpdateAsync(setters => setters
+                .SetProperty(static existing => existing.PrimaryVersionId, primaryVersionId), cancellationToken);
+    }
+
+    public async ValueTask<string?> GetReplicaVersionIdForPrimaryAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(primaryVersionId)) {
+            return null;
+        }
+
+        await EnsureInitializedAsync(cancellationToken);
+
+        await using var scope = serviceProvider.CreateAsyncScope();
+        var dbContext = ResolveDbContext(scope);
+
+        // Resolve the replica's own version id from the primary version it mirrors. Order by the surrogate key
+        // descending (a monotonically increasing int, which every relational provider — including SQLite — can
+        // translate) so that if a re-repair ever leaves two rows mapped to the same primary version, the most
+        // recently inserted replica version wins.
+        return await dbContext.Set<ObjectCatalogRecord>()
+            .Where(existing => existing.ProviderName == replicaProviderName
+                && existing.BucketName == bucketName
+                && existing.Key == key
+                && existing.PrimaryVersionId == primaryVersionId)
+            .OrderByDescending(existing => existing.Id)
+            .Select(existing => existing.VersionId)
+            .FirstOrDefaultAsync(cancellationToken);
+    }
+
     public async ValueTask<StoredObjectEntry?> GetObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default)
     {
         await EnsureInitializedAsync(cancellationToken);

--- a/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/IntegratedS3CoreOrchestrationTests.cs
@@ -3031,6 +3031,323 @@ public sealed class IntegratedS3CoreOrchestrationTests
         Assert.Null(currentCatalogObject.Tags);
     }
 
+    /// <summary>
+    /// #126: builds a write-through versioned fixture with a replica disk backend and returns the fixture plus the
+    /// primary/replica backends. The replica mints its own version ids, so a naive "pass request.VersionId to the
+    /// replica" would tag the wrong (nonexistent) replica version.
+    /// </summary>
+    private static CoreStorageFixture CreateWriteThroughReplicaFixture(out string replicaRootPath)
+    {
+        var capturedReplicaRoot = Path.Combine(Path.GetTempPath(), "IntegratedS3.Core.Tests", Guid.NewGuid().ToString("N"));
+        replicaRootPath = capturedReplicaRoot;
+        return new CoreStorageFixture(configureServices: services => {
+            services.Configure<IntegratedS3CoreOptions>(options => {
+                options.ConsistencyMode = StorageConsistencyMode.WriteThroughAll;
+            });
+            services.AddDiskStorage(new DiskStorageOptions
+            {
+                ProviderName = "replica-disk",
+                RootPath = capturedReplicaRoot,
+                CreateRootDirectory = true,
+                IsPrimary = false
+            });
+        });
+    }
+
+    [Fact]
+    public async Task OrchestratedStorageService_ExplicitVersionPutTags_TagsTranslatedReplicaVersionOnly()
+    {
+        await using var fixture = CreateWriteThroughReplicaFixture(out _);
+        var storageService = fixture.Services.GetRequiredService<IStorageService>();
+        var catalogStore = fixture.Services.GetRequiredService<IStorageCatalogStore>();
+        var replicaBackend = fixture.Services.GetServices<IStorageBackend>().Single(static backend => backend.Name == "replica-disk");
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = "vbucket",
+            EnableVersioning = true
+        })).IsSuccess);
+
+        await using var v1Stream = new MemoryStream(Encoding.UTF8.GetBytes("version one"));
+        var v1Put = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = v1Stream,
+            ContentType = "text/plain"
+        });
+        Assert.True(v1Put.IsSuccess);
+        var primaryV1 = Assert.IsType<string>(v1Put.Value!.VersionId);
+
+        await using var v2Stream = new MemoryStream(Encoding.UTF8.GetBytes("version two"));
+        var v2Put = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = v2Stream,
+            ContentType = "text/plain"
+        });
+        Assert.True(v2Put.IsSuccess);
+        var primaryV2 = Assert.IsType<string>(v2Put.Value!.VersionId);
+
+        // The replica minted its own independent version ids; resolve them via the recorded mapping.
+        var replicaV1 = await catalogStore.GetReplicaVersionIdForPrimaryAsync("replica-disk", "vbucket", "docs/f.txt", primaryV1);
+        var replicaV2 = await catalogStore.GetReplicaVersionIdForPrimaryAsync("replica-disk", "vbucket", "docs/f.txt", primaryV2);
+        Assert.False(string.IsNullOrWhiteSpace(replicaV1));
+        Assert.False(string.IsNullOrWhiteSpace(replicaV2));
+        Assert.NotEqual(replicaV1, replicaV2);
+        // The mapping must actually translate: the replica version must differ from the primary version it mirrors.
+        Assert.NotEqual(primaryV1, replicaV1);
+
+        // Tag the PRIMARY's explicit historical version (v1).
+        var putTags = await storageService.PutObjectTagsAsync(new PutObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = primaryV1,
+            Tags = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["gen"] = "one"
+            }
+        });
+        Assert.True(putTags.IsSuccess);
+
+        // The replica version that mirrors primary v1 must carry the tags...
+        var replicaV1Tags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = replicaV1
+        });
+        Assert.True(replicaV1Tags.IsSuccess);
+        Assert.Equal("one", replicaV1Tags.Value!.Tags["gen"]);
+
+        // ...and the replica version that mirrors primary v2 must NOT be touched.
+        var replicaV2Tags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = replicaV2
+        });
+        Assert.True(replicaV2Tags.IsSuccess);
+        Assert.Empty(replicaV2Tags.Value!.Tags);
+    }
+
+    [Fact]
+    public async Task OrchestratedStorageService_ExplicitVersionDeleteTags_RemovesFromCorrectReplicaVersionOnly()
+    {
+        await using var fixture = CreateWriteThroughReplicaFixture(out _);
+        var storageService = fixture.Services.GetRequiredService<IStorageService>();
+        var catalogStore = fixture.Services.GetRequiredService<IStorageCatalogStore>();
+        var replicaBackend = fixture.Services.GetServices<IStorageBackend>().Single(static backend => backend.Name == "replica-disk");
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = "vbucket",
+            EnableVersioning = true
+        })).IsSuccess);
+
+        await using var v1Stream = new MemoryStream(Encoding.UTF8.GetBytes("version one"));
+        var v1Put = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = v1Stream,
+            ContentType = "text/plain"
+        });
+        Assert.True(v1Put.IsSuccess);
+        var primaryV1 = Assert.IsType<string>(v1Put.Value!.VersionId);
+
+        await using var v2Stream = new MemoryStream(Encoding.UTF8.GetBytes("version two"));
+        var v2Put = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = v2Stream,
+            ContentType = "text/plain"
+        });
+        Assert.True(v2Put.IsSuccess);
+        var primaryV2 = Assert.IsType<string>(v2Put.Value!.VersionId);
+
+        // Tag BOTH primary versions (each write-through translates to the matching replica version).
+        foreach (var primaryVersion in new[] { primaryV1, primaryV2 }) {
+            Assert.True((await storageService.PutObjectTagsAsync(new PutObjectTagsRequest
+            {
+                BucketName = "vbucket",
+                Key = "docs/f.txt",
+                VersionId = primaryVersion,
+                Tags = new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    ["keep"] = "yes"
+                }
+            })).IsSuccess);
+        }
+
+        var replicaV1 = await catalogStore.GetReplicaVersionIdForPrimaryAsync("replica-disk", "vbucket", "docs/f.txt", primaryV1);
+        var replicaV2 = await catalogStore.GetReplicaVersionIdForPrimaryAsync("replica-disk", "vbucket", "docs/f.txt", primaryV2);
+        Assert.False(string.IsNullOrWhiteSpace(replicaV1));
+        Assert.False(string.IsNullOrWhiteSpace(replicaV2));
+
+        // Delete tags on the PRIMARY's explicit v1 only.
+        Assert.True((await storageService.DeleteObjectTagsAsync(new DeleteObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = primaryV1
+        })).IsSuccess);
+
+        var replicaV1Tags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = replicaV1
+        });
+        Assert.True(replicaV1Tags.IsSuccess);
+        Assert.Empty(replicaV1Tags.Value!.Tags);
+
+        // The replica version mirroring primary v2 must still carry its tag.
+        var replicaV2Tags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = replicaV2
+        });
+        Assert.True(replicaV2Tags.IsSuccess);
+        Assert.Equal("yes", replicaV2Tags.Value!.Tags["keep"]);
+    }
+
+    [Fact]
+    public async Task OrchestratedStorageService_NullVersionPutTags_TagsReplicaLatestVersion()
+    {
+        await using var fixture = CreateWriteThroughReplicaFixture(out _);
+        var storageService = fixture.Services.GetRequiredService<IStorageService>();
+        var replicaBackend = fixture.Services.GetServices<IStorageBackend>().Single(static backend => backend.Name == "replica-disk");
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = "vbucket",
+            EnableVersioning = true
+        })).IsSuccess);
+
+        await using var v1Stream = new MemoryStream(Encoding.UTF8.GetBytes("version one"));
+        Assert.True((await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = v1Stream,
+            ContentType = "text/plain"
+        })).IsSuccess);
+
+        await using var v2Stream = new MemoryStream(Encoding.UTF8.GetBytes("version two"));
+        var v2Put = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = v2Stream,
+            ContentType = "text/plain"
+        });
+        Assert.True(v2Put.IsSuccess);
+
+        // Tag the LATEST version (null VersionId): the replica must tag ITS OWN latest, not fail or mis-target.
+        Assert.True((await storageService.PutObjectTagsAsync(new PutObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Tags = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["latest"] = "true"
+            }
+        })).IsSuccess);
+
+        var replicaLatestTags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt"
+        });
+        Assert.True(replicaLatestTags.IsSuccess);
+        Assert.Equal("true", replicaLatestTags.Value!.Tags["latest"]);
+    }
+
+    [Fact]
+    public async Task OrchestratedStorageService_UnmappedExplicitVersionTags_PrimarySucceedsReplicaNotMisTagged()
+    {
+        await using var fixture = CreateWriteThroughReplicaFixture(out _);
+        var storageService = fixture.Services.GetRequiredService<IStorageService>();
+        var backends = fixture.Services.GetServices<IStorageBackend>().ToArray();
+        var primaryBackend = backends.Single(static backend => backend.Name == "catalog-disk");
+        var replicaBackend = backends.Single(static backend => backend.Name == "replica-disk");
+
+        Assert.True((await storageService.CreateBucketAsync(new CreateBucketRequest
+        {
+            BucketName = "vbucket",
+            EnableVersioning = true
+        })).IsSuccess);
+
+        // Replicated version (mapping recorded) — this is the version that must stay untouched.
+        await using var replicatedStream = new MemoryStream(Encoding.UTF8.GetBytes("replicated version"));
+        var replicated = await storageService.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = replicatedStream,
+            ContentType = "text/plain"
+        });
+        Assert.True(replicated.IsSuccess);
+
+        // Write a NEW version directly to the PRIMARY backend, bypassing the orchestrator, so no primary->replica
+        // mapping is recorded for it. Tagging this explicit primary version must not mis-tag any replica version.
+        await using var orphanStream = new MemoryStream(Encoding.UTF8.GetBytes("primary-only version"));
+        var orphan = await primaryBackend.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            Content = orphanStream,
+            ContentType = "text/plain"
+        });
+        Assert.True(orphan.IsSuccess);
+        var orphanVersion = Assert.IsType<string>(orphan.Value!.VersionId);
+
+        // Tag the primary-only version explicitly. Primary op must succeed; the unmapped replica write is skipped.
+        var putTags = await storageService.PutObjectTagsAsync(new PutObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = orphanVersion,
+            Tags = new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["orphan"] = "yes"
+            }
+        });
+        Assert.True(putTags.IsSuccess);
+
+        // The primary carries the tag on the orphan version.
+        var primaryTags = await primaryBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+        {
+            BucketName = "vbucket",
+            Key = "docs/f.txt",
+            VersionId = orphanVersion
+        });
+        Assert.True(primaryTags.IsSuccess);
+        Assert.Equal("yes", primaryTags.Value!.Tags["orphan"]);
+
+        // No replica version was tagged with the orphan tag (the orphan version does not exist on the replica, and
+        // the replicated version must remain tag-free).
+        await foreach (var replicaVersion in replicaBackend.ListObjectVersionsAsync(new ListObjectVersionsRequest
+        {
+            BucketName = "vbucket",
+            Prefix = "docs/f.txt"
+        })) {
+            var versionTags = await replicaBackend.GetObjectTagsAsync(new GetObjectTagsRequest
+            {
+                BucketName = "vbucket",
+                Key = "docs/f.txt",
+                VersionId = replicaVersion.VersionId
+            });
+            Assert.True(versionTags.IsSuccess);
+            Assert.False(versionTags.Value!.Tags.ContainsKey("orphan"));
+        }
+    }
+
     [Fact]
     public async Task OrchestratedStorageService_DeleteMissingObject_InVersionedBucketCreatesDeleteMarkerAndCatalogEntry()
     {
@@ -5281,6 +5598,31 @@ public sealed class IntegratedS3CoreOrchestrationTests
                     && string.Equals(existing.Key, key, StringComparison.Ordinal)
                     && string.Equals(existing.VersionId, versionId, StringComparison.Ordinal));
             return ValueTask.FromResult(entry);
+        }
+
+        /// <summary>Records the primary→replica version mapping keyed by (provider, bucket, key, primaryVersionId).</summary>
+        public List<(string ProviderName, string BucketName, string Key, string PrimaryVersionId, string ReplicaVersionId)> VersionMappings { get; } = [];
+
+        public ValueTask RecordReplicaVersionMappingAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, string replicaVersionId, CancellationToken cancellationToken = default)
+        {
+            VersionMappings.RemoveAll(existing => existing.ProviderName == replicaProviderName
+                && existing.BucketName == bucketName
+                && string.Equals(existing.Key, key, StringComparison.Ordinal)
+                && string.Equals(existing.PrimaryVersionId, primaryVersionId, StringComparison.Ordinal));
+            VersionMappings.Add((replicaProviderName, bucketName, key, primaryVersionId, replicaVersionId));
+            return ValueTask.CompletedTask;
+        }
+
+        public ValueTask<string?> GetReplicaVersionIdForPrimaryAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, CancellationToken cancellationToken = default)
+        {
+            var match = VersionMappings
+                .Where(existing => existing.ProviderName == replicaProviderName
+                    && existing.BucketName == bucketName
+                    && string.Equals(existing.Key, key, StringComparison.Ordinal)
+                    && string.Equals(existing.PrimaryVersionId, primaryVersionId, StringComparison.Ordinal))
+                .Select(existing => existing.ReplicaVersionId)
+                .LastOrDefault();
+            return ValueTask.FromResult<string?>(match);
         }
 
         public ValueTask<IReadOnlyList<StoredObjectEntry>> ListObjectsAsync(string? providerName = null, string? bucketName = null, string? keyPrefix = null, CancellationToken cancellationToken = default)

--- a/src/IntegratedS3/IntegratedS3.Tests/StorageReplicaRepairObjectLockTests.cs
+++ b/src/IntegratedS3/IntegratedS3.Tests/StorageReplicaRepairObjectLockTests.cs
@@ -140,6 +140,12 @@ public sealed class StorageReplicaRepairObjectLockTests
 
         public ValueTask RemoveObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default) => ValueTask.CompletedTask;
 
+        public ValueTask RecordReplicaVersionMappingAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, string replicaVersionId, CancellationToken cancellationToken = default)
+            => ValueTask.CompletedTask;
+
+        public ValueTask<string?> GetReplicaVersionIdForPrimaryAsync(string replicaProviderName, string bucketName, string key, string primaryVersionId, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult<string?>(null);
+
         public ValueTask<StoredObjectEntry?> GetObjectAsync(string providerName, string bucketName, string key, string? versionId = null, CancellationToken cancellationToken = default)
             => ValueTask.FromResult<StoredObjectEntry?>(null);
 


### PR DESCRIPTION
## Problem

`PutObjectTagsAsync` / `DeleteObjectTagsAsync` computed a `resolvedVersionId` for the **primary** catalog refresh but then passed the **raw** `request.VersionId` both into `ApplyReplicaWritePolicyAsync` and into the replica `PutObjectTagsRequest` / `DeleteObjectTagsRequest`.

Replicas mint their **own** independent version ids — there is no primary→replica version mapping in the system. So for an explicit-version tag operation the replica received the *primary's* version id, which does not exist on the replica: the tag write either failed (`ObjectNotFound`) or, in the worst case, could have targeted the wrong version. Closes #126.

## Design

When `request.VersionId` is:
- **null (latest)** — pass `null` through unchanged; the replica tags **its own** latest version. This is the pre-existing correct behaviour and is preserved (it is exactly what made a naive "pass resolvedVersionId" fix regress the latest-tag tests).
- **an explicit primary version** — translate it to the replica's own version via a recorded mapping. If **no mapping** exists for a replica (legacy row written before this feature, or not-yet-replicated), the synchronous replica tag write is **skipped gracefully** (logged) so the primary operation still returns success and no wrong replica version is tagged; the async repair backlog reconciles the replica later. The primary version id is **never** written to a replica verbatim.

## Where the mapping is stored

Reuses the catalog. A new nullable `ObjectCatalogRecord.PrimaryVersionId` (`string?`, max length 128) records, for a **replica** row, which primary version that replica version mirrors. A `(ProviderName, BucketName, Key, PrimaryVersionId)` index backs the lookup.

**Migration strategy:** the catalog uses `Database.EnsureCreated()` (no EF Migrations folder). A nullable column is backward-safe — fresh DBs get the column; legacy replica rows keep `PrimaryVersionId == null`, so an unmapped lookup simply returns `null` and the graceful-skip path handles it.

`IStorageCatalogStore` gains two methods (implemented in the EF, Null, and both test stores):
- `RecordReplicaVersionMappingAsync(replicaProvider, bucket, key, primaryVersionId, replicaVersionId)` — stamps `PrimaryVersionId` onto the already-persisted replica row (set-based update; no-op if the row is absent).
- `GetReplicaVersionIdForPrimaryAsync(replicaProvider, bucket, key, primaryVersionId)` → replica version id, or `null` when unmapped.

## Where the mapping is recorded

At every replica object write/repair that mints a replica version and has a concrete primary version id (versioned buckets only; null/unversioned needs no mapping):
- write-through buffered `PutObject` and `CopyObject` (`WriteReplicaBufferedObjectAsync`, now threaded the primary version),
- `RepairReplicaObjectFromPrimaryAsync` in the orchestrator, and
- `RepairReplicaObjectFromPrimaryAsync` in the async `StorageReplicaRepairService`.

## Where the translation happens

Inside the per-replica write-through lambda (so each replica maps its own version), in `WriteReplicaPutObjectTagsAsync` / `WriteReplicaDeleteObjectTagsAsync`. The `versionId` still handed to `ApplyReplicaWritePolicyAsync` for backlog/error tracking remains the primary version (the async repair path translates independently). The async tag-repair path (`RepairReplicaObjectTagsFromPrimaryAsync`) translates the same way and skips an explicit-but-unmapped version rather than tagging the wrong one.

## Test coverage (IntegratedS3.Tests)

Added four write-through, versioned-bucket regression tests (real EF/SQLite catalog + disk replica):
- explicit-version `PutObjectTags` tags only the **correct** replica version, leaving the other version untouched;
- explicit-version `DeleteObjectTags` removes tags from only the correct replica version;
- null-version (latest) tag still tags the replica's latest (guards the prior regression);
- an unmapped explicit primary version → primary op succeeds, replica not mis-tagged, no exception.

The two explicit-version tests were verified **non-vacuous** (they fail under the naive "pass the primary version to the replica" approach). The two named existing tests (`..._WriteThroughAll_ReplicatesObjectTags`, `..._VersionSpecificTagDeletes_RefreshCatalogForHistoricalEntries`) stay green.

Full suite: **1284 passed / 0 failed** (baseline 1280 + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
